### PR TITLE
Add signature support for static snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,11 @@ Then the script uses a Large Language Model (LLM) to translate sentence fragment
 ### CLI Call
 
     workon mastodon  # my virtualenv, created with virtualenvwrapper
-    ./emojis-mobydick.py 
+    ./emojis-mobydick.py
+
+You can fetch a random snippet from a static text file with:
+
+    ./emojis-mobydick.py --static-file path/to/file.txt --signature "Mark Twain"
 
 (Read toots from Mastodon, parse most recent toot; post fragment to LLM API, let LLM translate to Emojis, process LLM response, post fragment+Emojis to own account)
 

--- a/test_format_static_snippet.py
+++ b/test_format_static_snippet.py
@@ -1,0 +1,21 @@
+import importlib.util
+import unittest
+import os
+
+module_name = 'emojis_mobydick'
+file_path = os.path.join(os.path.dirname(__file__), 'emojis-mobydick.py')
+spec = importlib.util.spec_from_file_location(module_name, file_path)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+class TestFormatStaticSnippet(unittest.TestCase):
+    def test_with_signature(self):
+        result = module.format_static_snippet('hello', '🙂', 'Author')
+        self.assertEqual(result, 'hello:\n🙂\n        -- Author')
+
+    def test_without_signature(self):
+        result = module.format_static_snippet('hello', '🙂')
+        self.assertEqual(result, 'hello:\n🙂')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- allow specifying a signature for snippets processed via `--static-file`
- include helper `format_static_snippet` used by the CLI
- document new command line option in README
- test formatting helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b9a9b00c08321a48acecdea6bb655