### PR TITLE
Add static text parser and snippet posting option

### DIFF
--- a/static_fileparser.py
+++ b/static_fileparser.py
@@ -1,0 +1,17 @@
+import random
+
+class StaticFileParser:
+    """Parse a static text file and return random snippets."""
+    def __init__(self, file_path):
+        self.file_path = file_path
+        with open(file_path, 'r', encoding='utf-8') as f:
+            text = f.read()
+        # Split text by blank lines
+        blocks = text.split('\n\n')
+        self.snippets = [block.replace('\n', ' ').strip() for block in blocks if block.strip()]
+
+    def get_random_snippet(self):
+        """Return a random snippet from the file."""
+        if not self.snippets:
+            return ""
+        return random.choice(self.snippets)

--- a/test_static_fileparser.py
+++ b/test_static_fileparser.py
@@ -1,0 +1,24 @@
+import unittest
+import os
+from static_fileparser import StaticFileParser
+
+class TestStaticFileParser(unittest.TestCase):
+    def setUp(self):
+        self.test_file = 'data/test_static.txt'
+        with open(self.test_file, 'w') as f:
+            f.write('First paragraph.\n\nSecond paragraph.\n\nThird.')
+
+    def tearDown(self):
+        os.remove(self.test_file)
+
+    def test_snippet_count(self):
+        parser = StaticFileParser(self.test_file)
+        self.assertEqual(len(parser.snippets), 3)
+
+    def test_random_snippet_returns_value(self):
+        parser = StaticFileParser(self.test_file)
+        snippet = parser.get_random_snippet()
+        self.assertIn(snippet, parser.snippets)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `StaticFileParser` for pulling random passages from a file
- allow `emojis-mobydick.py` to read snippets from a file via `--static-file`
- post snippet directly with Mastodon API
- test parser functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b696e3c008321bca67e8a80627b14