### PR TITLE
Add date tracking for toots and posting delay

### DIFF
--- a/data/toot_storage.json
+++ b/data/toot_storage.json
@@ -1,1 +1,8498 @@
-{"The devil fetch ye, ye ragamuffin rapscallions; ye are all asleep. Stop snoring, ye sleepers": "\ud83d\ude08\ud83d\udd25\ud83d\udce5\ud83d\udc49, \ud83d\udc49\ud83d\udc55\ud83d\udd04\ud83d\udc82\u200d\u2642\ufe0f\ud83d\udc82\u200d\u2640\ufe0f; \ud83d\udc49\ud83d\udc65\ud83d\ude34\ud83d\udca4\ud83d\udca4. \u26d4\ufe0f\ud83d\udca4\ud83d\udca4, \ud83d\udc49\ud83d\ude34\ud83d\udca4\ud83d\udca4\ud83d\udc65", "sharks now freshly and more keenly allured by the before pent blood which began to flow from the carcass": "\ud83e\udd88\ud83e\udd88\ud83e\udd88\ud83d\udd1c\ud83c\udf3f\ud83c\udd95\u2795\ud83d\udd2a\ud83c\udfaf\ud83d\udc89\ud83d\udca7\ud83d\udfe5\ud83e\udd24\ud83c\udfac\ud83d\udcab\u27a1\ufe0f\ud83e\udd69\ud83c\udf56\ud83d\udd2e\ud83d\udc94\ud83d\udc9f\ud83d\udd50\ud83c\udf0a", "BLOODY BATTLE IN AFFGHANISTAN.": "\ud83d\udc89\u2694\ufe0f\ud83e\udd3c\u200d\u2642\ufe0f\ud83d\udd25\ud83c\udde6\ud83c\uddeb", "So in this vale of Death, God girds us round; and over all our gloom, the sun of Righteousness still shines a beacon and a hope.": "\ud83d\ude0c\u27a1\ufe0f\ud83d\udc80\u26f0\ufe0f, \ud83d\ude4f\ud83d\udcaa\ud83c\udf0d\u21aa\ufe0f; \u2b06\ufe0f\ud83d\ude1e\ud83c\udf11, \u2600\ufe0f\u2696\ufe0f\ud83d\udca1\u2728\ud83d\udea6\ud83d\udca1\ud83d\udd6f\ufe0f\ud83d\udca1\ud83e\udd1e.", "Consider, once more, the universal cannibalism of the sea": "\ud83e\udd14,\ud83d\udd02, \ud83c\udf10\ud83c\udf74\ud83c\udf0a", "Look at the crowds of water-gazers there.": "\ud83d\udc40\ud83d\udc65\ud83d\udc65\ud83d\udc65\u26f2\ud83d\udc40\ud83d\udc65\ud83d\udc65\ud83d\udc65", "What all men\u2019s minds and opinions but Loose-Fish?": "\u2753\ud83e\udd14\ud83d\udc68\u200d\ud83d\udc69\u200d\ud83d\udc67\u200d\ud83d\udc66\ud83d\udcad\ud83d\udcac\ud83d\udc1f\ud83d\udca8", "He announced himself as the archangel Gabriel, and commanded the captain to jump overboard.": "\ud83d\udde3\ufe0f\ud83d\udc64\ud83d\udd1c\ud83d\udc7cGabriel, \ud83c\udfa4\u26f4\ufe0f\ud83d\udc68\u200d\u2708\ufe0f\ud83d\udc49\u23e9\ud83c\udf0a", "Quick! forge me the harpoon.": "\u26a1\ufe0f\ud83d\udd28\ud83d\udd25\ud83d\udee0\ufe0f\ud83d\udc33\ud83d\udd31", "all of us are Ahabs": "\ud83c\udf0d\ud83d\udc6b\ud83d\udc6c\ud83d\udc6d\u27a1\ufe0f\ud83d\udc0b\ud83c\udfa3\ud83e\uddd4\ud83c\udffd", "as if, the longer linked with life, the less man has to do with aught that looks like death": "\ud83e\udd14\ud83d\udcad, \u23f3\ud83d\udd17\ud83e\uddd1\u200d\ud83e\udd1d\u200d\ud83e\uddd1\ud83c\udf31\ud83c\udf0d, \u2796\ud83d\udd7a\ud83d\udd0e\ud83e\udd37\u200d\u2642\ufe0f\ud83d\udd1c\ud83d\udc80\ud83d\udc40", "Beelzebub himself might climb up the side and step down into the cabin to chat with the captain, and it would not create any unsubduable excitement in the forecastle.": "\ud83d\ude08\ud83d\udc63\u2b06\ufe0f\ud83d\udc48\ud83c\udfd4\ufe0f\u2795\ud83d\udc83\u2b07\ufe0f\ud83d\udeaa\ud83d\udea2\ud83d\udde3\ufe0f\ud83d\udde3\ufe0f\ud83d\udc6e\u200d\u2642\ufe0f, \u2795\ud83d\udeab\ud83c\udf2a\ufe0f\ud83e\udd2f\ud83d\udd25\u2728\ud83c\udfaa\ud83c\udf89\ud83d\udd26.", "a score of voices from all parts of the vessel, simultaneously with the three notes from aloft, shouted forth the accustomed cry": "\ud83d\udd22\ud83d\udde3\ufe0f\ud83d\udde3\ufe0f\ud83d\udde3\ufe0f\ud83d\udd00\ud83c\udf10\ud83d\udee5\ufe0f, \u23f1\ufe0f\ud83d\udc65\ud83d\udc65\ud83d\udc65\ud83c\udfb5\ud83c\udfb5\ud83c\udfb5\ud83d\udd1d, \ud83d\udd0a\ud83d\udd0a\ud83d\udd0a\ud83d\udce3\ud83d\udce3\ud83d\udce3\ud83d\udde3\ufe0f\ud83d\udce2\ud83d\udce2\ud83d\udce2\ud83d\udd00\ud83d\udd27\ud83d\udc65\ud83d\udc65\ud83d\udc65\ud83d\udde3\ufe0f\ud83d\udde3\ufe0f\ud83d\udde3\ufe0f", "this earthly air, whether ashore or afloat, is terribly infected with the nameless miseries of the numberless mortals who have died exhaling it": "\ud83c\udf0d\ud83d\udca8, \ud83c\udfde\ufe0f\ud83d\udea2, \ud83d\ude31\ud83d\ude37 \ud83d\udeab\ud83d\udcdb \ud83d\ude22\ud83d\ude22 \ud83c\udf10\ud83d\udc80 \ud83d\udc65 \ud83d\udc94\ud83d\ude35 \ud83d\udcac\ud83c\udf2c\ufe0f\ud83d\udc4b", "the first boat always hovers at hand to assist its consort": "1\ufe0f\u20e3\ud83d\udea4\ud83d\udd04\u270b\ud83c\udd98\ud83e\udd1d\ud83d\udea4", "Be cool at the equator; keep thy blood fluid at the Pole.": "\ud83d\ude0e\ud83c\udd92\ud83c\udf0d\ud83c\udf13;\ud83e\udd32\ud83e\ude78\ud83d\udca7\ud83d\udccd\ud83c\udfd4\ufe0f.", "But when Leviathan is the text, the case is altered.": "\ud83d\udd0d\ud83d\udc09\ud83d\udcdc, \ud83d\udcbc\ud83d\udd04", "For the most part, in this tropic whaling life, a sublime uneventfulness invests you": "\ud83d\udc49\ud83c\udffb\ud83c\udf0f\u2696\ufe0f, \ud83c\udf34\ud83d\udc33\ud83c\udfa3\ud83c\udfde\ufe0f, \ud83d\ude4c\ud83c\udf0c\ud83d\udcc5\ud83e\udde5\ud83d\udc64", "Thou who, in all Thy mighty, earthly marchings, ever cullest Thy selectest champions from the kingly commons; bear me out in it, O God!": "\ud83d\ude4f\ud83c\udf0d\ud83d\udeb6\u200d\u2642\ufe0f\ud83d\udcaa\ud83d\ude4f\ud83d\udd74\ufe0f\ud83c\udfc6\u2935\ufe0f\ud83d\udc51\ud83d\udc65, \ud83d\ude4f\ud83d\ude4f\ud83d\ude4f\ud83d\udde3\ufe0f\ud83c\udd99\ud83c\udf2c\ufe0f\ud83d\udc48\ud83d\udd1b\ud83d\ude4b\u200d\u2642\ufe0f, \ud83d\uded0\ud83d\ude4f!", "does it not bear a faint resemblance to a gigantic fish? even the great leviathan himself?": "\u2753\ud83d\udeab\ud83d\udc3b\ud83d\udd0d\ud83d\udc65\ud83d\udc20\u2753\ud83c\udf0e\ud83e\udd88\ud83e\udd37\u200d\u2642\ufe0f\ud83e\udd14", "great hearts sometimes condense to one deep pang, the sum total of those shallow pains kindly diffused through feebler men\u2019s whole lives": "\ud83d\udc9f\ud83d\udc4d\ud83d\udc96\u23f0\ud83c\udf00\u27a1\ufe0f1\ufe0f\u20e3\ud83d\udd35\ud83d\ude16, \u2795\ud83d\udca2\ud83c\udfaf\ud83d\udd22\ud83d\udc65\ud83e\udd7a\ud83d\ude22\ud83e\udd32\ud83c\udf0d\ud83d\udcab\ud83d\udc6c\ud83d\udc74\ud83d\udc94\ud83d\udd70\ud83c\udf0d\ud83d\udd4a\ufe0f\ud83d\udd70\ufe0f", "There go the ships; there is that Leviathan whom thou hast made to play therein": "\ud83d\udc49\u26f5\u26f5\u26f5; \ud83d\udc49\ud83d\udc0b\ud83d\ude4f\ud83d\udee0\ufe0f\ud83c\udfad\ud83d\udc47", "this six-inch chapter is the stoneless grave of Bulkington": "\ud83d\udcd66\ufe0f\u20e3\u3030\ufe0f\ud83d\udd20\u27a1\ufe0f\u26b0\ufe0f\ud83d\udeab\ud83d\udc8e\ud83e\udea6\ud83e\uddd1\u200d\ud83e\uddb1\ud83d\udfe0", "you are now to be apprised of the nature of the substance which so impregnably invests all that apparent effeminacy": "\ud83d\udc49\ud83d\udc64\ud83d\udd1b\ud83d\udc40\ud83d\udd0d\u21aa\ufe0f\ud83e\uddea\ud83c\udf10\ud83e\udd14\ud83d\udcbc\ud83d\udeab\u2728\ud83d\udd2c\ud83d\udc40\ud83d\udc48\ud83c\udf38\ud83d\udc57\ud83d\udcaa", "why all the living so strive to hush all the dead": "\u2753\ud83c\udf0d\ud83c\udf33\ud83d\udc6b\ud83c\udffb\ud83e\udd81\ud83d\udc26\ud83d\udcaa\ud83d\udd07\ud83d\udc80\ud83d\udc7b\u26b0\ufe0f", "every strange, half-seen, gliding, beautiful thing that eludes him; every dimly-discovered, uprising fin of some undiscernible form, seems to him the embodiment of those elusive thoughts": "\ud83c\udf0d\ud83d\udc7d\ud83d\udc40\ud83d\udd7a\ud83c\udffd\ud83d\udc96\u2728\ud83c\udfde\ufe0f\ud83c\udfc3\u200d\u2642\ufe0f\ud83d\udca8; \ud83d\udca1\ud83d\ude14\ud83d\udd2c\u26f0\ufe0f\ud83e\udd88\ud83d\udd0d\ud83c\udfde\ufe0f\ud83d\udc64, \ud83e\udde9\ud83e\udd14\ud83c\udf2b\ufe0f\ud83d\udcad\ud83d\udcad", "I would fain feel this pulse, and let mine beat against it; blood against fire!": "\ud83d\udc41\ufe0f\u2764\ufe0f\ud83d\ude4f\ud83c\udffc\u270b\ud83d\udc93, \u2795\ud83d\udc4b\u262e\ufe0f\ud83d\udca2\u2194\ufe0f\ud83d\udc96; \ud83d\udc89\u2194\ufe0f\ud83d\udd25!", "all that stirs up the lees of things": "\ud83c\udf0e \u27a1\ufe0f\ud83d\udd04\u2b06\ufe0f \ud83c\udf77\ud83e\udd58\ud83d\udd0d\ud83d\udd2c\ud83d\udcda\ud83c\udfa8\ud83d\udcf8\ud83d\udca1\ud83c\udf31", "the wildest winds of heaven and earth conspire to cast her on the treacherous, slavish shore": "\ud83c\udf2a\ufe0f\ud83c\udf2c\ufe0f\ud83c\udf0e\ud83c\udf0c\ud83e\udd1d\ud83c\udfad\ud83d\udc69\u26f5\ufe0f\ud83c\udf0a\ud83c\udf34\u2693\ufe0f\u26d3\ufe0f\ud83c\udfd6\ufe0f", "This is the Pequod, bound round the world! Tell them to address all future letters to the Pacific ocean!": "\ud83d\udc48\ud83c\udffc\ud83d\udd35\ud83d\udea2\ud83d\udc33 Pequod, \u27b0\ud83c\udf0f! \ud83d\udde3\ufe0f\ud83d\udc65\ud83d\udcdd\u2709\ufe0f\ud83d\udd2e Pacific\ud83c\udf0a!", "In old England the greatest lords think it great glory to be slapped by a queen": "\ud83c\udff4\ud83d\udc74\ud83e\udd34\ud83d\udcad\ud83d\udc51\ud83d\udcab\ud83e\udd1a\ud83d\udc78", "His spout was short, slow, and laborious; coming forth with a choking sort of gush, and spending itself in torn shreds": "\ud83d\udc68\u200d\ud83e\uddb0\ud83d\udc33\ud83d\udca6\ud83d\udccf\ud83d\udc22\ud83d\ude2b\u27a1\ufe0f\ud83d\udeb0\ud83d\udca5\u23f1\ufe0f\ud83d\udd1a\ud83c\udf2a\ufe0f\ud83c\udf9f\ufe0f\ud83e\uddfb", "indeed, he is expected to set an example of superhuman activity": "\ud83d\udc4d, \ud83d\udc68\u200d\ud83d\udcbc\u23f3\ud83d\udd1c\u27a1\ufe0f\ud83d\udd28\ud83d\udc63\ud83c\udfc6\ud83e\uddb8\u200d\u2642\ufe0f\ud83c\udfc3\u200d\u2642\ufe0f\ud83d\udcbc\ud83c\udfaf\ud83c\udf10", "the other will be utterly excluded from your contemporary consciousness": "\ud83d\udc65\ud83d\udeab\ud83d\udeaa\ud83d\udeab\ud83d\udd52\ud83d\udcad", "A Fast-Fish belongs to the party fast to it.": "\ud83c\udd70\ufe0f\u23e9\ud83d\udc20\ud83d\udd10\ud83c\udf89\ud83d\udcce\ud83d\udd1b\ud83d\udd12", "there is nothing wonderful": "\u274c\ud83d\udeab\ud83c\udf08\ud83c\udf8a\ud83c\udf89", "\u201cBouton de Rose,\u201d\u2014Rose-button, or Rose-bud; and this was the romantic name of this aromatic ship.": "\"\ud83c\udf39\ud83d\udd18,\" - \ud83c\udf39\ud83d\udd18, or \ud83c\udf39\ud83c\udf31; and this was the \ud83d\ude0d name of this \ud83c\udfb6\ud83d\udea2.", "exceedingly juicy": "\ud83d\udd1d\ud83e\udd64\ud83c\udf49", "the sharks, also, with their jewel-hilted mouths, are quarrelsomely carving away under the table at the dead meat": "\ud83e\udd88\ud83e\udd88, \ud83d\udc8e\ud83d\udde1\ufe0f\ud83d\udc44, \ud83d\udd1b\u27a1\ufe0f, \ud83d\ude21\ud83d\udd2a\ud83d\udd2a\u2b07\ufe0f\ud83c\udf7d\ufe0f\u27a1\ufe0f\ud83d\udc80\ud83c\udf56", "the six men composing the crew pull into the jaws of death, with a halter around every neck": "6\ufe0f\u20e3\ud83d\udc68\u200d\ud83d\udc68\u200d\ud83d\udc66\u200d\ud83d\udc66\ud83c\udfbc\ud83d\udef6\u27a1\ufe0f\ud83d\udc80\ud83d\udc44, \ud83d\udd04\ud83d\udd17\ud83d\udd03\ud83d\udc64\ud83d\udc64\ud83d\udc64\ud83d\udc64\ud83d\udc64\ud83d\udc64\ud83d\udc54", "The harpoon was hurled.": "\ud83d\udd31\ud83e\udd3e\u200d\u2642\ufe0f", "it\u2019s a wicked world in all meridians; I\u2019ll die a pagan.": "\ud83d\ude08\ud83c\udf0d\u2194\ufe0f\ud83e\udded; \ud83d\ude4b\u200d\u2642\ufe0f\ud83d\udc80\ud83d\udd49\ufe0f.", "it must symbolize something unseen": "\ud83d\udc49\ud83d\udc65\ud83d\udd2e\ud83d\udcd6\u26a0\ud83d\udca1\ud83d\udc40\ud83d\udeab", "All Loose-Fish.": "\ud83d\udc20\ud83d\udc20\ud83d\udc20\ud83d\udc1f\ud83d\udc1f\ud83d\udc1f\ud83d\udca8\ud83d\udca8\ud83d\udca8", "I am so rich, I could have given bid for bid with the wealthiest Pr\u00e6torians at the auction of the Roman empire": "\ud83d\udc81\u200d\u2642\ufe0f\ud83d\udcb0\ud83e\udd11, \ud83d\udc81\u200d\u2642\ufe0f\ud83d\udd04\ud83d\udcb0\ud83d\ude4b\u200d\u2642\ufe0f\ud83c\udd9a\ud83d\udcb8\ud83d\udcb5\ud83e\udd35\u200d\u2642\ufe0f\ud83c\udfdb\ufe0f\ud83d\udd28\ud83c\udfe6\ud83c\udfdb\ufe0f\ud83c\udfdf\ufe0f\ud83e\udd1d\ud83c\udf0d\ud83d\udcdc\ud83c\udff7\ufe0f", "the fabled heavens with all their countless tents really lie encamped beyond my mortal sight": "\ud83d\udcd6\u2728\ud83c\udf0c\u26fa\u26fa\u26fa\ud83d\udd22\ud83d\udc40\ud83d\udc49\ud83d\udeab\ud83d\udc53\ud83d\udc68\u200d\ud83e\uddb3\ud83c\udf04", "Jonah merely meant a life-preserver\u2014an inflated bag of wind\u2014which the endangered prophet swam to, and so was saved from a watery doom": "\ud83d\udc68\u200d\ud83e\uddb0\ud83d\udc49\ud83e\udd37\u200d\u2642\ufe0f\ud83d\udcad\ud83d\udeab\ud83d\udd2a\ud83d\udd70\ufe0f, \ud83c\udf2c\ufe0f\u2795\ud83d\udecd\ufe0f\ud83d\udca8 (\ud83c\udfca\u200d\u2642\ufe0f\u270a\ud83d\udd1c) = \u26d1\ufe0f\ud83d\udca6\ud83d\udd2e\u2795\ud83d\ude4f.", "when I go to sea, I go as a simple sailor, right before the mast, plumb down into the forecastle, aloft there to the royal mast-head": "\ud83d\udd70\ufe0f\u2b05\ufe0f\ud83d\udeb6\u200d\u2642\ufe0f\ud83c\udf0a, \ud83d\udc49\ud83d\udeb6\u200d\u2642\ufe0f\u27a1\ufe0f\ud83d\udc4d\ud83e\uddd1\u2693\ufe0f, \ud83d\udc49\ud83d\udc4d\ud83d\udd0d\ud83d\udea2\u2693\ufe0f, \u2935\ufe0f\ud83d\udd1c\ud83d\udc47\ud83d\udea2\ud83d\udc48, \u2196\ufe0f\ud83d\udc46\ud83d\udc51\ud83d\udea2\u2693\ufe0f", "I will send you to hell.": "\ud83d\ude08\ud83d\udd1c\ud83d\udcf2\ud83d\udd1c\ud83d\udc49\ud83d\udd25\ud83d\udc79", "upon first cutting into him with the spade, the entire length of a corroded harpoon was found imbedded in his flesh": "\ud83d\udd70\ufe0f\ud83e\udd47\u2702\ufe0f\ud83d\udc68\u200d\u2695\ufe0f\ud83d\udd2a, \ud83d\udd0d\ud83d\udde1\ufe0f\ud83d\udccf\u2b05\ufe0f\ud83d\uddd1\ufe0f\ud83e\ude93\ud83d\udd0e\ud83c\udf56\ud83e\udd15\ud83d\udc89", "Now, how had this noble rescue been accomplished?": "\ud83e\udd14\u2753, \ud83d\udd0e\ud83d\udca1\ud83d\udc51\ud83d\ude91\ud83c\udfc5\ud83d\udcaa\ud83d\udcaf\u2753", "the whaleman is wrapped by influences all tending to make his fancy pregnant with many a mighty birth.": "\ud83d\udc0b\ud83d\udc68\ud83c\udf2c\ufe0f\ud83d\udd04\ud83c\udf10\ud83c\udf1f\u27a1\ufe0f\ud83e\udd30\ud83d\udcad\ud83d\udcaa\ud83d\udc23\ud83d\udd1a", "he cannot be thus circumstanced without a shudder that makes the very marrow in his bones to quiver in him like a shaken jelly": "\ud83d\udeab\u27a1\ufe0f\ud83d\udeb9\ud83c\udf00\ud83d\udc65\ud83d\udca6\ud83e\udd76, \ud83d\udc80(\ud83c\udf56\u27a1\ufe0f\ud83e\uddb4)\ud83e\udda0\ud83c\udf6e\ud83d\udc48\ud83d\ude31\ud83d\udd7a", "the blubber wraps the body of the whale, as the rind wraps an orange": "\ud83d\udc0b\u27a1\ufe0f\ud83c\udf10, \ud83c\udf4a\ud83c\udf43\ud83d\udd01\ud83c\udf4a", "But this is not the half; look again.": "\ud83d\udc46,\ud83d\udc40, \ud83d\udd0d\ufe0f,\ud83d\ude45\u200d\u2642\ufe0f, 1\ufe0f\u20e3/2\ufe0f\u20e3", "in her murderous hold this frigate earth is ballasted with bones of millions of the drowned": "\ud83d\udc69\ud83d\udc80\ud83e\udd1d\ud83d\udef3\ufe0f\ud83c\udf0d\ud83d\udd2e\ud83d\udc80\ud83d\udc80\ud83d\udc80\ud83c\udf0a\ud83c\udf0a\ud83c\udf0a\ud83d\udc65\ud83d\udc65\ud83d\udc65", "his ship was indeed what in the Fishery is technically called a clean one (that is, an empty one)": "\ud83d\udc68\ud83d\udea2\ud83d\udc4c\ud83d\udc1f\ud83c\udfed\ud83d\udcda\ud83d\udde3\ufe0f\ud83e\uddfc1\ufe0f\u20e3 (\u27a1\ufe0f\ud83d\udd73\ufe0f1\ufe0f\u20e3)", "Whales, sharks, and monsters, arm\u2019d in front or jaw, With swords, saws, spiral horns, or hooked fangs.": "\ud83d\udc0b, \ud83e\udd88, \ud83d\udc7e, \ud83d\udcaa\ud83d\udd14, \ud83d\udd19 or \ud83e\uddb7, \ud83d\udde1\ufe0f,\ud83e\ude9a,\ud83c\udf00\ud83e\udd84, or \ud83e\ude9d\ud83e\udddb\u200d\u2640\ufe0f.", "all three of us lifelessly swung from the spars, and for every swing that we made there was a nod from below from the slumbering helmsman": "\ud83d\udc68\u200d\ud83d\udc66\u200d\ud83d\udc66\u26d4\ufe0f\ud83d\udcab\ud83d\udd00\ud83d\udccf \u2795\ud83d\udd01\ud83e\udd15\ud83d\udd7a\ud83c\udffd\ud83d\udd1b\ud83d\udea2\ud83d\udd28, \u2795\u27b0\ud83d\udcab\ud83d\udd7a\ud83c\udffd\ud83d\udd1b\ud83d\udd01\u27a1\ufe0f\ud83d\ude47\u200d\u2642\ufe0f\ud83d\udd3d\u2b07\ufe0f\ud83d\udd19\ud83d\ude34\u26f5\ud83e\udd35\u200d\u2642\ufe0f", "Methinks we have hugely mistaken this matter of Life and Death.": "\ud83e\udd14\ud83d\udcad, \ud83d\udc65\ud83d\udeab\u2757\ufe0f\ud83d\udca1\ud83d\udd04\u2696\ufe0f, \u26a0\ufe0f\ud83e\udd37\u200d\u2640\ufe0f\u2122\ufe0f\ud83d\udca1\u2753\ud83d\udcab\u2b07\ufe0f\ud83d\udea7\ud83d\udc41\ufe0f\u200d\ud83d\udde8\ufe0f\ud83d\udd1a\ud83c\udf42\u2620\ufe0f\ud83d\udeab\ud83d\udd01\ud83c\udfad", "then Gemini, or the Twins\u2014that is, Virtue and Vice": "\u27a1\ufe0f\u264a, \ud83d\udc65 (\ud83d\udc7c\ud83d\udc79)", "Give it up, Sub-Subs!": "\ud83e\udd32\ud83d\uded1, \ud83d\udea2\ud83d\udea2!", "Madman! look through my eyes if thou hast none of thine own.": "\ud83d\ude21\ud83e\udd2a! \ud83d\udc40\ud83d\udc41\ufe0f\ud83d\udc41\ufe0f\ud83d\udc48\ud83d\udc47\ud83d\udd75\ufe0f\u200d\u2642\ufe0f if \u2b05\ufe0f\ud83d\udc64\u274c\ud83d\udeabof \ud83d\udc64\ud83d\udc40\ud83d\udc48.", "Full in this rapid wake, and many fathoms in the rear, swam a huge, humped old bull": "\ud83c\udf15\ud83d\udc49\ud83c\udf0a\ud83d\udca8\ud83c\udf0a, \u2795\ud83d\udd22\ud83d\udccf\ud83d\udc47\ud83d\udd19, \ud83c\udfca\u200d\u2642\ufe0f\ud83d\udc33\ud83d\udc0b\ud83d\udc74\ud83d\udc02", "Nor was this all.": "\u274c\ud83d\udc65\ud83d\udc49\u2b50\ud83d\udc68\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83c\udf19\ud83d\udc64\ud83d\udcad\ud83d\udd1b", "Dissect him how I may, then, I but go skin deep; I know him not, and never will.": "\ud83d\udd2a\ud83d\udc68\u200d\u2695\ufe0f\ud83e\udd37\u200d\u2642\ufe0f\ud83d\udd0e, \u27a1\ufe0f, \ud83d\ude4b\u200d\u2642\ufe0f\ud83d\udca8\ud83d\udc49\ud83c\udffb\ud83d\udc86\u200d\u2642\ufe0f\ud83d\udd1d; \ud83d\ude4b\u200d\u2642\ufe0f\ud83e\udd14\ud83d\udd75\ufe0f\u200d\u2642\ufe0f\ud83d\udeab, \u274c\ud83d\udd04\ud83d\udcad.", "all sailors of all sorts are more or less capricious and unreliable\u2014they live in the varying outer weather, and they inhale its fickleness": "\ud83d\udc65\u26f5\u2728\ud83c\udfad\ud83e\udd37\u200d\u2642\ufe0f \u2696\ufe0f\ud83d\udc40\ud83d\udcad\u2014\ud83c\udfe0\ud83c\udf26\ud83c\udf08\ud83c\udf2a\ud83d\udd2e, \ud83d\ude35\ud83d\udca8\ud83c\udf00\ud83c\udf26\ud83c\udfb2\ud83d\udd04", "the mate commanded him to get a broom and sweep down the planks, and also a shovel, and remove some offensive matters consequent upon allowing a pig to run at large": "\ud83d\udc65\ud83d\udde3\ufe0f\ud83d\udc49\ud83d\ude4d\u200d\u2642\ufe0f\u27a1\ufe0f\ud83e\uddf9\ud83e\uddf1,\ud83d\udd0d\ud83e\uddf9\u2b07\ufe0f\ud83c\udf43,\ud83d\ude4f\ud83d\udd0d\ud83e\udd44\ud83d\udd73\ufe0f,\u2795\ud83d\udd04\ud83d\udeae\ud83e\udda8\ud83d\uddd1\ufe0f\ud83d\udc16\ud83c\udd93\ud83c\udfc3\u200d\u2642\ufe0f\u2611\ufe0f", "A Loose-Fish is fair game for anybody who can soonest catch it.": "\ud83c\udd70\ufe0f\ud83d\udc1f\ud83d\udca8\ud83c\udfaf\ud83c\udfae\ud83d\udd04\ud83d\ude4b\u200d\u2642\ufe0f\ud83d\ude4b\u200d\u2640\ufe0f\ud83d\udca8\ud83d\udd1c\ud83c\udfa3\ud83c\udfa3\ud83c\udfa3", "Fate reserved the doubloon for me.": "\ud83d\udd2e\ud83d\udcbe\ud83d\udd04\ud83d\udcb0\ud83d\udc48\ud83c\udffb\ud83d\ude4b\u200d\u2642\ufe0f", "But then again, what has the whale to say?": "\ud83e\udd14\u27a1\ufe0f\ud83d\udd04, \ud83e\udd37\u200d\u2642\ufe0f\ud83d\udde3\ufe0f\ud83d\udc0b?", "Beneath the unclouded and mild azure sky, upon the fair face of the pleasant sea, wafted by the joyous breezes, that great mass of death floats on and on, till lost in infinite perspectives.": "\ud83d\udc47\ud83d\udd35\ud83c\udf0c\ud83c\udf24\ufe0f, \ud83d\udd1b\ud83d\udc69\u200d\ud83e\uddb0\ud83d\udc99\ud83c\udf0a, \ud83c\udf2c\ufe0f\ud83d\ude06\ud83d\udca8, \ud83d\udc47\u26b0\ufe0f\ud83d\uddfa\ufe0f\u2b50\ud83d\udea3\u200d\u2642\ufe0f\u27a1\ufe0f\u27a1\ufe0f, \ud83d\udcdb\u26d4\ud83d\udd01\u23f8\ufe0f\ud83d\udd0d.", "Thus they rushed; each man with might and main clinging to his seat, to prevent being tossed to the foam": "\ud83d\udca8\ud83d\udca8\ud83d\udc65\ud83c\udfc3\u200d\u2642\ufe0f\ud83d\udcaa\ud83d\udcba\ud83d\udc65\ud83e\udd32\ud83d\ude45\u200d\u2642\ufe0f\ud83c\udf0a\ud83c\udf0a\ud83d\udc4b\ud83c\udfc4\u200d\u2642\ufe0f", "he tried to shut down the dead lid of his murderous jaw": "\ud83d\udc68\u200d\ud83d\udcbc\ud83d\udd2a\ud83d\udc44\ud83d\udd3d\ud83d\udeab\ud83e\udea6\ud83d\udc80\ud83d\udeaa\u26b0\ufe0f", "God! God! God!\u2014crack my heart!\u2014stave my brain!\u2014mockery! mockery! bitter, biting mockery of grey hairs": "\ud83d\ude4f! \ud83d\ude4f! \ud83d\ude4f! - \ud83d\udc94 my \u2764\ufe0f! - \ud83e\udd2f my \ud83e\udde0! - \ud83c\udfad! \ud83c\udfad! \ud83d\ude16\ud83d\ude16, \ud83e\uddb7\ud83e\uddb7 mockery of \ud83e\uddd3\ud83d\udc68\u200d\ud83e\uddb3\ud83d\udc75\ud83d\udc74!", "from unavoidable circumstances, considerable of it is spilled, leaks, and dribbles away, or is otherwise irrevocably lost in the ticklish business of securing what you can": "\ud83d\udd04\u21a9\ufe0f\u26d4\ud83d\udeab\ud83d\udc65\ud83d\udcbc, \ud83d\ude2e\ud83d\udccf\ud83d\udca7\u2198\ufe0f\u2b07\ufe0f, \ud83d\udca6, \ud83c\udf76\u2614 \ud83d\udca8, \u27a1\ufe0f\u26d4\ud83d\udd19\ud83d\udd12\ud83d\udc94\u21a9\ufe0f\ud83d\udc40\ud83e\udd1a\ud83c\udfaf\ud83c\udfc6\ud83d\udd12\ud83d\udcbc\ud83c\udf40", "the secret of our paternity lies in their grave, and we must there to learn it": "\ud83d\udd12\ud83e\udd2b\ud83d\udc68\u200d\ud83d\udc67\u200d\ud83d\udc66\ud83d\udca1\ud83d\udccd\u2620\ufe0f\u26b0\ufe0f\ud83d\udc65\ud83d\udcda\ud83d\udc40\ud83d\udc48", "Ahab stands alone among the millions of the peopled earth, nor gods nor men his neighbors!": "\ud83e\uddd4\ud83d\udd74\ufe0f\ud83d\udeb6\u200d\u2642\ufe0f\ud83d\udcab\ud83c\udf0d\ud83d\udc6b\ud83d\udc6d\ud83d\udc6c\ud83d\udeab\ud83d\ude4f\ud83d\udeb6\u200d\u2642\ufe0f\ud83d\udeab\ud83d\udc65\ud83c\udfe0\ud83c\udfd8\ufe0f", "however prolonged and exhausting the chase, the harpooneer is expected to pull his oar meanwhile to the uttermost": "\ud83d\udd00\u23f3\ud83c\udfc3\u200d\u2642\ufe0f\ud83d\ude13\ud83d\udd01, \ud83c\udfaf\ud83d\udc33\ud83e\uddd1\u200d\ud83d\udea3\u200d\u2642\ufe0f\ud83d\udc48\ud83d\udc4d\ud83d\udd1c \ud83d\udea3\u200d\u2642\ufe0f\ud83d\udcaa\ud83c\udffd\u27a1\ufe0f\ud83d\udd1a\ud83d\udd04\u2757\ufe0f", "they regarded it, not as a foreshadowing of evil in the future, but as the fulfilment of an evil already presaged": "\ud83d\udc65\ud83d\udc40\ud83c\udfad, \u274c\ud83d\udd2e\ud83d\udc79\ud83d\udd70\ufe0f, \u27a1\ufe0f\ud83d\udcab\ud83d\udc79\ud83d\udd2e\ud83d\udd60", "Whether that mark was born with him, or whether it was the scar left by some desperate wound, no one could certainly say.": "\u2753\u2705\ud83c\udfaf\ud83d\udc76\ud83c\udf7c\ud83d\udc68\u200d\ud83c\udf7c, \u2753\u2705\ud83c\udfaf\ud83c\udf41\ud83e\udd15\ud83d\udc94\ud83d\ude14, \ud83d\udeab\ud83d\ude4d\u200d\u2642\ufe0f\ud83d\udc4d\ud83d\udcac\ud83e\udd37\u200d\u2642\ufe0f.", "The vast tackles have now done their duty. The peeled white body of the beheaded whale flashes like a marble sepulchre": "\ud83c\udf0c\ud83c\udfa3\ud83d\udc4d\u2705\ud83d\udcbc. \ud83d\udd2a\ud83e\udd0d\ud83d\udc0b\ud83d\ude80\ud83d\udca5\u26aa\ud83d\udca1\ud83c\udfdb\ufe0f.", "Woe to him whose good name is more to him than goodness!": "\ud83d\ude22\u27a1\ufe0f\ud83d\udc64\ud83d\udc4b\ud83c\udf1f\ud83d\udcdb\ud83e\udd47\u27a1\ufe0f\ud83d\udc64\ud83d\udc96\ud83e\udd1d\ud83d\udc4d", "Can\u2019t ye see the world where you stand?": "\ud83d\udeab\ud83d\udc40\ud83c\udf0d\ud83d\udccd\ud83d\udc63\u2753", "it is hidden away behind its vast outworks, like the innermost citadel within the amplified fortifications of Quebec": "\ud83e\udd2b\ud83d\udd0d\ud83d\udc48\ud83d\udd1b\ud83c\udff0\u26f0\ufe0f, \ud83d\udc4d\u2714\ufe0f\u21a9\ufe0f\ud83c\udfde\ufe0f\ud83c\udff0\ud83d\udd0d\u26d3\ufe0f\u27a1\ufe0f\ud83d\udd0a\ud83c\udfd7\ufe0f\ud83d\udd1b\ud83c\udde8\ud83c\udde6\ud83c\udff0", "And of all these things the Albino whale was the symbol.": "\ud83d\udcab\u2728\ud83d\udc33\ud83d\udc0b\ud83d\udd4a\ufe0f\ud83c\udfad\ud83d\udd79\ufe0f\ud83d\udebc\ud83d\udd16", "Inlanders all, they come from lanes and alleys, streets and avenues\u2014north, east, south, and west.": "\ud83c\udfde\ufe0f\ud83d\udc65\ud83d\udc65, \ud83d\udeb6\u200d\u2640\ufe0f\ud83d\udeb6\u200d\u2642\ufe0f\ud83d\udd04\ud83d\udee3\ufe0f\ud83d\udd00\ud83c\udfd8\ufe0f, \ud83d\udee4\ufe0f\ud83d\udee3\ufe0f- \ud83e\udded\ud83d\udd1d, \ud83e\udded\u27a1\ufe0f, \ud83e\udded\u2b07\ufe0f, \ud83e\udded\u2b05\ufe0f.", "every boat was a buoy; the sunken whale being suspended a few inches beneath them by the cords": "\u26f5\u26f5\u26f5 = \u2693; \ud83d\udc0b\ud83d\udca6\ud83d\udc47\ud83c\udffd\ud83d\udd17\ud83d\udd17\ud83d\udd17\ud83d\udca7\ud83d\udca7\ud83d\udca7\ud83d\udd17\u26f5\u26f5\u26f5", "O Nature, and O soul of man!": "\ud83c\udf3f\ud83c\udf33, \ud83d\udd2e\ud83d\ude4e\u200d\u2642\ufe0f!", "Each silent worshipper seemed purposely sitting apart from the other, as if each silent grief were insular and incommunicable.": "\ud83d\udd07\ud83d\ude4f\ud83d\udd1b\ud83d\udd02\ud83d\ude36\ud83d\ude47\u200d\u2642\ufe0f\ud83e\udd14\ud83d\udcba\u27a1\ufe0f\ud83d\udeb6\u200d\u2642\ufe0f\ud83d\udeb6\u200d\u2640\ufe0f, \u27a1\ufe0f\ud83d\udd07\ud83d\ude2d\ud83c\udfdd\ufe0f\ud83d\ude36\ud83d\udd0f\ud83d\udcf4.", "infantileness of ease undulates through a Titanism of power": "\ud83d\udc76\u27a1\ufe0f\ud83c\udfde\ufe0f\ud83d\ude0c\ud83c\udf0a\ud83d\udd04\ud83c\udfd4\ufe0f\ud83d\udcaa\ud83d\udd31\ud83d\udca5", "Unconsciously my chirography expands into placard capitals.": "\ud83d\ude34\u270d\ufe0f\ud83d\udcad\ud83d\udcc8\u27a1\ufe0f\ud83d\udcdc\ud83d\udd20", "give me the privilege of making my own summer with my own coals": "\ud83d\ude4f\ud83c\udf81\ud83d\udc49\ud83d\udc51\ud83d\udd28\ud83d\udee0\ufe0f\ud83d\udc48\u2600\ufe0f\ud83d\udd25\u26f1\ufe0f\ud83e\udd65\ud83d\udd25", "how then can this one small heart beat": "\u2753\ud83d\udd1c\ud83d\udd2e\u2753\ud83d\udc93\ud83d\udd2c\ud83d\udddd\ufe0f\u270a\ud83e\ude78", "the weapon is instantly at hand to its hurler": "\ud83d\udd2b\u23f1\ufe0f\u270b\ud83d\udd04\ud83e\udd3e\u200d\u2642\ufe0f", "Stubb scattered the dead ashes over the water; and, for a moment, stood thoughtfully eyeing the vast corpse he had made.": "'Stubb\ud83d\udcad\ud83d\udd00\ud83d\udc68\u200d\ud83c\udf3e\ud83e\uddf9\ud83e\udea6\u26b1\ufe0f\ud83d\udd1d\ud83d\udca7; \u2795, \ud83c\udd70\ufe0f\ud83d\udcad, \u23f1\ufe0f\ud83d\udeb6\u200d\u2642\ufe0f\ud83d\udcad\ud83d\udc41\ufe0f\ud83d\udc41\ufe0f\ud83c\udf0a\ud83d\udc80\u2620\ufe0f\ud83e\udd32\ud83d\udd28\ud83d\udd27.'", "in tormented chase of that demon phantom that, some time or other, swims before all human hearts; while chasing such over this round globe, they either lead us on in barren mazes or midway leave us whelmed": "\ud83d\ude30\ud83c\udfc3\u200d\u2640\ufe0f\ud83d\udc7f\ud83d\udc7b\ud83d\udd53\ud83d\udd5f\ud83d\udd57,\ud83c\udfca\u200d\u2642\ufe0f\ud83e\udde1\ud83d\udc94\ud83c\udf0d; \ud83d\ude30\ud83c\udfc3\u200d\u2640\ufe0f\u27a1\ufe0f\ud83c\udf0e, \ud83d\ude15\ud83d\udd00\ud83c\udfdc\ufe0f\u2639\ufe0f\ud83d\ude35\u200d\ud83d\udcab\ud83d\udd1a+\ud83c\udf0a\ud83c\udd98", "That head upon which the upper sun now gleams, has moved amid this world\u2019s foundations.": "\u261d\ufe0f\ud83d\udc64\ud83d\udca1\ud83d\udd1b\ud83c\udf1e\u21aa\ufe0f, \ud83d\udeb6\u200d\u2642\ufe0f\ud83d\udcab\ud83c\udf0d\ud83c\udfd7\ufe0f\ud83d\udd00.", "but the reason why the grave-digger made music must have been because there was none in his spade": "\ud83c\udf51, \ud83e\udd14\ud83d\udcac\ud83d\udc4d\ud83c\udffd \ud83d\udd39\ud83c\udd9a \ud83d\udd00 \u26b0\ufe0f\ud83d\udc77\ud83d\udd3a\ud83c\udfb5\ud83d\udc7e \ud83c\udd98\ud83c\ude36 \ud83d\uded1\ud83d\udcf5 \ud83c\udfb5\ud83d\udd04 \ud83c\udffa\ud83e\ude93\u26cf\ufe0f", "the motion of a Sperm Whale\u2019s flukes above water dispenses a perfume, as when a musk-scented lady rustles her dress in a warm parlor": "\ud83c\udf0a\ud83d\udc0b\ud83d\udc4b\ud83d\udc46\ud83d\udca6\ud83d\udca8\ud83d\udc43\ud83c\udf39, \ud83c\udf10\ud83d\udc69\ud83d\udc43\ud83d\udc8b\ud83d\udc83\ud83d\udc57\ud83d\udca8\ud83d\udd25\ud83c\udfe0", "Jeremy Bentham\u2019s skeleton, which hangs for candelabra in the library of one of his executors": "\ud83d\udc68\u200d\ud83e\uddb3\ud83e\uddb4\ud83d\udc80, \ud83c\udfd7\ufe0f\ud83d\udd6f\ufe0f\ud83d\udcda\ud83d\udcd6\ud83c\udfe3\ud83d\udc68\u2696\ufe0f", "with my own hand I ply my own shuttle and weave my own destiny into these unalterable threads": "\u270b\ud83e\udd1a\ud83d\udd04\ud83d\ude80\ud83d\udcab, \ud83d\udd2e\u23f3 \u27a1\ufe0f\ud83d\udeab\u23ea\ud83e\uddf5\ud83e\uddf6\ud83d\udd2e\u2696\ud83d\udd04\ud83d\udd2e.", "in what eternal, unstirring paralysis, and deadly, hopeless trance, yet lies antique Adam who died sixty round centuries ago": "\ud83e\udd14\ud83d\udd70\ufe0f\ud83d\udd04, \ud83d\udd12\u26d4\ud83d\udca4, \u2620\ufe0f\ud83d\ude1e\ud83d\udcad, \ud83d\udecf\ufe0f\ud83d\udc74\u23f3Adam\u26b0\ufe0f\u231b6\ufe0f\u20e30\ufe0f\u20e3\ud83d\udd04\ud83d\uddd3\ufe0f\ud83e\udd37\u200d\u2642\ufe0f\ud83d\udc48", "Ignorance is the parent of fear": "\ud83e\udd14\ud83d\udc68\u200d\ud83d\udc69\u200d\ud83d\udc67\u200d\ud83d\udc66\ud83d\udd78\ufe0f\ud83d\ude31", "these savages have an innate sense of delicacy, say what you will; it is marvellous how essentially polite they are": "\ud83d\udc65\ud83d\udc05\ud83d\udc2f\ud83e\udd41\ud83d\udc48\ud83e\uddea\ud83d\udca1\ud83c\udf39\ud83c\udfa9\ud83d\udcad\ud83d\udcac\ud83e\udd37\u200d\u2642\ufe0f; \ud83c\udf0c\ud83e\udd2f\ud83d\udc81\u200d\u2640\ufe0f\ud83d\udc4d\ud83c\udffc\ud83d\udd2c\ud83c\udf81\ud83c\udf8a\ud83d\udc4f\ud83c\udffc\ud83d\udc9d\ud83d\ude4f\ud83c\udffc", "one continual stream of Venetianly corrupt and often lawless life": "1\ufe0f\u20e3\ud83d\udd04\ud83c\udf0a\ud83c\uddee\ud83c\uddf9\ud83d\udcb0\ud83d\udd25\u2696\ufe0f\u274c\ud83e\udd37\u200d\u2640\ufe0f\ud83d\udc80", "Oh, won\u2019t ye pull for your duff, my lads\u2014such a sog! such a sogger! Don\u2019t ye love sperm?": "\ud83d\ude2e\u2757\ufe0f\ud83d\ude4f\ud83c\udffd\ud83d\udcaa\ud83d\udc5c\ud83d\udcbc\ud83d\udc6c\ud83c\udf0a\ud83c\udf0a\ud83c\udf0a\ud83d\udca6\ud83d\udca6\u2757\ufe0f\ud83d\ude0d\ud83d\ude0d\u2753\ud83d\udc33", "Delight is to him\u2014a far, far upward, and inward delight": "\ud83d\ude03\ud83d\udc49\ud83d\udc64 - \ud83d\ude80\u2934\ufe0f\u2934\ufe0f\ud83d\udd1d, \u2795\ud83d\udd0d\ud83c\udf89", "Hurrah for the gold cup of sperm oil, my heroes!": "\ud83c\udf89\ud83c\udfc6\ud83e\udd47\ud83e\udd64\ud83d\udc33\ud83d\udca6, \ud83d\ude4c\ud83e\uddb8\u200d\u2642\ufe0f!", "But flukes! man, what makes thee want to go a whaling, eh?": "\u2757\ufe0f\ud83d\udc33\u2693\ufe0f! \ud83d\udc68\u200d\ud83c\udfa4, \ud83e\udd14\u2753, \ud83d\udca1\ud83d\udc49\ud83d\udef6\ud83d\udc33\ud83c\udfa3, \u2753", "I\u2019m quite certain that he\u2019s no more fit to command a whale-ship than a St. Jago monkey. In fact, tell him from me he\u2019s a baboon.": "\ud83d\ude0a\ud83d\udd12\ud83d\udc4d\ud83c\udffb\ud83e\udd14\ud83d\udc66\u274c\ud83d\udcaa\ud83d\udef3\ud83d\udc0b \u27a1\ufe0f \ud83d\udc53\ud83d\udc12. \u2705\ud83d\udcac, \ud83d\udde3\ud83d\udc49\ud83d\udc66\ud83d\udc8c\ud83d\udc48\ud83d\udc12.", "this is what ye have shipped for, men! to chase that white whale on both sides of land, and over all sides of earth": "\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48\ud83d\udc48", "What does the whaler do when she meets another whaler in any sort of decent weather? She has a \u201cGam,\u201d a thing so utterly unknown to all other ships that they never heard of the name even": "\u2753\u2753\ud83d\udc33\ud83d\udc69\u200d\ud83e\uddb0\ud83e\udd14\ud83d\udcad\ud83d\udd51\u27a1\ufe0f\ud83e\udd1d\u27a1\ufe0f\ud83d\udc33\ud83d\udc69\u200d\ud83e\uddb0\ud83c\udf24\ufe0f\u2600\ufe0f\ud83c\udf25\ufe0f? \ud83d\udc69\u200d\ud83e\uddb0\ud83d\udd51\"Gam,\" \ud83d\udc65\ud83c\udf89\ud83d\udc40\u2757\ufe0f\u274c\ud83d\udca1\u2753\u2693\ud83d\udea2\ud83d\udc42\ud83d\udd09\u2753\ud83d\udcdb\u23ed\ufe0f\u26d4\u2755", "oil is a sliding thing": "\u26fd\ufe0f\u27a1\ufe0f\ud83d\udd00\ud83c\udf6e", "then scepticism, then disbelief, resting at last in manhood\u2019s pondering repose of If": "\ud83d\udd1c\u2753\ud83e\uddd0\ud83d\udd1c\u274c\ud83d\ude45\u200d\u2642\ufe0f\ud83d\udcad, \ud83d\udecf\ufe0f\ud83d\udd04\ud83d\udd1a\ud83d\udc68\u200d\ud83e\uddb1\ud83d\udcad\u270b\ud83e\udd14\ud83d\udd04'If'", "Alike, joy and sorrow, hope and fear, seemed ground to finest dust, and powdered, for the time, in the clamped mortar of Ahab\u2019s iron soul.": "\ud83d\udc65\ud83d\udd00, \ud83d\ude04\ud83e\udd1d\ud83d\ude22, \ud83e\udd1e\ud83e\udd1d\ud83d\ude28, \ud83d\udc40\ud83d\udc4d\ud83d\udd2c\ud83d\udca8, \u231b\ud83d\udd01\ud83e\udd0f, \ud83d\udd70\ufe0f, \ud83d\udd12\ud83d\udc8a\ud83e\udd32\ud83e\ude93\u2699\ufe0f\ud83d\udd2e\ud83d\udeb6\u200d\u2642\ufe0f\ud83e\udd0e.", "For sleeping man, \u2019twas hard to choose between such winsome days and such seducing nights.": "\ud83d\udca4\ud83d\ude34\ud83d\udc68, \u2696\ufe0f\ud83e\udd14\ud83d\udcca\ud83c\udf1e\ud83c\udfde\ufe0f\u2600\ufe0f\ud83c\udf89\ud83c\udf3b\ud83c\udf37\ud83c\udf08\ud83c\udd9a\ud83c\udf1a\ud83c\udf0c\ud83d\udda4\ud83d\ude0d\ud83c\udf1c\ud83c\udf03\ud83c\udf1f\ud83c\udf20\u27b0\ud83d\udcab\ud83c\udf1a.", "Suddenly bubbles seemed bursting beneath my closed eyes": "\ud83c\udf2b\ufe0f\ud83d\udca5\ud83d\ude2e\ud83d\udc40\ud83c\udf0a\ud83d\udd3d\ud83d\udc41\ufe0f\ud83d\udc41\ufe0f\u26d4", "I thought it was high time, now or never, before the light was put out, to break the spell in which I had so long been bound.": "\ud83d\udcad\ud83d\udca1\u23f0\u2b06\ufe0f\u23f1\ufe0f, \ud83d\udd70\ufe0f\u27a1\ufe0f\ud83d\udeab\ud83d\udd70\ufe0f, \ud83d\udd1c\ud83d\udd26\ud83d\udeab\ud83d\udca1\ud83d\udd1a, \ud83d\udde1\ufe0f\u26a1\ufe0f\ud83d\udc94\ud83d\udd2e\u2728\ud83d\udcd6\ud83d\udd04\u2728\ud83d\udd17\u23f3\ud83d\udd1f\ud83d\udcaf.", "for hours he fell into the deeper midnight of the insatiate maw": "\u23f3\ud83d\udd53\ud83d\udd54\ud83d\udd55\ud83d\udd56\ud83d\udd57\ud83d\udd58\ud83d\udd59\ud83d\udd5a\ud83d\udd5b\ud83d\udd5c\ud83d\udd5d\ud83d\udd5e\ud83d\udd5f\ud83d\udd60\ud83d\udd61\ud83c\udfa9\ud83d\udd73\ufe0f\ud83c\udf11\ud83c\udf11\ud83c\udf11\ud83d\udc44\ud83c\udf7d\ufe0f\ud83c\udf00\ud83d\udca4\ud83d\udc47\ud83c\udf1a\ud83c\udf1a\ud83c\udf1a", "It never wriggles.": "\u274c\ud83d\udc0d\ud83d\udd04", "This whole book is but a draught\u2014nay, but the draught of a draught.": "\ud83d\udcd6\u27a1\ufe0f\ud83c\udf7a\u27a1\ufe0f\u274c, \u27a1\ufe0f\ud83c\udf7a\ud83c\udf7a.", "the proverbial evanescence of a thing writ in water, a wake": "\ud83d\udcdc\ud83d\udcac\ud83d\udca8\ud83c\udf0a\u270d\ud83d\udc40\ud83d\udca6\u23f0", "in his poor opinion, the wondrous whale was but a species of magnified mouse, or at least water-rat, requiring only a little circumvention and some small application of time and trouble in order to kill and boil": "\ud83e\udd14\ud83d\udcad\ud83d\udeab\ud83d\udcb0, \ud83c\udf1f\ud83d\udc0b \u27a1\ufe0f \ud83d\udd0d\ud83d\udc2d, \ud83e\udd37\u200d\u2642\ufe0f\ud83d\udca6\ud83d\udc00, \ud83d\ude4f\u23f2\ufe0f\ud83d\udd04 \u2795 \u23f3\u2699\ufe0f\ud83e\udd0f 2\ufe0f\u20e3 \ud83d\udde1\ufe0f\u2795\ud83d\udd25\ud83c\udf72", "the Nor\u2019 West Passage, so long a problem to man, was never a problem to the whale": "\ud83e\udded\ud83c\udf0d\u2b05\ufe0f\ud83d\udea2\ud83d\udd57\ud83d\udeb6\u200d\u2642\ufe0f\u2753, \ud83d\udeab\u2753\ud83d\udc0b", "these marvels (like all marvels) are mere repetitions of the ages": "\ud83d\udc49\ud83c\udf20 (\u27a1\ufe0f\ud83d\udd70\ufe0f) (\ud83d\udc4d\ud83d\udcab) \u27a1\ufe0f\ud83d\udd02\ud83c\udfad\u231b", "this sunken-eyed young Platonist will tow you ten wakes round the world, and never make you one pint of sperm the richer": "\ud83d\udc40\ud83d\udc47\ud83e\uddd2\ud83d\udca1\ud83c\udf10\ud83d\ude9b\ud83d\udd1f\ud83c\udf0a\ud83c\udf0d, \ud83d\udc4e\ud83d\udcb01\ufe0f\u20e3\ud83c\udf7a\ud83d\udca6", "the Cape winds began howling around us, and we rose and fell upon the long, troubled seas that are there": "\ud83c\udfde\ufe0f\ud83d\udca8\ud83e\udde9\ud83c\udd71\ufe0f\ud83c\udf00\ud83d\udd04\ud83e\udd1f, \ud83c\udd99 \ud83d\udcc8\u2b07\ufe0f \u21a9\u2935\ufe0f\ud83d\udd1b\ud83c\udf0a\ud83d\udd03\ud83c\udf0a, \ud83c\udf2b\ufe0f\ud83d\udca6\u26a0\ufe0f\ud83d\udccd\ud83d\udc69\u200d\ud83d\udc69\u200d\ud83d\udc67\u200d\ud83d\udc66\ud83d\udc40", "Chief among these motives was the overwhelming idea of the great whale himself.": "\ud83d\udc51\ud83d\udca1\ud83c\udf0a\ud83d\udc0b\ud83d\udca1", "it seemed as if this were the Loom of Time, and I myself were a shuttle mechanically weaving and weaving away at the Fates": "\ud83e\udd14\u27a1\ufe0f\ud83d\udd70\ufe0f\ud83d\udc4d\ud83c\udffb\ud83d\udc68\u200d\ud83d\udd2c\u231b, \u2795\ud83d\udc64\ud83d\udc81\u200d\u2640\ufe0f\ud83c\udfce\ufe0f\ud83d\ude34\ud83d\udcad\u27b0\ud83d\udcad\ud83d\udc40\ud83d\udd2e\ud83c\udf9a\ufe0f", "if these secret golden keys did seem to open in him his own secret golden treasuries, yet did his breath upon them prove but tarnishing": "\ud83d\udd10\ud83d\udd11\ud83d\udd11\u2728\ud83d\udcab\ud83e\udd2b\ud83d\udcab\ud83e\uddd2\ud83d\udcab\ud83d\udd12\ud83d\udcb0\ud83d\udcb0\ud83d\udcb0\ud83d\udcb0\u2728\ud83d\udcab\ud83e\udd2b\ud83d\udcab, \u27a1\ufe0f\ud83d\ude24\ud83d\udca8\ud83d\udd10\ud83d\udd11\ud83d\udd11\ud83d\udc48\ud83d\udd0d\ud83d\udc94\ud83d\ude35\ud83e\udd48\ud83e\udd37\ud83e\udd14", "The skeleton dimensions I shall now proceed to set down are copied verbatim from my right arm, where I had them tattooed": "\ud83d\udc80\ud83d\udccf\ud83d\udc47\ud83d\udd1c\u270d\ufe0f\ud83d\udcbe\ud83d\udd01\ud83d\udcac\ud83d\udccb\ud83d\udc49\ud83d\udcaa,\u270d\ufe0f\ud83d\udccd\ud83d\udd8a\ufe0f\ud83c\udfa8\ud83d\udccc", "For that business is an exceedingly laborious one; is not very soon completed; and requires all hands to set about it.": "\ud83d\udc49\ud83c\udffb\ud83d\udcda\ud83d\udcbc\ud83d\udcc8\ud83d\udcbc \u27a1\ufe0f\ud83d\udd25\ud83d\udcaa\ud83d\udd70\ufe0f\ud83d\udcaf1\ufe0f\u20e3; \ud83d\udeab\u231b\u231b\ud83d\udc96\ud83d\udcaf1\ufe0f\u20e3; \u23e9\ud83d\ude4f\ud83d\udc50\ud83d\ude80\ud83c\udd70\ud83c\udd71\ud83d\udd0d\ud83d\udd0d\ud83d\udcaf1\ufe0f\u20e3.", "a headlong wave shot the boat far ahead, and its seethings drowned all speech": "\ud83c\udf0a\ud83c\udff9\ud83d\udea4\ud83d\udd1c\ud83c\udf2c\ufe0f\ud83d\udd07\ud83d\udde3\ufe0f", "Would to God these blessed calms would last.": "\ud83d\ude4f\ud83d\ude4c\ud83d\ude4f\ud83c\udf1f\ud83c\udf08\ud83d\uded0\ud83c\udf2c\ufe0f\ud83d\udd4a\ufe0f\ud83d\udd01\u23f3\ud83d\ude4f", "floating in the lovely sunset sea and sky, sun and whale both stilly died together": "\ud83d\udcad\ud83d\udc96\ud83c\udf05\ud83c\udf0a\ud83c\udf0c, \u2600\ufe0f\ud83d\udc33\ud83d\ude0c\u2620\ufe0f\ud83e\udd1d", "But Ahab\u2019s glance was averted; like a blighted fruit tree he shook, and cast his last, cindered apple to the soil.": "\ud83d\udd01 Ahab's \ud83d\udc40 was \ud83d\udd04; like a \ud83c\udf4f\ud83c\udf33 infected by\ud83e\udda0 he \ud83e\udd1d, and \ud83c\udfaf his last, \ud83d\udd25\ud83c\udf4e to the \ud83c\udf31.", "But what I am driving at here is this.": "\ud83e\udd14\ud83d\udcad\ud83d\ude97\ud83d\udc48\ud83d\udccd\ud83d\udccc\ud83d\udc40\ud83d\udc47", "singing some pagan psalmody": "\ud83c\udfa4\ud83c\udfb5\ud83d\udcdc\ud83c\udf19\ud83c\udf32", "I find so many great demi-gods and heroes, prophets of all sorts": "\ud83d\udc40\ud83d\udca1\ud83d\udd0e\ud83d\udc65\ud83c\udf96\ufe0f\ud83c\udfc5\ud83e\udde1\ud83d\udcaa\u26a1\ufe0f\ud83c\udfcb\ufe0f\u200d\u2642\ufe0f\ud83d\udd31, \ud83d\udd2e\ud83d\udcac\ud83d\udd4a\ufe0f\ud83c\udf86\ud83c\udf0d\ud83c\udf08\ud83d\udcab\ud83d\udd2e", "a vacated thing, a formless somnambulistic being, a ray of living light, to be sure, but without an object to colour, and therefore a blankness in itself": "\ud83c\udd70\ufe0f\u274e\ud83d\udce6, \ud83c\udd70\ufe0f\ud83d\udc64\ud83d\udca4\ud83d\udeb6\u200d\u2642\ufe0f, \ud83c\udd70\ufe0f\ud83d\udd26\ud83d\udca1\ud83d\udca1\ud83c\udf1e\u2600\ufe0f, \u2705\ud83d\udc4d, \ud83d\udeab\ud83c\udfaf \u27a1\ufe0f\ud83c\udfa8\ud83c\udfa8, \u2757\u274c\u2795 \u2b1b\u26ab\u25fc\ufe0f\u2b1b\u2b1b.", "Truth hath no confines.": "\ud83d\udcd6\u27a1\ufe0f\ud83d\udeab\ud83d\udea7", "Almost rather had I seen Moby Dick and fought him, than to have seen thee, thou white ghost!": "\ud83d\udc40\ud83d\udc0b\ud83d\udc94\ud83e\udd4a\ud83c\udd9a\ud83d\udc40\ud83d\udc7b\u26aa\ufe0f\u2757", "it arched forth its vast archangel wings, as if to embrace some holy ark": "\ud83d\udcab\ud83c\udf10\ud83c\udf08\ud83d\udd4a\ufe0f\ud83d\udc50, \ud83e\udd32\ud83d\udc92\ud83d\udea2\ud83d\ude4f", "I prospectively ascribe all the honor and the glory to whaling; for a whale-ship was my Yale College and my Harvard.": "\ud83d\udc41\ufe0f\ud83d\udd2e\u270d\ufe0f\ud83c\udf1f\ud83c\udfc6\ud83d\udd1b\ud83d\udc0b\ud83c\udfa3; \ud83d\udc0b\ud83d\udea2\ud83d\udc48\ud83c\udf93\ud83c\udfeb\ud83d\udd01Yale College\ud83c\udfdb\ufe0f\ud83d\udcda & Harvard.\ud83d\udcda\ud83c\udfdb\ufe0f", "I shall let it abide here till the White Whale is dead": "\ud83d\udc41\ufe0f\ud83d\udd1c\ud83d\udd01\ud83d\udc47\ud83c\udffd\ud83d\udc40\ud83d\udeaa\u23f1\ufe0f\u2b1b\ud83d\udc33\u2620\ufe0f", "in his inclement, howling old age, Ahab\u2019s soul, shut up in the caved trunk of his body, there fed upon the sullen paws of its gloom": "\ud83d\udc64\ud83c\udf27\ufe0f\ud83d\udd0a\ud83d\udc74\ud83c\udf1c\ud83d\udd73\ufe0f\ud83d\udce6\ud83d\udc64\ud83d\udeab\ud83d\ude15\ud83c\udf74\ud83d\udd90\ufe0f\ud83c\udf11", "fatal to the last degree of fatality; those repeated disastrous repulses, all accumulating and piling their terrors upon Moby Dick": "\ud83d\udc80\ud83d\udd1a\ud83c\udf9a\ufe0f\u2620\ufe0f; \ud83d\udd01\ud83d\ude31\ud83c\udff3\ufe0f, \ud83d\udcda\ud83c\udfd7\ufe0f\ud83d\ude28\ud83d\udd1b\ud83d\udc33", "in one of the Pagan temples, there stood for many ages the vast skeleton of a whale": "\ud83d\udccc1\ufe0f\u20e3\u27a1\ufe0f1\ufe0f\u20e3\ud83d\udd4d\ud83c\udfef, \ud83d\udd0e\ud83d\udd70\ufe0f\ud83d\udd70\ufe0f\ud83d\udd70\ufe0f\ud83d\udc0b\ud83d\udc80\ud83e\uddcd\u200d\u2642\ufe0f\u2b06\ufe0f\ud83d\udd22\ud83c\udf05\ud83c\udf05\ud83c\udf05", "Because no man can ever feel his own identity aright except his eyes be closed": "\ud83d\udd75\ufe0f\u200d\u2642\ufe0f\u26d4\ud83d\udc68\u200d\ud83e\uddb1\u27a1\ufe0f\ud83d\udcad\ud83c\udd97\ud83d\udc41\ufe0f\ud83d\ude48", "Retribution, swift vengeance, eternal malice were in his whole aspect": "\u2696\ufe0f\ud83c\udfc3\u200d\u2642\ufe0f\ud83d\udca8, \u2694\ufe0f\ud83d\udd25, \ud83d\udc79\u23f3 were in his \ud83c\udf42\ud83d\udc41\ufe0f\u200d\ud83d\udde8\ufe0f\ud83d\udc64\ud83c\udf10", "I survived myself; my death and burial were locked up in my chest.": "\ud83d\ude00\ud83d\udc4f\u2705\ud83d\udcaa; \u2620\ufe0f\u26b0\ufe0f\ud83d\udd12\ud83c\udd99\u27a1\ufe0f\ud83d\udc96.", "Does not this whole head seem to speak of an enormous practical resolution in facing death?": "\u2753\u274c\ud83c\udf10\ud83d\udca1\ud83d\udcad\ud83d\udde3\ufe0f\ud83e\udd14\u2728\ud83d\udcaa\ud83d\udee0\ufe0f\ud83d\udc4a\ud83d\udc80\u2753", "they cast long gleams of light over the turbid sea": "\ud83d\udc65\ud83e\ude84\ud83c\udf1f\ud83d\udd26\ud83d\udccf\u2728\ud83c\udf0a\ud83c\udf2b\ufe0f\ud83c\udf0a", "In tempestuous times like these, after everything above and aloft has been secured, nothing more can be done but passively to await the issue of the gale.": "\ud83c\udf29\u231b\ud83d\udd70\ufe0f\ud83d\udc4d\ud83d\udc65, \u23ed\ufe0f\ud83c\udf10\u2b06\ufe0f\u2708\ufe0f\ud83d\udd12, \ud83d\udeab\u2795\ud83d\udd1c\u2705\ud83d\udcbc\ud83d\udc4d\ud83d\udd04\ud83d\udd1c\u262e\ufe0f\ud83d\udd4a\ufe0f\u2600\ufe0f\ud83c\udf2a\ufe0f\ud83d\udd1a.", "There are only two books in being which at all pretend to put the living sperm whale before you, and at the same time, in the remotest degree succeed in the attempt.": "\ud83d\udcda\u270c\ufe0f\ud83d\udd1b\ud83d\udc0b\ud83d\udca6\ud83d\udc40, \u23f0\ud83d\udd1b, \ud83c\udfde\ufe0f\ud83d\udd2d\ud83c\udfaf\ud83d\udc4c.", "Buoyed up by that coffin, for almost one whole day and night, I floated on a soft and dirgelike main.": "\ud83c\udf88\u2b06\ufe0f\u26b0\ufe0f,\ud83d\udd04\ud83d\udd501\ufe0f\u20e3\ud83c\udf1e\ud83c\udf1a, \ud83c\udfca\u200d\u2642\ufe0f\ud83d\udc4d\ud83c\udf00\ud83d\udcd3\ud83c\udf0a\ud83c\udfb5\ud83c\udfb6.", "So man\u2019s insanity is heaven\u2019s sense": "\ud83d\udc49\ud83d\ude4e\u200d\u2642\ufe0f\ud83e\udd2a\ud83d\udd04\ud83c\udf0c\ud83c\udfaf", "Of such a letter, Death himself might well have been the post-boy.": "\ud83d\udce8\u2620\ufe0f\ud83d\udc66\ud83d\udcee", "Our sail was now set, and, with the still rising wind, we rushed along; the boat going with such madness through the water": "\ud83d\udc65\u26f5\ufe0f\u23e9\ud83d\udd1b, \u2795, \ud83c\udf43\ud83d\udd1d\ud83d\udca8, \ud83c\udfc3\u200d\u2642\ufe0f\ud83d\udca8\ud83d\udca8; \ud83d\udef6\ud83e\udd2a\ud83d\udca8\ud83d\udca6\ud83c\udf0a", "\u2014I come to report a fair wind to him. But how fair? Fair for death and doom": "\"\u27a1\ufe0f\ud83d\udeb6\u200d\u2642\ufe0f\ud83d\udcdd\ud83d\udca8\ud83d\ude0a\ud83d\udc68\u200d\u2696\ufe0f\u21a9\ufe0f\ud83e\udd14\ud83d\udcad\ud83c\udf24\ufe0f? \ud83c\udf24\ufe0f\u2620\ufe0f\ud83d\ude31\"", "Who but a fool would take his left hand by his right, and say to himself, how d\u2019ye do?": "\ud83e\udd37\u200d\u2642\ufe0f\ud83e\udd14\ud83e\udd2a\ud83e\udd1a\ud83d\udc48\ud83d\udc4a\ud83d\udc49\ud83d\udde3\ufe0f\ud83d\udc64\ud83d\udcad\ud83e\udd17\u2753", "his shipmates called him mad": "\ud83d\udc68\u200d\ud83d\udc66\u200d\ud83d\udc66\ud83d\udea2\ud83d\udcde\ud83e\udd2a", "Spain\u2014a great whale stranded on the shores of Europe.": "\ud83c\uddea\ud83c\uddf8\u2796\ud83d\udc0b\ud83d\udc4d\ud83c\udfd6\ufe0f\ud83c\uddea\ud83c\uddfa", "he and the sharks were at times half hidden by the blood-muddled water": "\ud83d\udc68\ud83e\udd88\ud83d\udd70\ufe0f\ud83d\udc65\ud83d\udd2e\ud83e\ude78\ud83d\udca6", "that great mass of death floats on and on, till lost in infinite perspectives": "\ud83d\udc49\ud83d\udfe3\u2728\ud83d\udc80\ud83c\udf0a\u27a1\ufe0f\u27a1\ufe0f\u27a1\ufe0f, \u23ed\ufe0f\ud83d\udc94\ud83c\udd9a\ud83d\udd1a\ud83c\udfa2\ud83c\udf00\ud83d\udd04\ud83d\udd04\ud83d\udd04", "we know the sea to be an everlasting terra incognita": "\ud83d\udc65\ud83e\udde0\ud83c\udf0a\u27a1\ufe0f\ud83d\udd04\ud83c\udf0d\ud83d\udeab\u2753", "the ocean\u2019s invisible flood-tide lifted him higher and higher towards his destined heaven": "\ud83c\udf0a\ud83d\udc7b\ud83c\udf0a\ud83d\udd1d\ud83d\udeb9\ud83c\udd99\ud83c\udd99\u27a1\ufe0f\ud83d\udd2e\u2601\ufe0f\ud83c\udf0c", "In a strait-jacket, he swung to the mad rockings of the gales": "\ud83d\udc64\u27a1\ufe0f\ud83d\udd12\ud83e\udde5, \ud83d\udc64\u25b6\ufe0f\u21aa\ufe0f \ud83c\udf00 \ud83d\udc49\u2195\ufe0f \ud83d\udd2e\ud83c\udf2c\ufe0f", "You shuddered as you gazed": "\ud83d\ude28\ud83d\udc40\ud83d\udc48", "I\u2019ll ten times girdle the unmeasured globe; yea and dive straight through it, but I\u2019ll slay him yet!": "\ud83d\udcac\ud83d\udd1f\u2716\ufe0f \ud83d\udc65\ud83c\udf0d\u2b55; \ud83d\udc4d \ud83c\udfca\u200d\u2642\ufe0f \u2935\ufe0f\u2194\ufe0f,  \u2757\ufe0f \ud83d\udc65\ud83d\udde1\ufe0f\ud83d\udc64\ud83d\udd1c!", "it was my cheerful duty to attend upon him while taking that hard-scrabble scramble upon the dead whale\u2019s back": "\ud83d\ude00\ud83d\udcbc\ud83d\udc48\ud83c\udffe\ud83d\udc81\u200d\u2642\ufe0f\ud83e\udd1d\u231a\ud83d\udd7a\ud83c\udfc3\u200d\u2642\ufe0f\ud83d\udcaa\ud83e\udd75\ud83d\udd1d\ud83d\udc0b\ud83d\udc80\ud83d\udd19", "Avast! How will that help him; jamming that iron-bound bucket on top of his head? Avast, will ye!": "\u2693\ufe0f\u2757\ufe0f\ud83e\udd14\u2753\ud83c\udd98\ud83e\udd37\u200d\u2642\ufe0f\ud83c\udf53\ud83d\udca2\ud83d\udd29\ud83d\udd12\ud83e\udea3\ud83d\udca0\ud83d\udd1d\ud83d\udc64\ud83d\udc68\u200d\ud83e\uddb2\u2753\u2693\ufe0f\ud83e\udd1a\ud83d\udc48\u2757\ufe0f", "nor one single star can revolve, but by some invisible power": "\ud83d\udeab1\ufe0f\u20e3\ud83c\udf1f\u2b50\ufe0f\ud83d\udd04, \u27a1\ufe0f\ud83c\udfaf\ud83d\udd0d\ud83c\udf08\ud83d\udcaa\ud83e\udd32", "the whale would by all hands be considered a noble dish, were there not so much of him": "\ud83d\udc0b\ud83c\udf7d\ufe0f\ud83d\udc4d\ud83d\ude4f\ud83d\udc51\ud83c\udf5b, \ud83d\udeab\ud83d\udc65\ud83e\udd37\u200d\u2642\ufe0f\ud83e\udd14\u2753\ud83d\udccf\ud83d\udcd0\ud83d\udd70\ufe0f\ud83d\udc0b", "straightway upon the ship\u2019s getting out of sight of land, his insanity broke out in a freshet": "\u27a1\ufe0f\ud83d\udea2\ud83d\udc41\ufe0f\ud83c\udf0a\ud83c\udfde\ufe0f, \ud83e\udd2a\ud83d\udca5\ud83c\udd95\ud83d\udd00", "it is one of the more curious things about this Leviathan, that his skeleton gives very little idea of his general shape": "\ud83e\udd14\u27a1\ufe0f1\ufe0f\u20e3\u2753\u2728\ud83d\udd75\ufe0f\u200d\u2642\ufe0f\ud83d\udcda\ud83d\udc0b, \ud83d\udc49\u26b0\ufe0f\ud83e\uddb4\ud83d\udde3\ufe0f\ud83d\udc65\ud83d\udd2c\ud83d\udca1\ud83d\udd0d\ud83d\udccf\ud83d\udd04\ud83d\udc64\ud83d\udca1.", "A vile wind that has no doubt blown ere this through prison corridors and cells, and wards of hospitals, and ventilated them, and now comes": "\ud83d\udc79\ud83d\udca8\ud83d\udeab\u2753\ud83d\udca8\u21a9\ufe0f\ud83d\udd1b\ud83d\udd70\ufe0f\ud83d\udd01\ud83d\ude94\ud83d\udeaa\ud83d\udeaa\ud83d\udc99\u2796\ud83c\udfe5\ud83d\udecf\ufe0f\ud83d\udd01\ud83d\udca8\ud83d\udd04\ud83c\udf2c\ufe0f\ud83d\udd1b\ud83d\udd1c\ud83d\udd1c", "all that cracks the sinews and cakes the brain": "\ud83c\udf0d\u2796\ud83d\udd28\ud83d\udca5\u2733\ufe0f\ud83d\udcaa\ud83d\udd17\ud83c\udf70\ud83e\udde0", "change places": "\ud83d\udd04\ud83d\udccd", "The predestinated day arrived": "\ud83d\udcc6\ud83d\udd2e\ud83d\udc4d\ud83c\udf89", "almost hidden in a discoloured, rolling, and oftentimes tumultuous and bursting sea": "\ud83d\udd75\ufe0f\u200d\u2642\ufe0f\ud83d\udd0e\ud83e\udd0f\ud83c\udf0a\ud83d\udca8\ud83d\udd04\ud83e\udd2f\ud83d\udca6", "The whale, therefore, must see one distinct picture on this side, and another distinct picture on that side; while all between must be profound darkness and nothingness to him.": "\ud83d\udc0b, \u27a1\ufe0f, \ud83d\udd2d\ud83e\ude9e 1\ufe0f\u20e3\ud83d\udcf7\ud83c\udf91\u27a1\ufe0f\ud83d\udc47\ud83d\udcd0, \u2795\ud83d\udc65\ud83d\udcf7\ud83c\udf91\u27a1\ufe0f\ud83d\udd1b\ud83d\udc65\ud83d\udcd0; \ud83c\udf0c\u2b1b\ud83d\udd1b\ud83d\udd1d\ud83c\udf20\ud83d\udd73\ufe0f\ud83d\udeab\ud83d\udd1c\ud83d\udc65.", "placed before the strict and piercing truth, this whole story will fare like that fish, flesh, and fowl idol of the Philistines": "\ud83d\udc49\u27a1\ufe0f\ud83d\udd28\ud83d\ude20\ud83d\udd0d\ud83d\udd06, \ud83d\udcd6\u2696\ufe0f\ud83d\udc20, \ud83e\udd69,\ud83d\udc13\ud83c\udffa\ud83d\ude4f\ud83c\udffc\ud83c\udfdb\ufe0f", "Wet the line! wet the line!": "\ud83d\udca6\ud83c\udfa3! \ud83d\udca6\ud83c\udfa3!", "GRAND CONTESTED ELECTION FOR THE PRESIDENCY OF THE UNITED STATES.": "\ud83c\udf96\ufe0f\ud83c\udfc6\ud83e\udd4a\ud83d\uddf3\ufe0f\ud83d\udc40\ud83d\uddf3\ufe0f\ud83d\udc64\ud83c\uddfa\ud83c\uddf8\ud83c\udfa9\ud83e\udd85\ud83d\udd1d", "when this hell in himself yawned beneath him, a wild cry would be heard through the ship": "\ud83d\udd70\ufe0f\u23ec\ud83d\ude08\ud83d\udd25\ud83d\ude31\ud83d\udc47, \ud83c\udf2a\ufe0f\ud83d\ude31\ud83d\udce3\ud83d\udc42\ud83c\udffb\ud83d\udea2", "Wonderfullest things are ever the unmentionable; deep memories yield no epitaphs": "\ud83c\udf1f\ud83d\udcab\ud83c\udf0d\ud83d\udcac\ud83d\udeab; \ud83d\udd73\ufe0f\ud83d\udd2e\ud83d\udcad\ud83d\udeab\ud83e\udea6", "And still deeper the meaning of that story of Narcissus": "\ud83d\udd0d\ud83d\udd73\ufe0f\u2795\ud83d\udcd6\ud83e\udd14 \ud83d\udd70\ufe0f\u23e9\ud83d\udcda\ud83d\udcad Narcissus\ud83d\udc71\u200d\u2642\ufe0f\ud83d\udca7\ud83c\udf3c", "lines suddenly vibrated in the water, distinctly conducting upwards to them, as by magnetic wires the life and death throbs of the whale": "\u3030\ufe0f\ud83c\udf0a\ud83d\udd00\ud83d\udcc8\u2195\ufe0f\ud83d\udc65\ud83e\uddf2\ud83d\udd0c\ud83e\uddec\ud83d\udc94\ud83d\udc93\ud83d\udc0b", "so better is it to perish in that howling infinite, than be ingloriously dashed upon the lee": "\ud83d\udcab\ud83d\udc4d\ud83c\udd99\ud83c\udfaf\ud83d\udc80\ud83d\udd1b\ud83c\udf2a\ufe0f\ud83d\udd1a, \u2796\ud83d\udc4e\ud83c\udfc1\ud83d\ude48\ud83d\udd28\u2693", "owing to the mystery of the spout\u2014whether it be water or whether it be vapour\u2014no absolute certainty can as yet be arrived at": "\ud83d\udcdd\u27a1\ufe0f\ud83d\udd2e\ud83c\udf00\ud83d\udca6\u2014\ud83e\udd14\ud83d\udca6or\ud83e\udd14\ud83d\udca8\u2014\u274c\ud83d\udcaf\ud83d\udd12\ud83d\udc4d\ud83d\udd70\ufe0f\ud83d\udccd\ud83e\udd37\u200d\u2640\ufe0f\ud83c\udfaf", "the sun is breaking through; the clouds are rolling off\u2014serenest azure is at hand.": "\u2600\ufe0f\ud83d\udca5\ud83d\udc49\ud83c\udf2b\ufe0f\ud83c\udf00\ud83d\udd1a- \u2728\ud83d\udc99\ud83e\udd1d", "Long exile from Christendom and civilization inevitably restores a man to that condition in which God placed him, i.e. what is called savagery.": "\ud83d\udd70\ufe0f\ud83c\udfdd\ufe0f\ud83d\uded0\ud83c\udf0d\ud83c\udf10\u27a1\ufe0f\ud83d\udcaa\ud83d\udd04\ud83d\udc68\u27a1\ufe0f\ud83c\udf31\ud83d\ude4f\ud83c\udf81\ud83d\udccd\ud83d\udeb9, \u27a1\ufe0f\ud83e\udde9\ud83d\udde3\ufe0f\ud83d\udc3e\ud83c\udfde\ufe0f.", "I know not all that may be coming, but be it what it will, I\u2019ll go to it laughing.": "\ud83d\udc41\ufe0f\ud83e\udde0\u274c\ud83d\udd2e\ud83c\udf10, \ud83d\udd2e\ud83c\udf81\u2b05\ufe0f\ud83d\udd1c, \ud83d\ude07\ud83d\udd2e\ud83c\udf81\ud83d\udc4d\u2714\ufe0f, \ud83d\udc41\ufe0f\ud83d\udeb6\u200d\u2642\ufe0f\u27a1\ufe0f\ud83d\ude02.", "Here, then, was this grey-headed, ungodly old man, chasing with curses a Job\u2019s whale round the world, at the head of a crew, too, chiefly made up of mongrel renegades, and castaways, and cannibals": "\ud83d\udc47, \ud83d\udc74, \ud83d\udc7f, \ud83c\udfc3\u200d\u2642\ufe0f\ud83d\uddef\ufe0f\ud83d\udc0b\ud83c\udf0d, \ud83d\udd1d\ud83d\udc65, \ud83c\udf0d\ud83d\udd04, \ud83d\udc65\u2795, \ud83c\udf0d\ud83d\udd00, \ud83d\udea3\u200d\u2642\ufe0f, \u200d\ud83c\udf0a\ud83d\uddd1\ufe0f, \ud83e\udd69\ud83d\udc64.", "But the awful lonesomeness is intolerable.": "\ud83c\udf51\ud83d\udd0d\ud83d\udc4e\ud83d\udc64\ud83d\ude1e\ud83d\udcf5\u26d4\ud83d\ude31", "I\u2019ve known some ships made of dead trees outlast the lives of men made of the most vital stuff of vital fathers.": "\ud83d\udc41\ufe0f\ud83c\udf04\ud83d\udc65\ud83d\udea2\ud83e\udeb5\ud83d\udc80\ud83c\udfb5\ud83d\udccf\ud83c\udfb5\u23f3\ud83d\udc68\ud83d\udc65\ud83c\udf2c\ufe0f\ud83d\udcaa\ud83d\udcab\ud83d\udc68\u200d\ud83d\udc67\u200d\ud83d\udc66\ud83d\udc74\ud83d\udcab\ud83c\udf1f", "the whaling voyage was welcome": "\ud83d\udc0b\u26f5\ufe0f\ud83d\udc4d\ud83e\udd17", "Hast thou seen the White Whale?": "\ud83d\udc40\ud83e\udd14\ud83d\udc48\ud83d\udc0b\u26aa\u2753", "more than suspects that the joke is at nobody\u2019s expense but his own": "\ud83d\udc65\u2795\u27a1\ufe0f\ud83e\udd14\ud83d\udcad\ud83c\udccf\ud83d\ude02\ud83d\udeab\ud83d\udcb8\ud83d\udc65\ud83d\udc94\ud83d\udc49\ud83d\udeb6\u200d\u2642\ufe0f\ud83d\udc94\ud83d\udc48", "\u201cSail ho!\u201d cried a triumphant voice from the main-mast-head.": "\"\u26f5\ufe0f\ud83d\udce2!\" \ud83d\ude2e a \ud83c\udfc6\ud83d\udde3\ufe0f from the \ud83c\udff4\u200d\u2620\ufe0f\ud83d\udd1d.", "Be it known that, waiving all argument, I take the good old fashioned ground that the whale is a fish, and call upon holy Jonah to back me.": "\ud83d\udd08\u270d\ufe0f, \ud83d\ude45\u200d\u2642\ufe0f\ud83d\uddef\ufe0f, \ud83d\udc49\ud83c\udffd\ud83d\udc4d\ud83c\udffc\ud83d\udd70\ufe0f\ud83c\udf3f\ud83d\udcdc\ud83d\udc0b\ud83d\udc20, \ud83d\ude4f\ud83c\udffd\ud83d\uded0\ud83d\udcab\ud83d\udc68\ud83c\udffd\ud83c\udff4\u200d\u2620\ufe0f\u2b05\ufe0f\ud83d\udc4d\ud83c\udffd.", "Out of the bottomless profundities the gigantic tail seems spasmodically snatching at the highest heaven.": "\u2b06\ufe0f\ud83d\udd3d\ud83c\udf00\ud83c\udf0a\ud83d\udc0b\ud83d\ude4c\ud83d\ude35\ud83c\udfde\ufe0f\ud83c\udfd4\ufe0f\u2601\ufe0f\ud83c\udf20\ud83c\udf0c\ud83d\udd1d\ud83d\ude07\u26c5", "Come in thy lowest form of love, and I will kneel and kiss thee": "\ud83d\udeb6\u200d\u2642\ufe0f\u27a1\ufe0f\ud83d\udc47\ud83d\udc97, \u2795\ud83d\udc64\ud83d\uded0\ud83d\udc8b\ud83d\udc48", "I could not help staring at this gallows with a vague misgiving.": "\ud83d\udc41\ufe0f\u274c\ud83c\udd98\ud83d\udc40\u2197\ufe0f\ud83d\uddfc\ud83d\udd31\ud83c\udf2b\ufe0f\ud83d\udcad\ud83e\udd14", "to the surprise of all, the announcement was made": "\ud83d\ude32\ud83d\udc65\ud83d\udce2\ud83d\udcdc\ud83d\udd08", "I have seldom seen such brawn in a man.": "\ud83d\udc41\ufe0f\ud83d\udcaa\ud83d\ude4c\ud83d\ude2f\ud83d\udd0d\ud83d\udc68\u200d\ud83d\udcbc", "let Ahab beware of Ahab; beware of thyself, old man": "\u26a0\ufe0f\ud83c\udd70\ufe0f\ud83d\udeab\ud83d\udc40\u26a0\ufe0f\ud83c\udd70\ufe0f\ud83d\udeab; \u26a0\ufe0f\ud83d\udc40\ud83d\udc74\u26a0\ufe0f", "if on that day I shall again raise him, then, ten times its sum shall be divided among all of ye!": "\ud83d\udd01\u21aa\ufe0f\ud83d\udcc5\ud83d\udc41\ufe0f\ud83d\udd1c\ud83d\ude4c\u2b06\ufe0f\ud83d\udc68\u200d\u2764\ufe0f\u200d\ud83d\udc68,\ud83d\udd1f\u274e\ud83d\udcb0\u2797\ud83d\udc6b\ud83c\udf0d\ud83d\udc48\ud83d\ude4c\u203c\ufe0f", "That is all.": "\ud83d\udc48\u2705\ud83d\udd1a", "don\u2019t be in such a devil of a hurry to sink!": "\ud83d\udeab\ud83c\udfc3\u200d\u2642\ufe0f\ud83d\udca8\ud83d\ude08\u23e9\ud83d\udea2\u2b07\ufe0f!", "all the things that God would have us do are hard for us to do": "\ud83d\udc65\ud83c\udf0d\ud83d\udcda\ud83d\udc40\ud83d\udd10\ud83d\udcaa\u26ea\ufe0f\ud83d\uded0\ud83d\udd1c\ud83c\udfaf\ud83e\udd14\ud83d\udca2", "let it continue hanging there a while till we can get a chance to attend to it": "\ud83d\udc49\ud83d\udd1c\ud83d\udd01\ud83d\udd50\ud83d\uddbc\ufe0f\ud83d\udd1b\ud83d\udd28\u231b\ud83d\udd1c\u23f0\ud83d\udd0e\ud83c\udd70\ufe0f\ud83c\udfb0\ud83e\udd1d\u2795\ud83d\udc65\ud83d\ude4f\ud83d\udc48", "In no living thing are the lines of beauty more exquisitely defined than in the crescentic borders of these flukes.": "\ud83d\udeab\u274c\ud83c\udf31\ud83d\udc90\ud83d\udc3e\ud83d\udc07\ud83e\udd9a\u2600\ufe0f\u2796\ud83d\udcc8\ud83d\udc85\u2728\ud83c\udf08\ud83c\udf80\u2795\ud83c\udf39\ud83d\udc96\ud83d\udca0\u2796\ud83c\udf1c\ud83c\udf19\ud83d\udd3d\u25c0\ufe0f\ud83c\udf3a\ud83d\udc2c\u2b50\ud83c\udf89", "sundry mystifications too tedious to detail": "\ud83c\udf24\ufe0f\ud83d\udd2e\ud83e\udd37\u200d\u2642\ufe0f\ud83d\ude44\ud83d\udcdd\ud83d\udcd1\ud83d\udd0d", "to the last gasp of my earthquake life will dispute its unconditional, unintegral mastery in me": "\ud83d\udd1c\ud83d\udd1a\ud83d\udca8\ud83c\udf0d\u26a1\ud83c\udf8a\ud83d\udc94, \u2705\ud83d\udcac\ud83c\udf10\ud83d\udc4e\u2795\u2b55\ud83c\udfc5\ud83d\udc4d\u26d4\u270d\ud83c\udffb\ud83d\udc68\u200d\ud83e\uddb1", "The devil fetch that harpooneer, thought I": "\ud83d\ude08\ud83d\udd0d\ud83d\udc0b\ud83d\udd31\ud83d\udcad\ud83d\ude42", "Tell me, does the magnetic virtue of the needles of the compasses of all those ships attract them thither?": "\ud83d\udde3\ufe0f\ud83d\udc42, \ud83e\uddf2\ud83d\udcab\ud83d\udccd\ud83e\udded\u26f5\ud83d\udea2\u26f4\ufe0f\ud83c\udfaf\ud83d\udc49?", "The sudden exclamations of the crew must have alarmed the whale": "\ud83d\ude31\ud83d\udcac\u26a1\ufe0f\u26f5\ufe0f\ud83d\udc65\ud83d\udd0a\ud83d\udc0b\ud83d\udc42\u203c\ufe0f\ud83d\udea8", "Lord, think of having half an acre of stomach-ache!": "\ud83d\ude4f, \ud83d\udcad of \ud83c\udf9a\ufe0f half an \ud83e\udeb4 of \ud83e\udd22!", "Bone is rather dusty, sir.": "\ud83d\udc80\u2620\ufe0f\ud83e\uddb4\ud83d\udca8\u2660\ufe0f\ud83c\udf00\u2195\ufe0f\ud83e\uddd1\u200d\ud83d\udcbc\ud83c\udfa9\ud83d\udd74\ufe0f", "you must first get fast to a whale, before any pitchpoling comes into play": "\ud83d\udc49\ud83c\udffe\u23e9\ud83c\udfc3\u200d\u2642\ufe0f\ud83e\udd47\ud83d\udc0b\u23f0\u23f1\ufe0f\ud83d\udd3d\ud83c\udfb3\ud83c\udfae\u2b05\ufe0f\ud83d\udd04", "By heaven, man, we are turned round and round in this world, like yonder windlass, and Fate is the handspike.": "\u2601\ufe0f\ud83d\ude4f, \ud83d\udc68, \ud83d\udd04\ud83d\udd04\ud83c\udf0d, \ud83d\udd04\ud83d\udd27, \ud83d\udcab\ud83d\udc4b\u23f3.", "So fare thee well, poor devil of a Sub-Sub, whose commentator I am.": "\ud83d\udc4b\ud83d\udc4d\ud83d\ude41\ud83d\ude08\ud83d\udc49\u2b07\ufe0f\u2b07\ufe0f, \ud83d\udc64\ud83d\udc48\ud83d\udde3\ufe0f\ud83e\udd47\ud83d\udd75\ufe0f\u200d\u2640\ufe0f\ud83d\ude4b\u200d\u2642\ufe0f.", "the blood imparts to the blood its vivifying principle": "\ud83d\udc89\ud83d\udd04\ud83d\udc89\ud83c\udf31\ud83d\udca1", "no doubt the first man that ever murdered an ox was regarded as a murderer": "\ud83d\udeab\ud83e\udd14\ud83e\udd47\ud83d\udc68\u200d\ud83e\uddb1\ud83d\udd2a\ud83d\udc02\ud83d\udc40\ud83d\udd75\ufe0f\u200d\u2642\ufe0f\ud83d\udd2a\ud83d\udc68\u200d\ud83d\udd2c", "He now has to drop and secure his oar, turn round on his centre half way, seize his harpoon from the crotch, and with what little strength may remain, he essays to pitch it somehow into the whale.": "\ud83d\udc68\u200d\ud83e\uddb1\u27a1\ufe0f\ud83d\udd04\ud83d\udef6\ud83d\udd3d\ud83d\udd10\ud83d\udea3\u200d\u2642\ufe0f, \u21a9\ufe0f\u27a1\ufe0f\ud83d\udd04\ud83c\udfaf\u21a9\ufe0f1/2\ufe0f\u20e3, \ud83e\udd32\ud83c\udfaf\ud83d\udd31\u2b05\ufe0f\ud83c\udf51, \ud83e\udd1d\ud83d\udd0d\ud83d\udcaa\ud83d\udd20\ud83e\udde9, \ud83d\udc68\u200d\ud83e\uddb1\ud83d\udca1\ud83d\udcdd\ud83d\udd3d\ud83d\udc33.", "Now hands are wanted here, and then again hands are wanted there.": "\ud83d\udd52\ud83d\udc4b\ud83d\udc64\ud83d\udccd\ud83d\udd0d, \u2795\ud83d\udd00\ud83d\udd52\ud83d\udc4b\ud83d\udc64\ud83d\udccd\ud83d\udd0d.", "What\u2019s the mighty difference between holding a mast\u2019s lightning-rod in the storm, and standing close by a mast that hasn\u2019t got any": "\u2753\u26a1\ud83d\udcaa\ud83c\udfad\ud83d\udd04\ud83e\udd32\u2693\ud83d\uddfc\ud83c\udf29\ufe0f\ud83c\udf29\ufe0f\ud83d\udd0e, \ud83c\udd9a\ud83d\udd74\ufe0f\ud83d\udc63\ud83d\udeb6\u200d\u2642\ufe0f\ud83d\udd0d\u2693\ud83d\uddfc\ud83d\udeab\ud83c\udf88\ud83e\udd37\u200d\u2642\ufe0f\ud83c\ude1a", "there lay the tomahawk sleeping by the savage\u2019s side, as if it were a hatchet-faced baby": "\ud83d\udc47\ud83d\udecc\u2692\ufe0f\ud83d\ude34\ud83d\udd00\ud83d\udc79\ud83d\udd1b\ud83d\udc65, \u2796\ud83d\udc7c\ud83d\ude20\ud83d\udc76\ud83d\udde1\ufe0f", "I cannot tell, can only hint, the things that darted through me then.": "\u274c\ud83d\udde3\ufe0f, \ud83e\udd37\u200d\u2642\ufe0f\ud83d\udcac\ud83d\udd0e, \u2b05\ufe0f\u27a1\ufe0f\ud83d\udca8\ud83d\udcad\ud83d\udd70\ufe0f.", "every one present must take good heed to dodge it when it swings, else it may box his ears and pitch him headlong overboard": "\ud83d\udc65\u27a1\ufe0f\ud83d\udc40\ud83d\udd0e\ud83c\udfaf\ud83d\udd03\ud83d\udc48, \u274c\u26a0\ufe0f\ud83d\udc4a\ud83d\udc42\ud83d\udce6\ud83d\udd04\u2935\ufe0f\ud83c\udf0a\ud83d\udea2", "and the great shroud of the sea rolled on as it rolled five thousand years ago": "\ud83d\udd00, \ud83c\udf1f\ud83c\udf0a\u26b0\ufe0f \ud83c\udf0a\ud83d\udd04\ud83d\ude80 ,\ud83d\udd04\ud83d\udcab5\ufe0f\u20e30\ufe0f\u20e30\ufe0f\u20e30\ufe0f\u20e3\ud83d\udcc6\ud83d\udd19", "ain\u2019t there too many heads in the world?": "\u274c\ud83d\udc65\ud83c\udf0d\u2795\u2795\u2753", "For this is one of those disheartening instances where truth requires full as much bolstering as error.": "\ud83d\udd0d\ud83d\udc40, \ud83d\udc47\ud83d\udcd61\ufe0f\u20e3\ud83d\udd28\ud83d\udc94\ud83d\udd2c\ud83d\udc65\ud83d\udcda, \ud83d\udcd6\u2696\ufe0f\ud83d\udcaf\ud83c\udfcb\ufe0f\u200d\u2640\ufe0f\ud83d\udd29\ud83d\udd10\ud83d\udd05\ud83d\udca1\ud83d\udca2\ud83c\udfad\u2696\ufe0f\ud83d\udcaf\ud83c\udfcb\ufe0f\u200d\u2640\ufe0f\ud83d\udc94\u2716\ufe0f.", "Will I have eyes at the bottom of the sea, supposing I descend those endless stairs?": "\u2753\ud83d\udc41\ufe0f\ud83c\udf0a\ud83d\udc47\ud83c\udf00\ud83e\udd14\u2b07\ufe0f\ud83d\udd1a\ud83e\udd7e\ud83d\udcad", "Not a chip of the boat was harmed, nor a hair of any oarsman\u2019s head; but the mate for ever sank.": "\ud83d\udeab\ud83c\udf5f\ud83d\udea2\ud83d\udc1a\u274c, \ud83d\udeab\ud83d\udc87\u200d\u2642\ufe0f\ud83d\udea3\u200d\u2642\ufe0f\ud83d\udc64\ud83d\udc86\u200d\u2642\ufe0f; \ud83d\ude14\ud83d\udc65\u23ed\ufe0f\ud83d\udd3d\ud83c\udf0a.", "It is not down in any map; true places never are.": "\u274c\u2b07\ufe0f\ud83c\udf10\ud83d\udccd\ud83d\uddfa\ufe0f; \ud83c\udfde\ufe0f\ud83d\udd0e\u27a1\ufe0f\ud83d\udd1d\ud83d\udcaf.", "Reality outran apprehension; Captain Ahab stood upon his quarter-deck.": "\ud83c\udf10\ud83c\udfc3\u200d\u2642\ufe0f\ud83d\udc40; \ud83d\udc68\u200d\u2708\ufe0f Ahab \ud83d\udd74\ufe0f\ud83e\ude9c\ud83d\udef3\ufe0f\ud83c\udccf\ud83e\ude91.", "and thus stabs us from behind with the thought of annihilation": "\u2795\u27a1\ufe0f\ud83d\udd2a\ud83d\udc65\ud83d\udd19\ud83d\udcad\ud83d\udca5\ud83d\udeab\ud83d\udcad", "on that shivering winter\u2019s night, the Pequod thrust her vindictive bows into the cold malicious waves": "\ud83d\udd1b\u2744\ufe0f\ud83c\udf2c\ufe0f\ud83c\udf03, \u26f5\ufe0fPequod\ud83d\udde1\ufe0f\ud83d\ude20\ud83c\udff9\u27a1\ufe0f\ud83e\udd76\ud83c\udf0a\ud83d\udc7f", "Oh! many are the Fin-Backs, and many are the Dericks, my friend.": "\ud83d\ude2e! \ud83c\udf0a\ud83d\udc0b\ud83d\udc0b\ud83d\udc0b, \ud83d\udd28\ud83d\udd28\ud83d\udd28, \ud83d\udc65\ud83d\udc6b\ud83d\udc6c!", "This whole book is but a draught\u2014nay, but the draught of a draught. Oh, Time, Strength, Cash, and Patience!": "\ud83d\udcda\u27a1\ufe0f\ud83c\udf7a, \u274c, \ud83c\udf7a\ud83c\udf7a. \u23f0\ud83d\udcaa\ud83d\udcb0\ud83d\ude07!", "Loftiest trucks were made for wildest winds, and this brain-truck of mine now sails amid the cloud-scud.": "\ud83d\uddfb\ud83d\ude9a\ud83d\udd28\ud83e\udd47\ud83c\udf2c\ufe0f\ud83c\udf00, \u2795\ud83e\udde0\ud83d\ude9a\ud83d\udc64\ud83d\udd57\u26f5\ud83d\udd79\ufe0f\u2601\ufe0f\ud83c\udf2b\ufe0f.", "the monster horribly wallowed in his blood, overwrapped himself in impenetrable, mad, boiling spray": "\ud83d\udc79\ud83d\ude31\ud83d\udec0\ud83d\udc89, \u27b0\ud83d\udc64\ud83d\udd10\ud83d\udd12\ud83c\udf00\ud83e\udd2a\ud83c\udf0a\ud83d\udd25\ud83d\udca6", "half-articulated wailings of the ghosts of all Herod\u2019s murdered Innocents": "\ud83d\udd70\ufe0f\ud83d\udde3\ufe0f\ud83d\udc7b\ud83d\udc76\ud83d\udde1\ufe0f\ud83e\udd34\ud83c\udffb\ud83d\udd2a\ud83c\udfad\ud83d\udd4a\ufe0f", "I wonder what the old man wants with this lump of foul lard": "\ud83e\udd14\u2753\ud83d\udc74\ud83c\udffb\ud83e\udd37\u200d\u2640\ufe0f\ud83d\udd04\ud83d\udc49\ud83d\ude4c\ud83e\uddc8\ud83d\udca9", "Wet, drenched through, and shivering cold, despairing of ship or boat, we lifted up our eyes as the dawn came on.": "\ud83d\udca6,\ud83d\ude13\ud83d\udca7, and \ud83e\udd76\u2744\ufe0f, \ud83d\ude1e of \ud83d\udea2 or \ud83d\udea3\u200d\u2642\ufe0f, we \ud83d\udc40\ud83c\udd99 as the \ud83c\udf05 arrived.", "Whales are scarce as hen\u2019s teeth whenever thou art up here.": "\ud83d\udc0b\u27a1\ufe0f\ud83d\udd0d\ud83d\udc13\ud83e\uddb7\ud83d\udd51\ud83d\udc64\ud83d\udc46\ud83d\udccd\ud83c\udf01", "Look ye, for yourselves, if Ahab be not lord of the level loadstone! The sun is East, and that compass swears it!": "\ud83d\udc40\ud83d\udc65, \ud83d\udc49\ud83d\udc65, \ud83e\uddd0 Ahab \u27a1\ufe0f\ud83d\udc51 \u2696\ufe0f\ud83e\uddf2! \u2600\ufe0f\u27a1\ufe0f\ud83e\udded, \ud83e\udd1e\ud83e\udded\ud83e\udd2c\ud83d\udc4f!", "all these things, I say, had awakened much interest and curiosity at the time": "\ud83d\udc40\ud83d\udc47\ud83d\udc68\u200d\ud83d\udc69\u200d\ud83d\udc67\u200d\ud83d\udc66\ud83d\udd2c\ud83d\udc42\ud83d\uddd3\ufe0f, \ud83d\udc41\ufe0f\ud83d\udde3\ufe0f, \ud83c\udf05\ud83d\udcc8\ud83d\udd0d\ud83e\udde0\ud83d\udca1\u23f3", "What I\u2019ve dared, I\u2019ve willed; and what I\u2019ve willed, I\u2019ll do!": "\u2753\ud83d\udcad\ud83c\udfc3\u200d\u2642\ufe0f, \ud83c\udfc3\u200d\u2642\ufe0f\ud83d\udcaa; \u2795\ud83d\udcad\ud83c\udfc3\u200d\u2642\ufe0f\ud83d\udcaa, \ud83d\ude4b\u200d\u2642\ufe0f\ud83d\udd1c\ud83d\udcbc!", "man, though idiotic, and knowing not what he does, yet full of the sweet things of love and gratitude": "\ud83d\udc68\u200d\ud83e\uddb3,\ud83c\udfad,\u274c\ud83d\udca1\ud83e\udd14,\ud83d\udd04, \ud83d\ude0d\ud83c\udf6b\ud83c\udf6c \u2764\ufe0f\ud83d\ude4f\ud83d\udc8c", "Who would think, then, that such fine ladies and gentlemen should regale themselves with an essence found in the inglorious bowels of a sick whale!": "\u2753\ud83e\udd14\ud83d\udcad, \ud83d\udd70\ufe0f, \ud83d\udc69\u200d\ud83e\uddb0\ud83d\udc85\u2728\ud83d\udc68\u200d\ud83e\uddb3\ud83c\udfa9\ud83c\udf79\ud83c\udf89\ud83d\udc44\ud83c\udf76\ud83d\udcab\ud83d\udc96\ud83d\udc33\ud83e\udd22\u2693\ufe0f\u2757", "The whale was now going head out, and sending his spout before him in a continual tormented jet": "\ud83d\udc0b \u27a1\ufe0f \ud83d\udd04 \ud83d\uddfa\ufe0f \ud83d\ude80, \u2795 \ud83d\udce4 \ud83d\udca6\ud83d\udca8 \ud83d\udc49\ud83c\udffb \ud83d\ude4b\u200d\u2642\ufe0f \u27a1\ufe0f \ud83d\udcab\ud83d\ude80\u23f3\ud83d\udee0\ufe0f\ud83d\udca6\ud83d\udebf", "previous to that connexion, the short-warp goes through sundry mystifications too tedious to detail": "\u21a9\ufe0f\ud83d\udd17,\u23ee\ud83d\udd00 \ud83d\udef8\ud83d\udd2e\ud83d\udc7b\ud83d\uded1\ud83d\udcd1\ud83d\udcab\ud83d\uddc2\ufe0f", "I cannot tell why it was exactly": "\u274c\ud83d\udde3\ufe0f\ud83e\udd37\u200d\u2640\ufe0f\ud83d\udd0e\ud83d\udcad\ud83e\udd14\ud83d\udcac\ud83d\udc48", "The burning ship drove on, as if remorselessly commissioned to some vengeful deed.": "\ud83d\udd25\ud83d\udea2\ud83d\ude80\u23e9, \ud83e\udd14\ud83d\udcad\ud83e\udd37\u200d\u2642\ufe0f\ud83d\udeab\ud83d\uded1\ud83d\udc94, \ud83d\udcdc\u270d\ufe0f\ud83d\udc49\ud83c\udd70\ufe0f\ud83d\ude45\u200d\u2642\ufe0f\ud83d\ude21\ud83d\udcbc\ud83d\udd79\ufe0f.", "these were the strong, troubled, murderous thinkings of the masculine sea": "\ud83d\udc49\ud83d\udcaa\ud83d\ude1f\ud83d\udde1\ufe0f\ud83d\udcad\ud83d\udd25\ud83c\udf0a\u2642\ufe0f\u23ea", "ye gods!": "\ud83d\ude31\ud83d\ude4c\ud83d\uded0", "that famous lexicographer\u2019s uncommon personal bulk more fitted him to compile a lexicon to be used by a whale author like me": "\ud83d\udc49\ud83c\udf1f\ud83d\udcd6\ud83d\udd0d\ud83d\udd74\ufe0f\ud83c\udf1f\ud83d\udcbc\ud83c\udf54\ud83c\udf54\ud83c\udf54\ud83c\udf54\ud83c\udf54\ud83d\udcaa\u2935\ufe0f\ud83d\udc64\ud83d\udee0\ufe0f\ud83d\udcd8\ud83d\udcd9\ud83c\udffa\ud83d\udc0b\u270d\ufe0f\ud83d\udc68\u200d\ud83c\udfa8\ud83d\udc4d\ud83d\udc64", "never mind if they lie side by side and touch each other": "\ud83d\udeab\ud83d\udcad\ud83e\udd37\u200d\u2642\ufe0f\ud83e\udd25\ud83d\udecf\ufe0f\ud83e\udd1d\ud83d\udc6b", "the spine of even the hugest of living things tapers off at last into simple child\u2019s play": "\ud83e\uddb4\u27a1\ufe0f\ud83d\udcaa\ud83d\udc0b\ud83e\udd95\ud83e\udd8d\u27a1\ufe0f\ud83d\udd1a\u2198\ufe0f\ud83d\udfe2\ud83e\uddd2\ud83c\udfae\ud83e\udd39\u200d\u2642\ufe0f", "a man who rides a horse is called a horseman": "\ud83d\udc68\ud83c\udffc\u27a1\ufe0f\ud83c\udfc7\ud83c\udffc\u27a1\ufe0f\ud83d\udcde\ud83d\udc34\ud83d\udc68\ud83c\udffc\u200d\ud83c\udf3e", "Yea, foolish mortals, Noah\u2019s flood is not yet subsided; two thirds of the fair world it yet covers.": "\ud83d\udc4d, \ud83d\udc80\ud83e\uddcd\u200d\u2642\ufe0f\ud83e\uddcd\u200d\u2640\ufe0f, \ud83d\udea2\ud83c\udf27\ufe0f\ud83c\udf0a(Noah's flood) \ud83d\udeab\u274c\u23ed\ufe0f; 2\ufe0f\u20e3/3\ufe0f\u20e3\ud83c\udf0e\ud83c\udf0d\ud83c\udf0f (fair world) \ud83c\udf0a\ud83d\udd04\ud83d\udd2e.", "What things real are there, but imponderable thoughts?": "\u2753\ud83d\udcad\ud83d\udca1\ud83c\udf10\ud83d\udc49, \u27a1\ufe0f\ud83d\udca1\u2696\ufe0f\ud83d\udcad\u2753", "do you not find a strange analogy to something in yourself?": "\u2753\ud83d\udc64\u274c\ud83d\udd0d\ud83e\udde9\ud83d\udc65\ud83e\udd14\ud83d\udd04\u2696\ufe0f\u2753", "down in the whirling heart of such a masterless commotion that he scarce heeds the moment when he drops seething into the yawning jaws": "\u2b07\ufe0f\u27a1\ufe0f\ud83c\udf00\u2764\ufe0f\ud83d\udc65\ud83d\udcab\ud83c\udfad\ud83d\udeab\ud83d\udc82\u200d\u2642\ufe0f\ud83d\ude48\ud83d\udd52\u23f3\ud83d\udd79\ufe0f\ud83c\udf0a\u27a1\ufe0f\ud83d\udd25\ud83d\udc44\ud83d\udd73\ufe0f", "Toes are scarce among veteran blubber-room men.": "\ud83d\udc63 \ud83d\udcc9 \ud83d\udd74\ufe0f\ud83d\udc74\ud83d\udcbc\ud83e\uddd1\ud83d\udeb9, \ud83d\udc0b\ud83c\udfe0 \u2642\ufe0f", "One and all, they were harpooned and dragged up hither from the bottom of the sea.": "1\ufe0f\u20e3\u2795\ud83d\udc65, \ud83d\udc65\ud83d\udd31\u2795\ud83d\udd1d\u2b06\ufe0f\ud83d\udccd\ud83c\udf0a\u2b07\ufe0f\ud83d\udd1a.", "there reigned, too, a sense of peculiar dread at this flitting apparition, as if it were treacherously beckoning us on and on, in order that the monster might turn round upon us, and rend us at last in the remotest and most savage seas": "\ud83d\udc51\ud83d\udd2e\ud83d\ude31\ud83d\udca8\ud83d\udc7b, \ud83e\udd14\ud83d\udcad\ud83c\udfad \ud83c\udff3\ufe0f\ud83d\udc65\ud83d\udc49\ud83d\udc49, \ud83d\udc32\ud83d\udd04\ud83d\udc65, \ud83d\udca5\ud83d\udc65\u23ed\ufe0f\ud83c\udf0a\ud83c\udf0a\ud83c\udfde\ufe0f\ud83c\udfde\ufe0f\u27a1\ufe0f\ud83c\udf0e.", "move your foot or hand an inch; slip your hold at all; and your identity comes back in horror": "\ud83d\udc49\ud83d\udc63\ud83e\udd1a\u2194\ufe0f1\ufe0f\u20e3\ud83d\udccf; \ud83d\udc4b\ud83d\uded1\ud83d\udcaa\ud83d\udcbc\ud83d\udd1b; \ud83d\ude31\ud83d\udd19\u3030\ufe0f\ud83c\udd94\ud83d\udd1c", "In thought, a fine human brow is like the East when troubled with the morning.": "\ud83d\udcad, \ud83d\udc4c\ud83e\uddd1\ud83e\udd14\ud83d\udca1\u27a1\ufe0f\ud83d\udc4d\u2600\ufe0f\ud83c\udf04\ud83d\udd00\ud83d\ude1f\u2600\ufe0f\ud83c\udf1e\ud83c\udf05", "though thou launchest navies of full-freighted worlds, there\u2019s that in here that still remains indifferent": "\ud83e\udd14\ud83d\udcad\u26f5\u26d3\ufe0f\ud83c\udf10\ud83c\udf10\ud83c\udf10\ud83d\udef3\ufe0f,\ud83d\udca1\ud83d\udd1b\ud83d\udd12\ud83e\udd37\u200d\u2642\ufe0f\ud83c\udfde\ufe0f\ud83d\udd1b\ud83d\udeb6\u2795\u2744\ufe0f\ud83d\udd1b\ud83d\udd04", "through numberless perils to the very point whence we started, where those that we left behind secure, were all the time before us": "\ud83d\udd04\ud83d\udd22\u26a0\ufe0f\u2b06\ufe0f\ud83d\udccd\ud83d\udccd\u21aa\ufe0f\ud83d\udeb6\u200d\u2642\ufe0f\ud83d\udeb6\u200d\u2640\ufe0f\ud83d\udc65\ud83d\udd19\ud83d\udd10\ud83d\udd52\ud83d\udd1b\ud83d\udd1d\ud83d\udc40\ud83d\udc48", "Why is almost every robust healthy boy with a robust healthy soul in him, at some time or other crazy to go to sea?": "\u2753\ud83e\udd37\u200d\u2642\ufe0f\ud83d\udd70\ufe0f\ud83d\udc66\ud83c\udf33\ud83d\udcaa\ud83d\ude07\ud83d\udcaa\ud83d\udd04\ud83e\udd2a\ud83c\udf0a\ud83d\udea2\ud83e\udd14\u2753", "Look your last, now": "\ud83d\udc40\ud83d\udc49\ud83d\udd1a\ud83d\udd50, \u23f1\ufe0f", "the Leviathan that but few supposed to be at this particular time lurking anywhere near": "\ud83d\udc09\ud83d\udd2e\ud83d\udc65\u21a9\ufe0f\ud83d\udd70\ufe0f\ud83d\udd75\ufe0f\u23ed\ufe0f\ud83d\udc40\ud83d\udccd", "You would have thought we were offering up ten thousand red oxen to the sea gods.": "\ud83d\udc49\ud83e\udd14\ud83d\udcad\ud83d\udc65\ud83d\udc48\ud83d\udcca\ud83c\udd99\ud83d\udd1fK\ud83d\udd34\ud83d\udc02\ud83c\udf0a\ud83d\uded0\ud83c\udf0a\ud83d\udc7c", "Well, sir, I want to see what whaling is. I want to see the world.": "\ud83d\udc4c,\ud83e\udd35, \ud83d\ude4b\u200d\u2642\ufe0f\ud83d\udc40\ud83d\udc33\ud83d\udd0e. \ud83d\ude4b\u200d\u2642\ufe0f\ud83d\udc40\ud83c\udf0d.", "this mere painstaking burrower and grub-worm of a poor devil of a Sub-Sub": "\ud83d\udc49\u26cf\ud83d\udd73\ufe0f\ud83d\udc1b\ud83d\ude08\ud83d\udd17\ud83d\udd0d\ud83d\udd0d\ud83d\udc7f\ud83d\udc47\ud83d\udc47", "accept the first hint of the hitching tiller; believe not the artificial fire, when its redness makes all things look ghastly": "\ud83d\udc4d\ud83e\udd47\ud83d\udca1\u2693\ud83d\ude9c; \ud83d\ude45\u200d\u2640\ufe0f\ud83d\udd2e\ud83d\udd25, \ud83d\udd25\ud83d\udd34\ud83d\udc40\ud83d\udc7b\ud83d\udc80", "What then remained?": "\u2753\u27a1\ufe0f\ud83d\udd1c\ud83d\udd19\u2753", "To sailors, oaths are household words; they will swear in the trance of the calm, and in the teeth of the tempest": "\u26f5\ufe0f\ud83d\udc68\u200d\ud83d\ude80\ufe0f, \ud83e\udd1e\ud83e\udd2c\ud83c\udfe0\ud83d\udde3\ufe0f; \ud83e\udd1e\ud83e\udd2c\ud83d\udfe2\u270c\ufe0f\ud83d\ude0c, \ud83c\udf2c\ufe0f\ud83e\uddb7\ufe0f \u26c8\ufe0f\u270c\ufe0f\ud83d\ude21", "what\u2019s made in fire must properly belong to fire; and so hell\u2019s probable.": "\u2753\ud83c\udfed\ud83d\udd25\u2696\ufe0f\ud83e\udd1d\ud83d\udd25; \u23e9\ud83d\udd25\ud83d\udc79\ud83d\udd2e\ud83e\udd37\u200d\u2642\ufe0f", "Upon the opening of that fatal cork, forth flew the fiend, and shrivelled up his home.": "\ud83d\udd1b\ud83d\udd13\ud83c\udf7e, \ud83d\udc79\ud83d\udca8\ud83d\ude80, \ud83c\udfda\ufe0f\ud83d\udd25\ud83d\udcc9.", "suddenly going down in a maelstrom, within three rods of the planks, he wholly disappeared from view": "\ud83d\ude31\u2935\ufe0f\ud83c\udf00, \ud83d\udccf\ud83d\udccf\ud83d\udccf\ud83d\udc49\ud83e\udeb5, \ud83d\ude48\u2b1b\ud83d\udc40", "to and fro in the deeps, far down in the bottomless blue, rushed mighty leviathans, sword-fish, and sharks": "\u2194\ufe0f\ud83d\udd3d\ud83c\udf0a, \u2b07\ufe0f\u2b07\ufe0f\ud83d\udd35\ud83d\udd73\ufe0f, \ud83c\udfc3\u200d\u2642\ufe0f\ud83d\udcaa\ud83d\udc0b, \ud83d\udde1\ufe0f\ud83d\udc20, \ud83e\udd88", "life for the most part was a telling pantomime of action, and not a tame chapter of sounds": "\ud83c\udf0d\u27a1\ufe0f\ud83d\udd1d\u23f3\ud83c\udfad\ud83c\udfac, \ud83d\udeab\ud83d\udc22\ud83d\udd0a\ud83d\udcda", "when you come to sit down before a meat-pie nearly one hundred feet long, it takes away your appetite": "\ud83d\udd52\ud83d\udc49\ud83d\udeb6\u200d\u2642\ufe0f\ud83d\udc48\ud83d\udcba\u2935\ufe0f\ud83e\udd67\ud83c\udf56\ud83d\udd1b\ud83d\udcaf\ud83d\udc63\ud83d\udccf, \ud83d\ude2e\ud83d\udeab\ud83c\udf74\ud83e\udd22", "pull down and pulverize that subaltern\u2019s tower, and make a little heap of dust of it": "\ud83d\udc47\u2b07\ufe0f\ud83d\udcaa\ud83c\udff0\ud83d\udd28\u203c\ufe0f\ud83d\udd1c\ud83d\udc48\ud83d\udd3d\ud83d\uddfc, \u2795\ud83d\udcab\ud83d\udd28\ud83d\udd28\u27a1\ufe0f\ud83c\udf87\ud83c\udfdc\ufe0f\ud83d\udd1c\u23e9\ud83d\udd1d\ud83d\udc48\u267b\ufe0f", "this whale carries the everlasting mail!": "\ud83d\udc0b\u27a1\ufe0f\ud83d\udce8\u23f3\ud83d\udc8c", "Thou art as unprincipled as the gods, and as much of a jack-of-all-trades.": "\ud83d\udc49\ud83c\udfad\ud83c\udfdb\ufe0f\ud83d\udeab\ud83d\udc96\ud83d\udc66, \ud83d\udca1\ud83d\udd00\ud83c\udccf\ud83c\udfad\ud83c\udf10\ud83d\udc68\u200d\ud83d\udd27\ud83d\udc66.", "he sent him below for his ivory stool, and also his pipe.": "\ud83d\udc68\u200d\ud83d\udcbc\u27a1\ufe0f\ud83d\udc47\ud83d\udeb6\u200d\u2642\ufe0f\ud83d\udd0d\ud83d\udc18\ud83d\udcba, \ud83d\udd00\ud83d\udd0d\ud83d\udeac", "Virtue, if a pauper, is stopped at all frontiers.": "\ud83c\udf96\ufe0f, if \ud83d\udc68\u200d\ud83c\udf3e, is \ud83d\udeab at all \ud83d\uddfa\ufe0f\ud83d\udea7.", "We must now retrace our way a little.": "\ud83d\udc65\ud83d\udd19\ud83d\udd1c\ud83d\udd04\ud83d\udc63\u21a9\ufe0f\ud83d\udee3\ufe0f\ud83d\udd0d\ud83d\udd70\ufe0f", "Like desperadoes they tugged and they strained, till the welcome cry was heard": "\ud83d\udc4d\ud83e\udd20\ud83e\uddd1\u200d\ud83e\udd1d\u200d\ud83e\uddd1\ud83e\udd0f\ud83c\udfcb\ufe0f\u200d\u2640\ufe0f\ud83d\udca6, \u23f3\ud83d\udce3\ud83d\udc42\ud83c\udf8a\ud83d\udd0a", "boggy, soggy, squitchy picture truly, enough to drive a nervous man distracted": "\ud83c\udf2b\ufe0f\ud83c\udf27\ufe0f\ud83d\udca7\ud83d\uddbc\ufe0f\ud83d\ude33\ud83d\udcaf\ud83d\ude98\ud83e\udde0\ud83d\ude35\u200d\ud83d\udcab\u2668\ufe0f", "Circumambulate the city of a dreamy Sabbath afternoon.": "\ud83d\udd04\ud83c\udf03\ud83d\udcad\ud83d\udca4\ud83d\udd70\ufe0f\ud83c\udf1e", "There was an infinity of firmest fortitude, a determinate, unsurrenderable wilfulness, in the fixed and fearless, forward dedication of that glance.": "\ud83d\udd2e\u21aa\ufe0f\ud83c\udf0c\ud83d\udcaa\ud83c\udffc\ud83d\udcaa\ud83c\udffc, \ud83d\udd0d\ud83d\udcaf, \ud83d\udeab\ud83d\udd01\ud83d\udcaa\ud83c\udffc\ud83d\udcbc, \ud83d\udd12\ud83d\ude0f\ud83d\udc4a\ud83d\udd1b\ud83d\udc49, \ud83d\udc41\ufe0f\u200d\ud83d\udde8\ufe0f\ud83d\udcab\ud83d\udc4a\ud83d\udd04.", "this leviathan seems the banished and unconquerable Cain of his race": "\ud83d\udc0b\ud83d\ude31\ud83d\udeab\ud83d\udd13\ud83d\udc64\ud83d\udd31\ud83c\udfc1\ud83d\udeab\ud83d\udea9\ud83d\udeb6\u200d\u2642\ufe0f\ud83d\udd31\ud83c\udfc1", "The dark ocean and swelling waters were nothing": "\ud83c\udf11\ud83c\udf0a\ud83d\udca6\ud83d\udeab\ud83d\udd1b\ud83d\udc81\u200d\u2642\ufe0f\ud83d\udd1a", "the skeleton of the whale furnishes but little clue to the shape of his fully invested body": "\ud83d\udc80\ud83d\udc0b\ud83d\udee0\ufe0f\ud83d\udd0d\ud83d\udd0e\u27a1\ufe0f\ud83d\udd0d\ud83d\udd0e\ud83d\udc65\ud83d\udd04\ud83d\udca1\ud83d\udd0d\ud83d\udd0e\ud83d\udfe5\ud83d\udcaa\ud83d\udd0d\ud83d\udd0e\ud83d\udcbc\ud83d\udc54\ud83d\udc56\ud83d\udc0b", "thy spirit ebbs away to whence it came": "\ud83d\udc49\ud83d\udc7b\u23ee\ufe0f\ud83d\udd19\ud83d\udc49\ud83c\udfde\ufe0f\ud83d\udc48", "Nothing was done, and nothing seemed capable of being done": "\u274c\ud83d\udeab\ud83d\udd28\u2705, \u274c\ud83d\udeab\ud83d\udcaa\ud83d\udca1\ud83d\udd28\u2705", "All your oaths to hunt the White Whale are as binding as mine": "\ud83d\udc68\u200d\ud83d\udc69\u200d\ud83d\udc67\u200d\ud83d\udc66\ud83e\udd1d\ud83c\udff9\ud83d\udc0b\u26aa\ud83d\udd17\u2795\ud83d\udd12\ud83d\udc81\u200d\u2642\ufe0f\ud83e\udd1d", "far over from the deep green convent valleys of the Manilla isles, the Spanish land-breeze, wantonly turned sailor, had gone to sea": "\ud83d\udd2d\ud83d\udccf\u27a1\ufe0f\ud83c\udfde\ufe0f\ud83c\udf33\ud83c\udf34\ud83d\udd4d\u27a1\ufe0f\ud83c\uddf5\ud83c\udded, \ud83c\uddea\ud83c\uddf8\ud83c\udf2c\ufe0f\ud83d\udd04\ud83d\udc68\u200d\u2708\ufe0f, \ud83c\udff4\u200d\u2620\ufe0f\ud83d\udef3\ufe0f\ud83c\udf0a\ud83c\udf0d", "what all this gibberish of yours is about, I don\u2019t know, and I don\u2019t much care": "\u2753\ud83e\udd37\u200d\u2640\ufe0f\ud83e\uddd0\ud83d\udcdd\ud83d\udcac\u2049\ufe0f\ud83d\udc48\ud83d\ude15\u2753, \ud83d\ude45\u200d\u2640\ufe0f\ud83e\udd37\u200d\u2640\ufe0f\ud83e\udde0\u2753, \ud83d\udc4e\ud83e\udd37\u200d\u2640\ufe0f\ud83d\udc81\u200d\u2640\ufe0f\ud83e\udd37\u200d\u2642\ufe0f\ud83d\udca4\ud83e\udd37\u200d\u2642\ufe0f.", "every true whaleman sleeps with his harpoon": "\ud83c\udf10\u2714\ufe0f\ud83d\udc0b\ud83d\udc68\u200d\ud83d\udd27\ud83d\udca4\ud83d\udecc\ud83d\udd31", "God keep me from ever completing anything.": "\ud83d\ude4f\ud83d\ude4c\ud83d\udeab\ud83d\uded1\u26d4\ud83c\udfaf\ud83d\udd1a\ud83d\udcaf\ud83d\ude45\u200d\u2642\ufe0f\ud83d\udd04\ud83d\udcac\ud83d\udcdd\u2705", "Moby Dick seemed combinedly possessed by all the angels that fell from heaven.": "\ud83d\udc33 Moby Dick \u26d3\ufe0f\ud83d\udc65\ud83d\udcab\u2601\ufe0f\ud83d\ude07\ud83d\udd3d\ud83d\udd00\ud83c\udf0c\ud83d\udc79\ud83c\udff0\ud83d\ude4f\ud83d\udc40\ud83d\udc49\ud83d\udd25\ud83d\udc7c", "Such is the subtle elasticity of the organ I treat of, that whether wielded in sport, or in earnest, or in anger, whatever be the mood it be in, its flexions are invariably marked by exceeding grace.": "\ud83d\udc49\ud83d\udd0d\ud83c\udf3a\ud83d\udd2c\ud83c\udfaf\ud83e\udd4f\ud83e\udde0, \ud83d\udc48\u2696\ufe0f\ud83d\ude39\ud83e\udd39, \ud83d\udcbc\ud83d\udcbc, \ud83d\ude21, \ud83d\udd1d\ud83d\udc9e\ud83c\udfad, \ud83d\udc48\ud83d\udc4b\ud83d\udc83\ud83d\udc40\u2714\ufe0f\ud83c\udf3a\ud83c\udf39\ud83c\udf8a\ud83c\udf89.", "It does seem to me, that herein we see the rare virtue of a strong individual vitality": "\ud83e\udd14\ud83d\udca1\ud83d\udc40\ud83d\udc49, \ud83c\udf0d\ud83d\udc97\ud83d\udd75\ufe0f\u200d\u2642\ufe0f\ud83d\udd2e\ud83c\udf1f\ud83c\udf37\u26a1\ud83d\udcaa\ud83c\udf10\ud83d\udcbc\ud83d\udd7a\ud83d\udcab\ud83d\udcaf", "pay attention": "\ud83d\udcb0\ud83d\udc40", "Death and devils! men, it is Moby Dick ye have seen\u2014Moby Dick\u2014Moby Dick!": "\ud83d\udc80\ud83d\ude08! \ud83d\udc68\u200d\ud83d\udc68\u200d\ud83d\udc66\u200d\ud83d\udc66, \ud83d\udc0b Moby Dick \ud83d\udc40\ud83d\udc65- Moby Dick- Moby Dick!", "I account it high time to get to sea as soon as I can.": "\ud83d\udcdd\ud83d\udcbc\ud83d\udd70\ufe0f\u2b06\ufe0f\ud83d\udd52\ud83c\udf0a\ud83d\ude80\ud83d\udd1c\u23e9\ud83d\udc4d\ud83d\udca8", "the harpooneers of this world must start to their feet from out of idleness, and not from out of toil": "\ud83c\udf10\ud83d\udd31\ud83d\udd74\ufe0f\ud83d\udeb6\u200d\u2642\ufe0f\ud83c\udd99\ud83d\udca4\ud83d\udeab\ud83d\udcbc", "Frighted Jonah trembles, and summoning all his boldness to his face, only looks so much the more a coward.": "\ud83d\ude31 Jonah \ud83d\ude28, and \ud83d\udcde all his \ud83d\udcaa to his \ud83c\udfad, only looks \ud83d\udc40 so much the more \ud83d\udc13.", "As for the men, though some of them lowly rumbled, their fear of Ahab was greater than their fear of Fate.": "\ud83d\udc65\ud83d\udc64\ud83d\udc64\u27a1\ufe0f, \ud83d\ude4d\u200d\u2642\ufe0f\ud83d\ude4d\u200d\u2642\ufe0f\u2b07\ufe0f\ud83d\udde3\ufe0f\u26a1, \ud83d\udc68\u200d\ud83d\udc68\u200d\ud83d\udc66\u200d\ud83d\udc66\ud83d\udc53\ud83d\ude28\ud83d\udc33\ud83c\udfa9\ud83d\udd1d\ud83d\udc40\ud83d\ude28\ud83d\udd2e\ud83d\udd01.", "exceeding slipperiness": "\ud83d\udcc8\ud83e\uddfc\ud83d\udc63", "I will wreak that hate upon him.": "\ud83d\udc41\ufe0f\ud83d\udc49\ud83d\udca5\ud83d\udd28\ud83d\ude21\ud83d\udd1b\ud83d\udc68", "But here I\u2019ll stay, though this stern strikes rocks; and they bulge through; and oysters come to join me.": "\ud83c\udf51\ud83d\udccd\ud83d\udc47\ud83c\udffd\ud83d\uded1\ud83d\udc81\u200d\u2642\ufe0f, \u21a9\ufe0f\ud83d\udc47\ud83d\udc4a\u26f0\ufe0f; \u2795\ud83d\udc65\ud83d\udcaa\ud83d\udcab; \u2795\ud83d\udc1a\ud83d\udeb6\u200d\u2642\ufe0f\ud83d\udd04\ud83e\udd1d\ud83d\udc65.", "Oh! spite of million villains, this makes me a bigot in the fadeless fidelity of man!": "\ud83d\ude2e! \ud83d\udc4e\ud83d\udc4e\ud83d\udc4e\ud83d\udc4e\ud83d\udc4e\ud83d\udcb0\ud83d\udcb0\ud83d\udcb0\ud83d\udcb0\ud83d\udcb0, \ud83d\udeab\ud83d\ude08\ud83d\ude08\ud83d\ude08\ud83d\ude08\ud83d\ude08\ud83d\ude08\ud83d\ude08, \ud83c\udf20 \ud83d\udd3d\ud83d\ude4b\u200d\u2642\ufe0f\u27a1\ufe0f\ud83d\udc82\u200d\u2642\ufe0f \ud83d\udd3d\ud83d\udd15\ud83d\udd17\ud83d\udc96\ud83d\udc68!", "You and I must understand one another, and that too without delay.": "\ud83d\udc65\ud83d\udca1\ud83e\udd1d, \u23e9\u23f0\ud83d\udeab.", "mate, flushed with conquest, betrayed": "\ud83e\uddd1\u200d\ud83e\uddb0, \ud83e\udd75\ud83c\udf89\ud83e\udd47, \ud83d\ude35\ud83d\udd2a\ud83d\udd04", "the least tangle or kink in the coiling would, in running out, infallibly take somebody\u2019s arm, leg, or entire body off": "\ud83d\udc4e\u27b0\ud83d\udd00\u27bf, \ud83c\udfc3\u200d\u2642\ufe0f\ud83d\udd1b, \ud83d\udd12\ud83d\udcaf\ud83e\udd1c\ud83e\uddbe, \ud83e\uddb5, \ud83e\udd37\u200d\u2642\ufe0f\ud83d\udd2a", "sink to rise no more": "\ud83d\udeb0\u2198\ufe0f\ud83d\udd1d\ud83d\udeab\ud83d\udd02", "and what is more, the Sperm Whale has done it": "'\u2795, \ud83e\udd14\u2753\u2795, \ud83d\udc0b\ud83d\udca1\ud83d\udc4d\ud83c\udffd\ud83c\udfaf'", "yet all were vain": "\ud83d\udd0d\ud83d\udc65\ud83d\udc65\ud83d\udc65\ud83d\udc65\ud83d\udc65\ud83d\ude45\u200d\u2642\ufe0f\ud83d\udc4e\ud83d\udd2e", "Ecclesiastes is the fine hammered steel of woe.": "\ud83d\udcd6\u26ea \ud83d\ude25\ud83d\udd28\ud83d\udd29\ud83d\udd27\ud83d\udeac", "you involuntarily took an oath with yourself to find out what that marvellous painting meant": "\ud83d\udc49\ud83e\udd1a\ud83d\udc64\ud83d\udcac\ud83e\udd1d\ud83e\udd33\ud83d\udd0d\ud83d\udc40\ud83e\udd14\ud83d\uddbc\ufe0f\u2728\ud83d\udcdd\ud83e\udd37\u200d\u2642\ufe0f", "Leviathan maketh a path to shine after him; One would think the deep to be hoary": "\ud83d\udc09\ud83d\udee3\ufe0f\u2728\ud83d\udd19\ud83d\udc65\ud83d\udcad\ud83c\udf0a\ud83d\udc74\ud83e\udd14", "refuse resurrections to the beings who have placelessly perished without a grave": "\ud83d\udeab\ud83d\udc80\u27a1\ufe0f\ud83d\udc65\ud83d\ude35\ud83c\udf10\u274c\u26b0\ufe0f\ud83d\udeab\ud83e\udea6", "methinks that white-lead chapter about whiteness is but a white flag hung out from a craven soul": "\ud83d\udcad\ud83e\udd14\u26aa\ud83d\udcd6\u27a1\ufe0f\u26aa\u2b1c\ud83c\udff3\ufe0f\ud83c\udf8f\u27a1\ufe0f\ud83c\udff3\ufe0f\ud83d\udc4b\ud83d\udd06\ud83d\udc14\u2795\ud83d\udc7b\ud83d\udcad", "the wonderful comparative smallness of his brain proper is more than compensated by the wonderful comparative magnitude of his spinal cord": "\ud83c\udf1f\ud83d\ude32\ud83d\udccf\ud83e\udde0\ud83d\udc68\u200d\ud83e\uddb1\u2795\ud83c\udd9a\ud83d\udcb0\u2705\ud83c\udf1f\ud83d\ude32\ud83d\udccf\ud83d\udd0e\ud83e\uddb4\u2795\ud83c\udd9a\ud83d\udcb0\u2705", "Horrible old man!": "\ud83d\ude31\ud83d\udc74\u203c\ufe0f", "And yet, \u2019tis a noble and heroic thing, the wind! who ever conquered it?": "'\ud83d\udc65\ud83d\udd1b\u23ed\ufe0f, '\ud83d\udc65\u23e9\ud83c\udd70\ufe0f\ud83d\udd74\ufe0f\ud83e\uddb8\ud83d\udd31\ud83d\udd2e, \ud83c\udf2c\ufe0f! \ud83d\udc65\ud83d\udc4e\ud83c\udfc6\ud83d\udea9'", "veritable gospel cetology": "\ud83d\udcd6\u2705\ud83d\udc0b\ud83d\udd2c", "But war is pain, and hate is woe.": "\ud83c\udf51\ud83d\udd1b\ud83d\udca3\ud83d\udd1b\ud83d\udc94, \ud83c\udf41\ud83d\udd1b\ud83d\ude21\ud83d\udd1b\ud83d\ude2d", "when our smoke was over, he pressed his forehead against mine, clasped me round the waist, and said that henceforth we were married": "\ud83d\udd70\ud83d\udeac\ud83d\udd1a, \ud83d\udc68\u200d\u2696\ufe0f\ud83e\udd32\ud83d\udc86\u200d\u2642\ufe0f\ud83e\udd1d\ud83d\udc86, \ud83d\udc50\ud83e\udd17\ud83d\udc6b\ud83d\udc8d\ud83d\udde3\ufe0f\ud83d\udc70\u200d\u2640\ufe0f\ud83e\udd35\u200d\u2642\ufe0f", "hard, remorseless service the soles of my boots were in a most miserable plight": "\ud83d\udcaa\ud83d\ude14\ud83d\udd27\ud83d\udd28\u2699\ufe0f\ud83d\udc62\ud83d\udc62\ud83d\udd1a\ud83d\ude31\ud83d\ude4d\u200d\u2642\ufe0f\ud83d\udd3b", "the wild and distant seas where he rolled his island bulk": "\ud83c\udfde\ufe0f\ud83c\udf2a\ufe0f\ud83c\udf00\ud83c\udf0a\ud83d\udccd\ud83c\udf0a\ud83c\udfdd\ufe0f\ud83c\udf2c\ufe0f\ud83d\udd04\u21a9\ufe0f\ud83c\udfdd\ufe0f\ud83c\udfde\ufe0f\ud83c\udf54\u26f0\ufe0f\ud83c\udf04", "So go thy ways, and I will mine.": "\ud83d\udc49\u27a1\ufe0f\ud83d\udc83\ud83d\udeb6\u200d\u2642\ufe0f, \u2795\ud83d\udc41\ufe0f\u27a1\ufe0f\u26cf\ufe0f\ud83d\udd28\u26cf\ufe0f.", "it is by no means uncommon to see the needles in the compasses, at intervals, go round and round": "\u27a1\ufe0f\ud83d\ude45\u200d\u2642\ufe0f\u274c\ud83d\udd2e\ud83d\udc40\ud83d\udccc\ud83d\udd04\ud83e\udded, \u23f0\u23f3, \ud83d\udd04\ud83d\udd04\ud83d\udd04", "The sovereignest thing on earth is parmacetti for an inward bruise.": "\ud83d\udc51\ud83c\udf0d\ud83c\udf1f\ud83d\udc33\ud83d\udc8a\ud83e\ude79\ud83e\udd15\ud83d\udd2e", "out of sight of land": "\ud83d\udc40\u274c\ud83c\udfde\ufe0f", "Shall we keep chasing this murderous fish till he swamps the last man?": "\ud83e\udd14\ud83d\udd04\ud83c\udfc3\u200d\u2642\ufe0f\ud83d\udc1f\ud83d\udd2a\ud83c\udd9a\ud83d\ude4d\u200d\u2642\ufe0f\ud83c\udfde\ufe0f\u2753", "Coming afoul of that old man has a sort of turned me wrong side out.": "\ud83d\udeb6\u200d\u2642\ufe0f\ud83d\udca5\ud83d\udc74\ud83d\udd00\ud83d\ude35\ud83d\udca4\ud83d\udca2\u21a9\ufe0f\ud83d\ude43", "This ignorant, unconscious fearlessness of his made him a little waggish in the matter of whales": "\ud83d\udc49\ud83e\udd37\u200d\u2642\ufe0f\ud83d\ude48\ud83d\ude31\u26d4\ud83c\udfad\ud83e\udd2d\u2696\ufe0f\ud83d\udc33\u000f", "Ahab\u2019s harpoon had shed older blood than the Pharaoh\u2019s. Methuselah seems a school-boy.": "\ud83d\udc68\u200d\ud83e\uddb3\ud83d\udd31\ud83d\udc89\ud83e\ude78\ud83d\udc74\ud83e\ude78\u21aa\ufe0f\ud83e\udd34\ud83c\uddea\ud83c\uddec. \ud83e\uddd3\ud83d\udc48\ud83e\uddd1\u200d\ud83c\udf93.", "man is fitted to sit down on tomb-stones, and break the green damp mould with unfathomably wondrous Solomon": "\ud83d\udc68\u200d\ud83e\uddb0\ud83d\udc4c\ud83e\ude91\u2b07\ufe0f\ud83e\udea6\ud83d\udd28\ud83d\udfe2\ud83c\udf31\ud83d\udca6\ud83c\udf44\ud83d\udd73\ufe0f\ud83e\udd2f\ud83e\uddd9\u200d\u2642\ufe0f\ud83d\udcab", "It should not have been omitted that previous to completely stripping the body of the leviathan, he was beheaded.": "\ud83d\udeab\u2757\ud83d\udcd8\ud83d\udca1\ud83d\udde8\ufe0f\ud83d\udd19\ud83d\udc64\ud83d\udcaf\ud83d\udc4b\ud83d\udeab\ud83d\udc55\ud83d\udc56\ud83e\uddbe\ud83d\udc0b, \ud83d\udc64\ud83d\udd2a\ud83d\udc80.", "the German soon evinced his complete ignorance of the White Whale": "\ud83c\udde9\ud83c\uddea\ud83d\udd1c\ud83e\udd37\u200d\u2642\ufe0f\ud83d\udcaf\u274c\ud83e\udde0\ud83d\udd0d\u26aa\ud83d\udc0b", "a man of a singular appearance, even in that wild whaling life where individual notabilities make up all totalities": "\ud83d\udc68\u200d\ud83e\uddb0\ud83d\udcab\ud83d\udc40, \u27a1\ufe0f\ud83c\udf00\ud83d\udc0b\ud83c\udfa3\ud83c\udf0d\ud83c\udf1a, \ud83e\uddd1\ud83c\udf1f\ud83c\udfac\ud83c\udd99\ud83d\udc65\ud83c\udf10\ud83c\udf10", "For a few minutes the struggle was intensely critical; for while they still slacked out the tightened line in one direction, and still plied their oars in another, the contending strain threatened to take them under.": "\u23f3\u231b\ud83e\udd3c\u200d\u2642\ufe0f\ud83d\udd25\ud83d\udcaf; \u23e9\ud83d\udd00, \ud83e\udd1c\ud83e\udd1b\ud83c\udfa3\ud83d\udd12\u27b0\ud83c\udfde\ufe0f, \ud83e\udd1c\ud83e\udd1b\ud83d\udea3\u200d\u2642\ufe0f\ud83d\udd04\ud83d\udd79\ufe0f, \ud83e\udd1c\ud83e\udd1b\ud83e\udd1d\ud83d\udcaa\u26a0\ufe0f\ud83d\udca6\ud83d\udc47\ud83c\udf0a\ud83c\udd98.", "In all directions expanding in vast irregular circles, and aimlessly swimming hither and thither, by their short thick spoutings, they plainly betrayed their distraction of panic": "\ud83d\udd04\u2197\ufe0f\u2198\ufe0f\u2196\ufe0f\u2199\ufe0f\ud83d\udcc8\ud83d\udd35\ud83d\udd35\u2796\ud83d\udd00\ud83d\udd00, \ud83c\udfca\u200d\u2642\ufe0f\ud83d\udd00\ud83d\udd00\ud83d\udc0b, \ud83d\udc49\ud83d\udca6\ud83d\udca6, \ud83d\ude31\ud83d\ude28\ud83d\ude16\ud83c\udd98\ud83d\udea8\ud83d\udea8", "the charmed, churned circle of the hunted sperm whale": "\u2728\ud83c\udf00\u2b55\ufe0f\ud83c\udfaf\ud83d\udc0b", "O head! thou hast seen enough to split the planets and make an infidel of Abraham, and not one syllable is thine!": "\ud83d\udca1\ud83d\udde3\ufe0f! \ud83d\udc40\ud83d\udc4d\ud83c\udf0e\ud83d\udca5\u26a1\ufe0f\ud83d\udc64\u271d\ufe0f\ud83d\udd4c\ud83d\udd4d\u262a\ufe0f\ud83d\udd49\ufe0f\ud83d\udc94, \ud83d\udeab1\ufe0f\u20e3\ud83d\udcdd\ud83d\udd0a\ud83e\udd10!", "we found ourselves launched into this tormented sea, where guilty beings transformed into those fowls and these fish, seemed condemned to swim on everlastingly without any haven in store, or beat that black air without any horizon": "\ud83d\udc65\ud83d\udd0d\ud83d\udc65 \ud83d\ude80\ud83d\udd1b\ud83c\udf0a\ud83c\udf00, \ud83d\udc65\ud83d\ude08\ud83d\udd04\ud83d\udc26\ud83d\udc20, \ud83d\ude2d\ud83d\udc14\ud83c\udfca\u200d\u2642\ufe0f\u23e9\ud83d\udc94\ud83d\udeab\u2693\ufe0f, \ud83e\udd41\u26ab\ufe0f\ud83c\udf2b\ufe0f\ud83d\udeab\ud83c\udf05.", "There\u2019s a sermon now, writ in high heaven, and the sun goes through it every year, and yet comes out of it all alive and hearty.": "\ud83d\udcd6\u27a1\ufe0f\ud83d\ude4f\ud83d\udcac\u2b06\ufe0f\ud83c\udf08, \u2600\ufe0f\ud83d\udd04\ud83d\udcc6\ud83d\udcc5, \u27a1\ufe0f\ud83d\ude0a\ud83d\udcaa\ud83c\udf1e\ud83d\udc4d.", "Come; let us squeeze hands all round; nay, let us all squeeze ourselves into each other": "\ud83d\udcac\ud83d\udc49\ud83e\udd1d\ud83d\udcab\u270b\ud83d\udd04\u2728\ud83d\udc6b\ud83d\udc9e\ud83d\udc65\ud83d\udd04\ud83d\udc49\ud83d\udc65\ud83d\udc96", "during the violence of the gale, he had only steered according to its vicissitudes": "\ud83d\udd52\ud83c\udf2a\ufe0f\ud83d\udca5\ud83c\udf2c\ufe0f, \ud83d\udc68\u200d\u2693\ufe0f\ud83d\udd0e\ud83d\ude80\u23ed\ufe0f\ud83d\udd04\ud83c\udfad\ud83c\udf2a\ufe0f\ud83d\udcc8\ud83d\udcc9", "But none of us are in heaven yet.": "\ud83d\udeab\u274c\ud83d\udc65\ud83d\udc64\ud83d\udc46\ud83d\ude42\ud83d\udc48\u2601\ufe0f\ud83c\udff0\u23ed\ufe0f", "They must get just as nigh the water as they possibly can without falling in.": "\ud83d\udc65\ud83d\udc49\ud83d\udd2d\u27a1\ufe0f\ud83c\udf0a\u23ed\ufe0f\ud83d\udeab\ud83d\udca7\u2b07\ufe0f\ud83d\ude31\u2757\u2705\ud83d\udeb7", "True enough, but then whalemen themselves are poor devils; they have no good blood in their veins.": "\ud83d\udc4d\u2705, \u27a1\ufe0f\ud83d\udd31\ud83d\udc0b\ud83d\udc68\u200d\ud83d\udd2c\ud83e\udd37\u200d\u2642\ufe0f\ud83d\udc4e\ud83d\ude08; \ud83d\udeab\u2764\ufe0f\ud83d\udc89\ud83d\ude0a\ud83d\udd34\ud83d\udc49\ud83d\udc89\ud83d\ude15.", "Nor is this the end. Desecrated as the body is, a vengeful ghost survives and hovers over it to scare.": "\ud83d\udeab\u27a1\ufe0f\ud83d\udd1a. \ud83d\udd28\ud83d\udc64\ud83d\udc80, \ud83d\udc7b\ud83d\udca2\ud83d\udd1b\u270a\ud83c\udf2c\ufe0f\ud83d\udc46\ud83d\ude31.", "He is, without doubt, the largest inhabitant of the globe; the most formidable of all whales to encounter": "\ud83d\udc68\u200d\ud83d\udcbc\ud83d\udeab\u2754, \ud83d\udc49\ud83c\udf0d\ud83c\udf0e\ud83c\udf0f, \ud83d\udc0b\u27a1\ufe0f\ud83d\udc4c\ud83c\udfc6, \ud83d\ude31\ud83d\udc0b\ud83e\udd1d\ud83c\udd98", "I\u2019ll chase him round Good Hope, and round the Horn, and round the Norway Maelstrom, and round perdition\u2019s flames before I give him up.": "\ud83c\udfc3\u200d\u2642\ufe0f\ud83d\udd01\ud83d\udc68\u200d\ud83c\udf3e\ud83c\uddff\ud83c\udde6,\ud83d\udd01\ud83d\udcef,\ud83d\udd01\ud83c\udf00\ud83c\uddf3\ud83c\uddf4,\ud83d\udd01\ud83d\udd25\ud83d\ude08\ud83d\udd25 \u23ed\ufe0f\ud83e\udd32\ud83d\udd01\ud83d\udc68\u200d\ud83c\udf3e.", "rather than wander further about a strange town on so bitter a night, I would put up with the half of any decent man\u2019s blanket": "\ud83d\udd00 \u27a1\ufe0f \ud83d\udeb6\u200d\u2642\ufe0f\ud83d\udd0d\ud83c\udfd9\ufe0f \u2795 \ud83d\udc82\u200d\u2642\ufe0f\ud83c\udf19, \ud83d\ude4b\u200d\u2642\ufe0f\ud83e\udd37\u200d\u2642\ufe0f \ud83d\udc4d \u27971\ufe0f\u20e3\ud83d\udc68\u200d\ud83e\uddb3\ud83d\udecc\ud83d\udd25", "if he is going to live for ever, what good will it do to pitch him overboard": "\ud83e\udd14\u27a1\ufe0f\ud83d\udc68\u200d\u2695\ufe0f\ud83d\udd1c\ud83e\udd37\u200d\u2640\ufe0f\ud83d\udc98\ud83d\udd01\ud83d\udc80\ud83d\udc4d\u27a1\ufe0f\ud83e\udde9\ud83d\udc4b\ud83c\udf0a\ud83c\udf0a\ud83d\udef3\ufe0f", "there is considerable glory in that": "\ud83d\udc49\u2728\ud83c\udfc6\ud83d\udc48\u2b06\ufe0f\ud83d\udcab\ud83c\udf1f\ud83d\udcaf", "Like most sea-terms, this one is very happy and significant.": "\ud83d\udc4d\ud83c\udf0a\ud83d\udd20, \ud83d\udcd6\u261d\ufe0f\ud83d\ude00\ud83d\udcaa\ud83d\udd23", "How, then, with me, writing of this Leviathan?": "\u2753, \u27a1\ufe0f, \ud83d\udc65, \u270d\ufe0f, \ud83d\udd1b, \ud83d\udc33?", "Over unsounded gorges, through the rifled hearts of mountains, under torrents\u2019 beds, unerringly I rush!": "\ud83d\udd1d\ud83d\udd08\ud83c\udfde\ufe0f, \ud83d\udd2b\ud83d\udc96\u26f0\ufe0f, \u2b07\ufe0f\ud83d\udca6\ud83d\udecf\ufe0f, \ud83c\udfaf\ud83d\udca8\u2757", "at last he loses his identity; takes the mystic ocean at his feet for the visible image of that deep, blue, bottomless soul": "\u23f1\ufe0f\ud83d\udc94\ud83d\udd75\ufe0f\u200d\u2642\ufe0f; \ud83c\udf88\ud83c\udf0a\ud83d\udc63\ud83d\uddbc\ufe0f\ud83c\udf0a\ud83d\udc99, \u2b07\ufe0f\u26d3\ufe0f\ud83c\udf0c\ud83c\udf0a\ud83c\udf00\u27a1\ufe0f\ud83d\udc64\ud83d\udc99", "The heavers forward now resume their song": "\ud83d\udcaa\ud83d\udeb6\u200d\u2642\ufe0f\ud83d\udd1c\ud83c\udfb5\ud83d\udcd6\ud83d\udd01", "though a sworn foe to human bloodshed, yet had he in his straight-bodied coat, spilled tuns upon tuns of leviathan gore": "\ud83e\udd14\ud83d\ude21\ud83d\udd2a\ud83d\udc6b\ud83d\udc89, \u27a1\ufe0f\ud83d\udc68\ud83d\udc54, \u2705\ud83d\ude31\ud83d\udc0b\ud83d\udc94\u26d4\ud83d\udee2\ufe0f\ud83d\udee2\ufe0f\ud83e\ude78", "What he thought of death itself, there is no telling.": "\u2753\ud83d\udc68\ud83d\udcad\ud83d\udc80\u26b0\ufe0f, \ud83d\udeab\ud83d\udde3\ufe0f\ud83d\udd2e", "Human madness is oftentimes a cunning and most feline thing. When you think it fled, it may have but become transfigured into some still subtler form.": "\ud83d\udc65\ud83e\udd2a\ud83d\udd70\ufe0f\ud83e\udd8a\ud83d\udc31\ud83c\udf1f. \ud83e\udd14\ud83d\udcad\ud83c\udfc3\u200d\u2640\ufe0f\ud83d\udd19, \ud83e\udd37\u200d\u2642\ufe0f\ud83d\udd04\ud83d\udcbc\ud83d\udcd8\u27a1\ufe0f\ud83d\udc7b\ud83d\ude43.", "sway me to my wish": "\ud83d\udc83\ud83d\udd04\ud83d\ude4f\ud83c\udf20", "From this last vent no blood yet came, because no vital part of him had thus far been struck.": "\ud83d\udd00\ud83d\udeab\ud83d\udc89\u23ed\ud83d\udd73\ufe0f , \ud83d\udc4e\ud83d\udd34\ud83d\udc96\ud83e\uddbe\ud83d\udd28\ud83c\udfaf \ud83d\udd70\ufe0f\ud83d\udc48\ud83d\ude15.", "What do you see?": "\u2753\ud83d\udc40\ud83d\udc49\ud83c\udf10", "there is an \u00e6sthetics in all things": "\ud83d\udc40\u2728\ud83c\udfa8\ud83c\udf0d\ud83c\udf38\ud83c\udf39\ud83c\udf00\ud83c\udfde\ufe0f\ud83c\udfad\ud83c\udfb6\ud83c\udf0c\ud83d\udcda\ud83d\udc60\ud83c\udf72\ud83d\uddbc\ufe0f\ud83c\udfdb\ufe0f\ud83c\udfa1\ud83c\udf20\ud83d\udd79\ufe0f\ud83c\udf81\ud83d\udca1\ud83d\udd2c#\ufe0f\u20e3\u26bd\ud83c\udf43\ud83d\udc8e\ud83d\udcd8\ud83d\udecd\ufe0f\ud83c\udf88\ud83c\udf08\ud83d\udc96\ud83d\udd0d\ud83d\udcab\ud83c\udf0c\ud83d\udcae\u2696\ufe0f\ud83c\udfef\ud83c\udff0\ud83d\uddfc\u231b\u23f3\ud83d\udd70\ufe0f\ud83c\udf01\ud83c\udf0c\ud83c\udf06\ud83c\udf07\ud83c\udf09\ud83c\udf20\u2728\ud83c\udf03\u26fa\ud83c\udfde\ufe0f\ud83d\udee3\ufe0f\ud83c\udfdc\ufe0f\ud83c\udf05\ud83c\udf04\u23f2\ufe0f\u23f0\ud83d\udca3\ud83d\udca1\ud83d\udd6f\ufe0f\ud83c\udf91\ud83d\udda5\ufe0f\ud83d\udcbb\ud83d\udcf1\u231a\ufe0f\ud83d\udcf7\ud83c\udfa5\ud83d\udcfa\ud83c\udfbc\ud83c\udfb9\ud83c\udfb7\ud83c\udfb8\ud83c\udfbb\ud83c\udf9a\ufe0f\ud83c\udf9b\ufe0f\ud83d\udd08\ud83d\udd09\ud83d\udd0a\ud83c\udfb6\ud83c\udfb5", "Yes, as every one knows, meditation and water are wedded for ever.": "\ud83d\udc4d, \ud83c\udf0d\ud83d\udca1, \ud83e\uddd8\u200d\u2642\ufe0f\ud83e\udd1d\ud83d\udca7\ud83d\udd174\ufe0f\u20e3\ud83d\udc70\u200d\u2642\ufe0f\ud83e\udd35\u200d\u2640\ufe0f.", "the rumor of a knocking in a tomb will terrify a whole city": "\ud83d\udde3\ufe0f\ud83d\udc42\ud83d\udcac\ud83d\udc4a\u27a1\ufe0f\u26b0\ufe0f\u2b1b\ud83c\udfd9\ufe0f\ud83d\ude31\ud83c\udf10", "the room seeming almost supernaturally quiet after these orgies, I began to congratulate myself": "\ud83c\udfe0\ud83d\udd2e\ud83e\udd2b\ud83d\udd07\u27a1\ufe0f\ud83e\udd73\ud83c\udf89, \ud83d\ude4b\u200d\u2642\ufe0f\ud83d\udc4f\ud83c\udf8a\ud83e\udd32\ud83d\udc48\ud83d\udcad", "Other poets have warbled the praises of the soft eye of the antelope, and the lovely plumage of the bird that never alights; less celestial, I celebrate a tail.": "\ud83d\udc65\ud83d\udcdd\ud83c\udfb6\ud83d\udc4d\ud83d\udc40\ud83e\udd8c, \ud83d\udd4a\ufe0f\ud83d\udc96\ud83d\udd4a\ufe0f\ud83c\udfb6; \ud83d\udda4\ud83d\udcab, \ud83c\udf89\ud83d\udc3e\ud83c\udf8a.", "I see in him outrageous strength, with an inscrutable malice sinewing it.": "\ud83d\udc41\ufe0f\ud83d\udc40\u27a1\ufe0f\ud83d\udc68\ud83d\udcaa\ud83d\ude32, \ud83d\ude08\ud83d\udeab\ud83d\udd0d\ud83d\ude20\ud83d\udcaa it.", "And with what quill did the Secretary of the Society for the Suppression of Cruelty to Ganders formally indite his circulars?": "'\ud83d\udd00\ud83d\udd8b\ufe0f\ud83d\udcbc\ud83e\udd14\u2753\ufe0f\ud83d\udc68\u200d\ud83d\udcbc\ud83d\udcda\ud83d\udcdc\ud83d\udeab\ud83d\udc26\ud83d\udc4a\ud83c\udf10\u270d\ufe0f\ud83d\udce8\ud83d\udccf'", "others were set down for magnificent parts in high tragedies, and short and easy parts in genteel comedies, and jolly parts in farces": "\ud83d\udc65\ud83d\udc65\u27a1\ufe0f\ud83d\udccd\u2b07\ufe0f\ud83c\udfad\ud83c\udfad\u2b07\ufe0f\ud83d\udd31\ud83c\udfad\ud83d\udcc9\ud83c\udfad, \ud83d\udd1d\ud83c\udfad, \ud83d\udccf\ud83d\udd1c\u23e9\ud83c\udfad\u2b07\ufe0f\ud83d\udc4c\ud83c\udfad, \ud83d\ude02\ud83c\udfad\u2b07\ufe0f\ud83c\udf89\ud83c\udfad.", "young whales, in the highest health, and swelling with noble aspirations, prematurely cut off in the warm flush and May of life, with all their panting lard about them; even these brawny, buoyant heroes do sometimes sink": "\ud83d\udc76\ud83d\udc33\ud83d\udc76\ud83d\udc33, \ud83d\udd1d\ud83d\udc8a\ud83c\udfe5, \ud83d\udc40\ud83d\ude80\ud83d\udc51\ud83d\ude4f, \u23f0\u2702\ufe0f\ud83d\udcf4\ud83d\udd25\ud83d\ude0a\ud83c\udf3c\ud83d\udd51, \ud83d\udc40\ud83c\udf57\ud83e\udd53\u2934\ufe0f; \ud83c\udf1a\ud83d\udcaa\ud83c\udfcb\ufe0f\u200d\u2642\ufe0f\ud83d\udca6\ud83e\uddb8\u200d\u2642\ufe0f\ud83e\uddb8\u200d\u2640\ufe0f \ud83c\udfca\u200d\u2642\ufe0f\u23ec\ud83d\ude2b\ud83d\udc94.", "what god made him shark": "\u2753\ud83d\ude4f\ud83d\udc7c\ud83d\udd28\ud83d\udc68\ud83e\udd88", "in the foamy confusion of their mixed and struggling hosts, the marksmen could not always hit their mark": "\ud83c\udf0a\ud83d\udcad\ud83e\udd2f\ud83d\udd00\ud83e\udd3c\u200d\u2642\ufe0f\ud83d\udc19\ud83e\udd91, \ud83c\udfaf\ud83d\udc68\u200d\ud83c\udfeb\ud83d\udeab\ud83c\udfaf\u2714\ufe0f\u2705\ud83d\udd70\ufe0f", "it is only when caught in the swift, sudden turn of death, that mortals realize the silent, subtle, ever-present perils of life": "\ud83d\udd70\ufe0f\ud83d\udd39\ud83d\udcad\ud83d\udd73\ufe0f\ud83d\udd04\ud83d\udc80, \ud83d\udd0d\ud83d\udc65\u26a1\ufe0f\ud83e\uddd0\ud83e\udd2b, \ud83e\udde0\ud83c\udf0c, \u23f0\ud83d\udc0d\ud83d\udea7\ud83c\udf0d\ud83c\udf1f", "But there is no Champollion to decipher the Egypt of every man\u2019s and every being\u2019s face.": "\ud83d\udeab\ud83d\udd4a\ufe0f\ud83d\udcda\ud83c\udfdb\ufe0f\ud83d\udd0d\ud83c\uddea\ud83c\uddec\ud83d\udc68\ud83d\udc69\ud83d\udc7d\ud83d\ude42\ud83c\udf0d", "Stand up, and give it to him!": "\ud83d\udeb6\u200d\u2642\ufe0f\u2b06\ufe0f, \u2795\ud83c\udf81\ud83d\udc49\ud83d\udc68\u200d!", "all deep, earnest thinking is but the intrepid effort of the soul to keep the open independence of her sea": "\ud83c\udf30\ud83d\udcad\ud83d\udca1\ud83d\ude4f\ud83d\udcaa\ud83c\udffb\ud83d\ude07, \u26f5\ufe0f\ud83c\udf0a\ud83d\udca1\ud83e\udd14\u23e9\ud83d\udeb6\u200d\u2642\ufe0f\ud83d\udc81\ud83d\ude07\ud83c\udd93\ud83d\ude80\ud83d\udca1\u2b06\ufe0f\ud83d\udca1\ud83c\udf0a.", "whaling may well be regarded as that Egyptian mother, who bore offspring themselves pregnant from her womb": "\ud83d\udc0b\ud83d\udc0b\ud83d\udc0b \u27a1\ufe0f\ud83d\udd0e\ud83d\udcad\ud83d\udc4d\ud83d\udc64\ud83d\udd1c \ud83c\uddea\ud83c\uddec\ud83d\udc69\u200d\ud83d\udc67\u200d\ud83d\udc67, \ud83d\udc69\u200d\ud83d\udc67\u200d\ud83d\udc67\ud83d\udcad\ud83d\udebc\ud83d\udcad\ud83d\udc69\u200d\ud83d\udc67\ud83e\udd30\u2b05\ufe0f\ud83d\udc69\u200d\ud83e\uddbd", "There is one God that is Lord over the earth, and one Captain that is lord over the Pequod.": "\u261d\ufe0f\u271d\ufe0f\ud83c\udf0d\ud83d\udd31, \u261d\ufe0f\ud83d\udc6e\ud83d\udd31\ud83d\udef3\ufe0f.", "murderous din": "\ud83d\udd2a\ud83d\udd0a", "he toiled away, as if toil were life itself, and the heavy beating of his hammer the heavy beating of his heart": "\ud83d\udc68\u200d\ud83d\udd27\ud83d\udcaa\u23f1\ufe0f, \ud83d\udd04\ud83d\udcbc\ud83d\udd32\ud83d\udd12\ud83c\udf0d\ud83c\udf3b, \u2795 \ud83c\udfcb\ufe0f\u200d\u2642\ufe0f\ud83d\udd28\ud83c\udfb5\ud83c\udfcb\ufe0f\u200d\u2642\ufe0f\ud83d\udd28\ud83d\udc93\ud83c\udfb5", "Thus, then, in our hearts\u2019 honeymoon, lay I and Queequeg\u2014a cosy, loving pair.": "\"\ud83d\udc49, \ud83d\udd19, \u2764\ufe0f\ud83c\udf89, \ud83d\udecc\ud83d\udc65\ud83d\udc68\u200d\u2764\ufe0f\u200d\ud83d\udc68 - \ud83d\ude0a, \u2764\ufe0f \ud83d\udc6b\"", "it has the savor of analogical probability": "\ud83d\udcda\ud83d\udc49\ud83e\udd69\ud83c\udf6f\ud83d\udcca\ud83c\udfb2\ud83e\udd14", "I shall hereafter detail to you all the specialities and concentrations of potency everywhere lurking in this expansive monster": "\ud83d\ude4b\u200d\u2642\ufe0f\ud83d\udd1c\ud83d\udcdd\ud83d\udc49\ud83d\udc65\ud83d\udd0d\ud83c\udf3d\u2795\ud83d\udcaa\ud83c\udf0d\ud83c\udfaf\ud83d\udd0e\ud83d\udc41\u200d\ud83d\udde8\ud83c\udf0c\ud83d\udc79", "The Killer is never hunted.": "\ud83d\udd2a\ud83d\udc80\ud83d\udeab\ud83d\udd0d\u23ed\ufe0f", "To produce a mighty book, you must choose a mighty theme.": "\ud83d\udcda\u27a1\ufe0f\ud83d\udcaa\ud83d\udcd8, \ud83d\udcdd\ud83d\udc49\ud83d\udd0d\ud83d\ude80\u2b50\ud83d\udca1\ud83d\udcad", "But still you see his power in his play.": "\ud83c\udf51\u23e9\ud83d\udc40\ud83d\udc47\ud83d\udcaa\ud83c\udfae\ud83c\udfad", "Nantucketer, out of sight of land, furls his sails, and lays him to his rest, while under his very pillow rush herds of walruses and whales": "\ud83d\udc64\ud83c\udfde\ufe0f\ud83d\udc40\ud83d\udeab, \u26f5\ufe0f\u2b07\ufe0f, \ud83d\udecc\ud83d\udca4, \ud83d\udc33\ud83d\udc0b\ud83d\udca8\ud83d\udc47\ud83d\udecf\ufe0f\ud83e\udd2f.", "But what does he want of them?": "\u2753\ud83e\udd14\ud83d\udc40\ud83d\udc68\u200d\ud83e\uddb1\ud83d\udce8\ud83d\udc48\ud83e\udd37\u200d\u2640\ufe0f\ud83d\udc65\ud83e\udd37\u200d\u2642\ufe0f\ud83d\udc65\ud83c\udf81\ud83e\udd37\u200d\u2640\ufe0f", "the scaramouch in question had gained a wonderful ascendency over almost everybody": "\ud83c\udfad\u2753\ud83d\udcc8\ud83c\udf1f\ud83d\udcaa\ud83d\udd1d\ud83d\udc6b\ud83d\udc6c\ud83d\udc6d\ud83d\udc65", "He is both ponderous and profound.": "\ud83d\udc68\u2b05\ufe0f\ud83d\udcad\ud83e\uddee\ud83d\udd04\ud83d\udca1\ud83d\udd73\ufe0f", "millions of mixed shades and shadows, drowned dreams, somnambulisms, reveries": "\ud83d\udcb0\ud83d\udcb0\ud83d\udcb0\ud83c\udfa8\ud83d\udd00\ud83c\udf2b\ufe0f\ud83c\udf13\ud83c\udf1a,\ud83c\udf0a\ud83d\udcad\ud83d\udecc\ud83d\udca4, \ud83d\udca4\ud83d\udeb6\ud83c\udf19, \ud83c\udf25\ufe0f\ud83e\udd14\ud83d\udcad", "vexed with rapacious flights of screaming fowls, whose beaks are like so many insulting poniards": "\ud83d\ude24\ud83d\udd04 \ud83e\udd85\ud83d\udca8\ud83d\udde3\ufe0f\ud83d\udc26\ud83d\udc26, \ud83d\udc44\ud83d\udc4d\ud83d\udca5\ud83e\udd2c\ud83d\udd2a\ud83d\udd2a", "some idea may hence be had of the enormousness of that animated mass, a mere part of whose mere integument yields such a lake of liquid as that": "\ud83d\udca1\ud83e\udd14 \u27a1\ufe0f\ud83d\udc4d\ud83c\udfff\ud83e\udd37\u200d\u2642\ufe0f\ud83c\udfa9\ud83d\udc0b\ud83d\udc0b, \u26aa\ud83d\udd2e \u2795\u21a9\ufe0f\ud83d\udce6\ud83d\udca1\ud83c\udf0a\ud83d\udca7\ud83c\udf0a\ud83d\udca7\ud83d\udc4d\ud83c\udfff", "What could be more full of meaning?": "\u2753\ud83e\udd14\ud83d\udcad\u2795\ud83d\udcda\ud83d\udc9f\ud83e\udd37\u200d\u2642\ufe0f", "I thought I would sail about a little and see the watery part of the world.": "\ud83d\udcad\ud83e\udd14\u26f5\ufe0f\ud83d\udd04\ud83c\udf0a\ud83c\udf0d", "there was another thought, or rather vague, nameless horror concerning him, which at times by its intensity completely overpowered all the rest": "\ud83e\udd14\u2757\ufe0f\u27951\ufe0f\u20e3\ud83d\udcad,\ud83d\udd0d\ud83d\udca4\ud83d\udc65\ud83d\udc7b\ud83d\ude31\ud83d\udc49\ud83c\udffb\ud83d\udc64,\u23f0\u23f0\ud83d\udd25\u26a1\ufe0f\ud83d\udcaf\u2757\ufe0f\u26d4\ufe0f\ud83d\udd04\ud83c\udf10\ud83d\udd15\ud83d\udc65\ud83d\udd04.", "so the graceful repose of the line, as it silently serpentines about the oarsmen before being brought into actual play\u2014this is a thing which carries more of true terror than any other aspect of this dangerous affair": "\ud83d\ude0c\ud83d\udd7a\ud83d\udc83\u27b0\ud83d\udc0d\u2194\ufe0f\ud83d\udea3\u200d\u2642\ufe0f\ud83d\udea3\u200d\u2642\ufe0f\ud83e\udd2b\ud83d\udd1c\ud83c\udfad\ud83c\udfb2\u27a1\ufe0f\ud83d\ude31\ud83d\udd1d\ud83d\ude31\u26a0\ufe0f\ud83d\udd25\ud83d\udcbc", "What was America in 1492 but a Loose-Fish": "\u2753\ud83e\udd37\u200d\u2642\ufe0f\ud83c\uddfa\ud83c\uddf8\u23ea1492\ud83d\udc1f\ud83d\udd13", "more a demon than a man!": "\ud83d\udc79\u2795\ud83d\ude08\u2796\ud83d\udc68\u200d\ud83d\udcbc\u2757\ufe0f", "I have heard it said, and I do not much doubt it": "\ud83d\udc42\ud83d\udde3\ufe0f, \u2795 \ud83d\ude45\u200d\u2642\ufe0f\ud83e\udd14\ud83d\udcad\ud83e\udd37\u200d\u2642\ufe0f\ud83e\udd14", "after having repeatedly smelt the sea as a merchant sailor, I should now take it into my head to go on a whaling voyage": "\ud83d\udd01\ud83d\udc43\ud83c\udf0a\ud83d\udef3\ufe0f\ud83d\udc68\u200d\u2708\ufe0f, \ud83e\udd14\u26f5\ud83d\udc0b\ud83d\uddfa\ufe0f\ud83c\udfaf", "the silent ship, as if manned by painted sailors in wax, day after day tore on through all the swift madness and gladness of the demoniac waves": "\ud83d\udd07\ud83d\udef3\ufe0f, \ud83c\udfa8\u26f5\ud83d\udc68\u200d\ud83d\udc68\u200d\ud83d\udc66\u200d\ud83d\udc66\ud83d\udc6c\ud83d\udd6f\ufe0f,\ud83c\udf1e\ud83d\udd04\ud83d\udcc6 \ud83d\ude80\ud83d\udca8\ud83d\udcab\ud83c\udf0a\ud83c\udf0a\ud83d\ude08\ud83c\udfad\ud83c\udf0a\ud83c\udf0a", "far beneath the fantastic towers of man\u2019s upper earth, his root of grandeur, his whole awful essence sits in bearded state; an antique buried beneath antiquities, and throned on torsoes!": "\u2198\ufe0f\ud83d\udc47\u2b07\ufe0f\ud83d\uddfc\ud83c\udff0\ud83c\udfe2\ud83c\udf0d\ud83d\udc68\ud83d\udc51\ud83c\udf89, \ud83d\udc68\u200d\ud83e\uddb3\ud83d\udc51\ud83c\udf33\u2b50\ud83d\udd70\ufe0f, \ud83d\udc68\u2b1c\u2b1c\u2b1b\ud83d\udc68\ud83d\udc51\ud83d\udcbc\ud83d\uddfb; \ud83c\udffa\ud83d\udcbc\u2b07\ufe0f\ud83d\udd31\ud83c\udffa\ud83c\udffa, \ud83d\udecb\ufe0f\ud83d\udcba\ud83d\uddff\ud83d\udcbc!", "all these passing things": "\ud83d\udc65\ud83d\udc49\ud83d\udd5b\ud83d\udd04\ud83d\udd00\ud83c\udf10", "Thou saw\u2019st the locked lovers when leaping from their flaming ship": "\ud83d\udc40\ud83d\udd12\ud83d\udc91\u2b07\ufe0f\ud83d\udd25\ud83d\udea2", "what are the comprehensible terrors of man compared with the interlinked terrors and wonders of God!": "\u2753\u2705\ud83e\uddd1\u200d\ud83e\udd1d\u200d\ud83e\uddd1\ud83d\udc7b\u2696\ufe0f\ud83d\ude31\ud83e\udd14\ud83d\udcab\ud83d\udd17\ud83d\ude31\u2757\ufe0f\ud83c\udf8a\ud83d\udd04\ud83d\ude4f\ud83c\udf0c\ud83c\udf86\u271d\ufe0f\u2757\ufe0f", "the many noses on the Pequod\u2019s deck proved more vigilant discoverers than the three pairs of eyes": "\ud83d\udd22\ud83d\udc43\ud83d\udef3\ufe0f\ud83c\udf03\u2795\ud83d\udd0d\ud83d\udd2d\ud83d\udd75\ufe0f\u200d\u2640\ufe0f\ud83d\udc41\ufe0f\ud83d\udc41\ufe0f\ud83d\udc41\ufe0f\ud83d\udc41\ufe0f\ud83d\udc41\ufe0f\ud83d\udc41\ufe0f", "Unhinge the lower jaw": "\ud83d\udd13\ud83d\udc47\ud83e\uddb7\ud83d\udc44", "What are the sinews and souls of Russian serfs and Republican slaves but Fast-Fish": "\u2753\ud83e\udd14\ud83d\udcaa\ud83c\udffd\ud83d\udc65\ud83c\uddf7\ud83c\uddfa\ud83d\udd17\ud83d\udd4a\ufe0f\ud83d\udc94\ud83c\uddfa\ud83c\uddf8\ud83d\udd17\u26d3\ufe0f\ud83d\udc1f\ud83d\udca8", "Thou canst consume; but I can then be ashes.": "\ud83d\udc49\ud83d\ude4f\ud83c\udf7d\ufe0f, \ud83d\udca1\ud83d\udd25\ud83d\udc41\ufe0f\ud83d\udc49\ud83c\udffd\ud83c\udf2b\ufe0f", "prepare for what follows": "\ud83d\udd0d\ud83d\udc40\ud83d\udd1c\ud83d\udd2e\ud83d\udcab", "your whales must be seen before they can be killed": "\ud83d\udc49\ud83d\udc0b\ud83d\udc0b \u27a1\ufe0f\ud83d\udc40\ud83d\udd0d\ud83c\udd71\ufe0f4\ufe0f\u20e3 \u2694\ufe0f\ud83d\udc80", "So be it, then. Born in throes, \u2019tis fit that man should live in pains and die in pangs! So be it, then!": "\ud83d\udc4c, \ud83d\udd01. \ud83d\udc76\ud83c\udfaf, '\ud83c\udfad\ud83e\udd1d\ud83d\udd7a\u27a1\ufe0f\ud83d\udc93\ud83d\udc94\ud83d\udc80\ud83d\ude16! \ud83d\udc4c, \ud83d\udd01!'", "break your backbones, my boys": "\ud83d\udc94\ud83d\udcaa\ud83e\uddb4, \ud83d\udc66\ud83d\udc66", "it\u2019s a wicked world in all meridians": "\ud83d\ude08\ud83c\udf0d\u2194\ufe0f\ud83d\udcd0\ud83d\udd00\ud83c\udf10", "For all his tattooings he was on the whole a clean, comely looking cannibal.": "\ud83d\udc64\ud83d\udc89\ud83c\udfa8, \u27a1\ufe0f\ud83e\uddfc\ud83d\udc40\ud83d\ude0b\ud83d\udc79", "Future things swim before me, as in empty outlines and skeletons; all the past is somehow grown dim.": "\ud83d\udd2e\ud83c\udfca\u200d\u2640\ufe0f\ud83d\udd1b\ud83d\udd1d\u21aa\ufe0f\ud83d\udc64, \ud83d\udd04\ud83d\udd32\ud83d\udc64\u25b6\ufe0f\ud83d\udc80; \ud83d\udd05\ud83c\udf05\ud83d\udd26\u21a9\ufe0f\ud83c\udf0c\ud83c\udf01\ud83c\udf11\ud83e\udd0e.", "the thousand concurring accidents of such an audacious enterprise": "\ud83d\udcaf0\u2b50\ud83d\udd00\ud83d\udca5\ud83d\udea7\u2728\ud83d\udd1d\ud83d\udee0\ud83c\udfd7\ufe0f", "With a philosophical flourish Cato throws himself upon his sword; I quietly take to the ship.": "\ud83d\udcda\ud83e\uddd0\ud83c\udf00 Cato \ud83d\udeb6\u200d\u2642\ufe0f\ud83d\udca8\ud83d\udde1\ufe0f; \ud83e\udd2b I \ud83d\udeb6\u200d\u2642\ufe0f\ud83d\udea2", "Almost invariably it is all over obliquely crossed and re-crossed with numberless straight marks in thick array": "\u23f3\u27a1\ufe0f\ud83d\udd04\u2197\ufe0f\u2199\ufe0f\u2716\ufe0f\ud83d\udd00\ud83d\udd04\u2795\ud83d\udd01\u27a1\ufe0f\ud83d\udd22\ud83d\udcaf\ud83d\udcaf\u2714\ufe0f\u2796\ud83d\udd1b\ud83d\udd1d\ud83d\udd1b\ud83d\udd1d2\ufe0f\u20e35\ufe0f\u20e3\u27a1\ufe0f\ud83c\udfde\ufe0f\ud83d\udcf6\ud83d\udd1d", "there is a certain mathematical symmetry in the Sperm Whale\u2019s which the Right Whale\u2019s sadly lacks": "\ud83d\udd0d\u27a1\ufe0f\u2795\ud83d\udd23\ud83d\udd04\ud83c\udf00\ud83d\udd00\ud83d\udc0b\ud83d\udd0d\u2194\ufe0f\ud83d\udc0b\ud83d\udd0d\ud83d\ude22\ud83d\udeab\u2796", "Well, well, what\u2019s signed, is signed; and what\u2019s to be, will be; and then again, perhaps it won\u2019t be, after all.": "\ud83e\udd14\ud83e\udd14,\u270d\ufe0f\u2705,\u270d\ufe0f\u2705; \u27a1\ufe0f\ud83e\udd37\u200d\u2640\ufe0f, \ud83c\udf08 ; \u27a1\ufe0f\ud83d\udd04, \u2753\ud83e\udd37\u200d\u2640\ufe0f\u274c, \u23ed\ufe0f\ud83d\ude45\u200d\u2640\ufe0f.", "But my whole clock\u2019s run down; my heart the all-controlling weight, I have no key to lift again.": "\ud83d\udd0d\ud83d\udd70\ufe0f\u23f1\ufe0f\ud83c\udfc3\u200d\u2642\ufe0f\u2935\ufe0f; \u2764\ufe0f\u2696\ufe0f\ud83c\udf10\ud83c\udf9b\ufe0f,\ud83d\udddd\ufe0f\ud83d\udeab\ud83d\udd1d\ud83d\udd04\u2753", "there is no earthly way of finding out precisely what the whale really looks like": "\u274c\ud83c\udf0d\ud83d\udca1\ud83d\udd0d\ud83c\udfaf\ud83d\udc0b\ud83d\udc40\ud83d\udcaf", "all evil, to crazy Ahab, were visibly personified, and made practically assailable in Moby Dick": "\ud83d\udc65\ud83d\ude08\ud83d\udc49\ud83e\udd2aAhab, \ud83d\udc41\ufe0f\ud83d\udc64, \u2795\ud83d\udee0\ud83e\udd1d\ud83d\udc4a\ud83d\udc49\ud83d\udc0bMoby Dick.", "have I been but forging my own branding-iron, then?": "\u2753\ud83d\udc41\ufe0f\ud83d\udd28\ud83d\udd25\ud83d\udcad\ud83d\udd27\u26cf\ufe0f\ud83d\udd25\ud83c\udfed\ud83d\udd04\ud83e\udd14", "for ever and for ever, to the crack of doom, the sea will insult and murder him, and pulverize the stateliest, stiffest frigate he can make": "\ud83d\udd01\u23f3\ud83d\udd01\u23f3, \ud83d\udd04\u26a1\ud83d\udca5\ud83c\udf0b, \ud83c\udf0a\ud83d\udc49\ud83e\udd2c\ud83d\udd2a\ud83d\ude4e\u200d\u2642\ufe0f, \ud83d\udd04\u2699\ufe0f\ud83d\udca3\ud83c\udfdb\ufe0f, \ud83d\udd74\ufe0f\u2b1b\u26f5\ud83d\udc49\ud83d\udc4d\ud83d\udcaa\ud83d\udee0\ufe0f", "Chowder for breakfast, and chowder for dinner, and chowder for supper, till you began to look for fish-bones coming through your clothes.": "\ud83e\udd63\ud83c\udf72\ud83e\udd50 for \ud83c\udf73, and \ud83e\udd63\ud83c\udf72\ud83e\udd50 for \ud83c\udf7d\ufe0f, and \ud83e\udd63\ud83c\udf72\ud83e\udd50 for \ud83c\udf19\ud83c\udf7d\ufe0f, till you \ud83d\ude33 to \ud83d\udd0d for \ud83d\udc1f\ud83e\uddb4 coming through your \ud83d\udc55\ud83d\udc56.", "a poor pegging lubber": "\ud83e\udd32\ud83d\udcb8\ud83d\udd28\u2693", "the eyes themselves seem clear, eternal, tideless mountain lakes": "\ud83d\udc41\ufe0f\ud83d\udc41\ufe0f\ud83d\udd1b\ud83c\udfde\ufe0f\ud83d\udca6\ud83d\udd04\ud83d\udc8e\ud83c\udf05\ud83d\udd50\ud83d\udd55\ud83d\udd5a\ud83c\udf0a\ud83c\udfd4\ufe0f\ud83c\udfde\ufe0f", "Take almost any path you please, and ten to one it carries you down in a dale, and leaves you there by a pool in the stream.": "\ud83d\udc49\ud83d\udd00\ud83d\udeb6\u200d\u2642\ufe0f\ud83d\udee4\ufe0f\u27a1\ufe0f\ud83c\udfb0, \u2795\ud83d\udd1f\u27a1\ufe0f1\ufe0f\u20e3, \ud83d\ude9b\ud83d\udc47\u2935\ufe0f\ud83c\udf04, \u2795\ud83d\udd1a\ud83d\udc48\ud83c\udf0a\ud83c\udfde\ufe0f.", "They are fighting Quakers; they are Quakers with a vengeance.": "\ud83d\udc65\ud83e\udd4a\u2694\ufe0f\ud83d\udc7b\ud83d\udd4a\ufe0f; \ud83d\udc65\ud83d\udc7b\ud83d\udd4a\ufe0f\ud83d\ude21\ud83d\udd25\u26a1\ud83d\udca5", "Old age is always wakeful": "\ud83d\udc74\ud83d\udc75\u23f0\ud83c\udf19\ud83c\udf19\ud83c\udf19\u26a0\ufe0f", "The universe is finished; the copestone is on, and the chips were carted off a million years ago.": "\ud83c\udf0c\u2705; \ud83d\udd1d\ud83c\udfd7\ufe0f\ud83d\udd1b, \ud83c\udf5f\ud83d\ude9a\ud83d\udca8\ud83d\ude80\ud83d\udd70\ufe0f\ud83d\udd19\u23ed\ufe0f1\ufe0f\u20e3\u24c2\ufe0f\ud83d\udcc6\ud83d\udd1a.", "Hand in hand, ship and breeze blew on": "\ud83e\udd1d\ud83d\udea2\ud83d\udca8\ud83d\udd1b", "the perilous depth to which he had sunk": "\u26a0\ufe0f\ud83d\udd73\ufe0f\u2b07\ufe0f\ud83d\udc47\ud83e\udd37\u200d\u2642\ufe0f\ud83d\udd1a\ud83d\udc47", "That mortal man should feed upon the creature that feeds his lamp": "\u2620\ufe0f\ud83e\uddcd\u200d\u2642\ufe0f\ud83c\udf7d\ufe0f\u27a1\ufe0f\ud83d\udc10\ud83d\udc04\ud83d\udc16\u27a1\ufe0f\ud83c\udf7d\ufe0f\u26fd\ud83d\udd25\ud83d\udca1", "Here\u2019s food for thought, had Ahab time to think; but Ahab never thinks; he only feels, feels, feels": "\ud83d\udcda\ud83d\udca1\ud83c\udf54\ud83e\udde0, \u23f3\ud83e\udd14 Ahab; \u274cAhab \ud83d\udeab\ud83e\udd14; \ud83d\udc65\ud83d\udd32\ud83d\udc40, \ud83d\udc40, \ud83d\udc40", "No town-bred dandy will compare with a country-bred one\u2014I mean a downright bumpkin dandy": "\ud83d\udeab\ud83c\udfd9\ufe0f\ud83c\udfa9\ud83e\uddd1\u200d\ud83d\ude80\ud83d\udd01\ud83c\udd9a\ud83c\udfde\ufe0f\ud83c\udfa9\ud83e\uddd1\u200d\ud83c\udf3e\u2014\ud83d\udc48\ud83c\udffd\ud83e\udd14\ud83d\udcaf\ud83c\udf3d\ud83e\udd35", "in the deep shadows of his eyes floated some reminiscences that did not seem to give him much joy": "\ud83c\udf11\ud83c\udfad\ud83d\udc41\ufe0f\ud83d\udcad\ud83d\udca1\ud83d\udd19\ud83d\ude14\ud83d\udcc9\ud83c\udf88", "a cannon-ball, missent, becomes a plough-share": "\ud83d\udd35\ud83d\udca3, \u274c\u2709\ufe0f, \ud83d\udd04\ud83d\ude9c\ud83d\udd27", "\ufeff\u2014oh, weariness! heaviness! Guinea-coast slavery of solitary command!": "\"\ud83d\ude2b! \ud83d\ude29! \ud83c\udf0d\ud83d\udd17\u26d3\ud83d\udeb6\u200d\u2642\ufe0f\ud83d\udcbc!\"", "I own thy speechless, placeless power; but to the last gasp of my earthquake life will dispute its unconditional, unintegral mastery in me.": "\ud83d\udcac\u27a1\ufe0f\ud83e\udd10\ud83d\udeab\ud83c\udf0d\ud83c\udfde\ufe0f\ud83d\udca5; \u23ed\ufe0f\ud83d\udca8\ud83d\ude35\ud83c\udf0e\ud83d\udd25\ud83e\udd1c\ud83c\udd9a\u274e\ud83d\udeab\ud83d\udccf\ud83c\udf96\ufe0f\ud83d\udd17\ud83d\ude24", "is not Possession the whole of the law?": "\u2753\u274c\ud83d\udcbc\ud83d\udd10\ud83c\udf0d\ud83d\udcdc\u2696\ufe0f\u2753", "For by how much the more pains ye take to please the world, by so much the more shall ye for ever go thankless!": "\ud83d\udcaa\ud83c\udf0d\u27a1\ufe0f\ud83d\ude14\u2194\ufe0f\u27a1\ufe0f\ud83d\udcaa\ud83c\udf0d\u2194\ufe0f\u27a1\ufe0f\ud83d\ude4f\ud83d\udd01\ud83d\ude45\u200d\u2642\ufe0f\ud83d\udcab", "and then turn to the green, gentle, and most docile earth; consider them both, the sea and the land": "\u27a1\ufe0f\ud83d\udd04\ud83d\udc49\ud83d\udfe2\ud83c\udf0e\ud83d\udd4a\ufe0f; \ud83d\udcad\ud83d\udc65\ud83c\udf0a\ud83e\udd1d\ud83c\udfde\ufe0f", "Call me Ishmael.": "\u260e\ufe0f\ud83d\udc64\ud83d\udc33", "a rather good sort of god, who perhaps meant well enough upon the whole, but in all cases did not succeed in his benevolent designs": "\ud83c\udd70\ufe0f\u2197\ufe0f\ud83d\udc4d\ud83d\udd2e\u271d\ufe0f, \ud83d\udc64\u23ed\ufe0f\ud83d\udcad\ud83d\udcaf\ud83c\udf0d, \u27a1\ufe0f\ud83c\udd9a\ud83c\udd70\ufe0f\ud83d\udd04 \ud83c\udf00\u274c\ud83c\udfc6\ud83c\udfc5\ud83c\udf81\ud83e\udd32\ud83d\udd4a\ufe0f\ud83c\udfa8", "that unspeakable thing called his \u201cflurry,\u201d the monster": "\ud83d\udc49\ud83d\udeab\ud83d\udde3\ufe0f\ud83c\udf2c\ufe0f\ud83d\udc48\ud83d\udc7d\ud83d\udc7e\ud83e\udd2d\ud83d\udc79", "a howling night": "\ud83c\udd70\ufe0f\ud83c\udf03\ud83d\udc3a\ud83d\udca8", "So be cheery, my lads, let your hearts never fail, While the bold harpooneer is striking the whale!": "\ud83d\udc49\ud83c\udf89\ud83d\ude04, \ud83d\udc6c, \u2764\ufe0f\ud83d\udcaa\ud83d\udeab\u274c, \u23f3 \ud83d\udd1d\ud83d\udcaa\ud83c\udfa3\ud83d\udc68\u200d\ud83e\uddb0\ud83d\udc4a\ud83d\udc0b!", "you are struck by the general contrast between these heads.": "\ud83d\ude2e\ud83d\udc65\u26a1\ufe0f\ud83c\udfad\ud83d\udd01\ud83d\udc64\ud83d\udc64", "Cussed fellow-critters! Kick up de damndest row as ever you can; fill your dam\u2019 bellies \u2019till dey bust\u2014and den die.": "\ud83d\ude20\ud83e\udd2c\ud83d\udc65! \ud83e\uddb5\u2b06\ufe0f\ud83d\udc79\ud83d\udca5\ud83d\ude31\ud83d\udd0a as \ud83c\udf1f\ud83d\udcabyou \ud83d\udc49 can; \ud83c\udf7d\ufe0f\ud83c\udf7e\ud83d\udc49\ud83c\udf54\ud83c\udf55\ud83c\udf57\ud83c\udf69 bellies 'till they\ud83d\udca5\u2014and then\ud83d\udc80.", "much of a man\u2019s character will be found betokened in his backbone": "\ud83d\udc64\ud83d\udcaa\ud83d\udd0d\ud83d\udcd6\ud83d\udca1\ud83d\udd11\ud83d\udd1d\ud83d\udd19\ud83e\uddb4", "He desires to paint you the dreamiest, shadiest, quietest, most enchanting bit of romantic landscape": "\ud83d\udc68\ud83d\udcad\ud83c\udfa8\ud83d\udc69\ud83c\udf05\ud83d\udca4\ud83c\udf34\ud83d\udd07\ud83d\udd2e\ud83d\udccf\ud83d\udc96\ud83c\udf04", "it might yet in great part be buoyed up by its native element": "\ud83e\udd14\u27a1\ufe0f\u23ed\ufe0f\ud83c\udf1f\u2b06\ufe0f\ud83c\udd71\ufe0f\u26f5\ud83c\udd99\ud83d\udd1d\ud83d\udd01\ud83c\udf0d\ud83d\udd18", "never violate the Pythagorean maxim": "\ud83d\udeab\u274c\u2797\ud83d\udd3a\ud83d\udcd0\ud83e\uddee\ud83d\udcda\ud83d\udca1\ud83c\udc04\ud83d\ude4f", "Oh, woe on woe! Oh, Death, why canst thou not sometimes be timely?": "\ud83d\ude2e, \ud83d\ude2d\ud83d\udc94\ud83d\ude2d! \ud83d\ude2e\ud83d\udc80, \u2049\ufe0f\u2753\ud83d\udd70\ufe0f\ud83d\udd70\ufe0f\ud83d\udd70\ufe0f\u2753", "it almost seemed that while he himself was marking out lines and courses on the wrinkled charts, some invisible pencil was also tracing lines and courses upon the deeply marked chart of his forehead": "\ud83d\udc64\ud83d\udcad\ud83d\udd2e, \ud83e\udd14\ud83c\udfc3\ud83d\udd8d\ufe0f\ud83d\udcc8\ud83d\ude8f\ud83d\udccd\ud83d\uddfa\ufe0f, \ud83e\udd37\ud83d\udc40\u270f\ufe0f\ud83d\udc7b\ud83e\udd1d\ud83d\udd8d\ufe0f\ud83d\udcc8\ud83d\ude8f\ud83d\udccd\ud83c\udfde\ufe0f\ud83e\udd14\ud83d\udee4\ufe0f\ud83d\uddbc\ufe0f\ud83d\udc74\ud83d\udc68\u200d\ud83e\uddb3\ud83d\udc4d", "everything was filled with sperm, except the captain\u2019s pantaloons pockets": "\ud83c\udf10\ud83d\udc48\ud83c\udfaf\ud83c\ude35\ud83e\udd5b\ud83c\udf76, \u274c\ud83d\udc56\ud83d\udc64\ud83e\udde5\ud83d\udcb0\ud83d\udeab\ud83d\udc48\u2693\ufe0f\ud83d\udc68\u200d\u2708\ufe0f\ud83d\udc56\ud83d\udc5b\ud83d\udc48", "the weapon is instantly at hand to its hurler, who snatches it up as readily from its rest as a backwoodsman swings his rifle from the wall": "\ud83d\udd2b\u23f1\ufe0f\u270b\ud83d\udd04\ud83e\udd3e\u200d\u2642\ufe0f, \ud83d\udc64\ud83d\udca8\ud83c\udd99\ud83d\ude80\u21a9\ufe0f\ud83d\ude34, \ud83c\udf32\ud83d\udeb6\u200d\u2642\ufe0f\ud83d\udd04\ud83d\udd7a\ud83c\udd95\ud83d\udd2b\ud83d\uddbc\ufe0f\ud83d\udca5", "As for the sons and the daughters they beget, why, those sons and daughters must take care of themselves": "\ud83d\udd0d\ud83d\udc66\ud83d\udc67\ud83d\udc68\u200d\ud83d\udc69\u200d\ud83d\udc67\u200d\ud83d\udc66\u27a1\ufe0f\u2753, \ud83d\udc66\ud83d\udc67\u26a0\ufe0f\ud83e\udd1d\ud83e\udd32\ud83d\udc69\u200d\ud83d\udc69\u200d\ud83d\udc67\u200d\ud83d\udc66\ud83d\udc68\u200d\ud83d\udc68\u200d\ud83d\udc67\u200d\ud83d\udc66\ud83d\udc40\ud83d\ude4f\ud83d\udc48.", "Madness! To be enraged with a dumb thing, Captain Ahab, seems blasphemous.": "\ud83d\ude31! \ud83d\ude21\ud83d\ude24\ud83c\udd9a\ud83e\udd10\ud83e\udd16, \ud83e\uddd1\u200d\u2708\ufe0f\ud83d\udc33, \ud83d\ude07\ud83d\ude45\u200d\u2642\ufe0f\u26ea\ufe0f.", "the line is running": "\ud83d\udd32\u2796\ud83d\udd32\ud83c\udfc3\u200d\u2642\ufe0f", "Consider the subtleness of the sea; how its most dreaded creatures glide under water, unapparent for the most part": "\ud83e\udd14\ud83c\udf0a\ud83e\udd0f\ud83d\udc0b\ud83d\udc40\ud83d\udca7\u2b07\ufe0f\ud83d\udeab\ud83d\udc40\u23f0\u27a1\ufe0f\ud83e\udd0f\ud83d\udd0d", "hint nothing": "\ud83d\udca1\u274c", "we are sown in dishonor, but raised in glory": "\ud83d\udc65\ud83c\udf31\u27a1\ufe0f\ud83d\udc4e\ud83c\udffb\ud83d\udd2e, \u2197\ufe0f\ud83d\udc6b\ud83c\udf89\u27a1\ufe0f\ud83c\udf1f\u2728", "all collapsed, and the great shroud of the sea rolled on as it rolled five thousand years ago": "\ud83d\udcaf\ud83d\udcc9, \u2795 \ud83c\udf0a\ud83d\udea9\ud83c\udf0a \ud83d\udd04 \u27a1\ufe0f \ud83d\udd01 5\ufe0f\u20e30\ufe0f\u20e30\ufe0f\u20e30\ufe0f\u20e3\ud83d\udcc6 \ud83d\udc48", "speak, mighty head, and tell us the secret thing that is in thee": "\ud83d\udde3\ufe0f, \ud83d\udcaa\ud83d\udc64, \ud83e\udd2b\ud83d\udde3\ufe0f\u261d\ufe0f\ud83e\udd14\ud83d\udd10\ud83c\udf81\ud83d\udc49\ud83c\udffb\u2764\ufe0f", "what after all canst thou do, but tell the poor, pitiful point, where thou thyself happenest to be on this wide planet": "\u2753\u27a1\ufe0f\ud83d\udd1a\u2753\u2754\ud83d\udc49\ud83d\udcd6\ud83d\udcac\ud83d\udcb0\ud83d\udc4e\ud83d\ude22\ud83d\udccd\ud83c\udf0d\u2b06\ufe0f\ud83d\udc49\u26a1\ud83d\udcab\ud83d\ude4b\u200d\u2642\ufe0f\ud83c\udf0e", "how nobly it raises our conceit of the mighty, misty monster, to behold him solemnly sailing through a calm tropical sea; his vast, mild head overhung by a canopy of vapour": "\ud83e\udd14\ud83c\udfa9\ud83d\udc4f\ud83d\ude80\ud83d\udc46\ud83d\ude44\ud83d\ude24\ud83e\udddf\u200d\u2642\ufe0f\ud83c\udf2b\ufe0f, \ud83d\udc40\ud83d\udc49\ud83d\udd4d\ud83d\udef3\ufe0f\ud83c\udfde\ufe0f\ud83c\udf34\ud83c\udf0a; \ud83d\udc49\ud83d\udc0b, \ud83d\udd4a\ufe0f\ud83d\udc64\ud83d\udca6\u2601\ufe0f\ud83c\udf2b\ufe0f\ud83c\udfaa", "Your only salvation lies in eluding it": "\ud83d\udc49\ud83d\udd79\ufe0f\ud83d\udd10\ud83d\udca1\u2b07\ufe0f\ud83d\udc83\ud83d\ude45\u200d\u2642\ufe0f\ud83d\udd2e", "that famous great tierce is mystically carved in front": "\u2728\ud83d\udc51\ud83c\udfb5\ud83c\udfbc\ud83d\udd2e\u270d\ufe0f\ud83d\udc40\ud83d\udd1d", "our beset boat was like a ship mobbed by ice-isles in a tempest": "\ud83d\udc65\ud83d\udef3\ud83c\udfdd\ufe0f\ud83e\udd76\ud83c\udf2a\ufe0f\ud83d\udca2", "this one is very happy and significant": "\u261d\ufe0f\ud83d\ude04\ud83d\udcaf\ud83c\udf1f", "the undeliverable, nameless perils of the whale": "\ud83d\udeab\ud83d\udce8\ud83d\udd16\ud83d\udc0b\u26a0\ufe0f\ud83c\udd98", "And I, you, and he; and we, ye, and they, are all bats; and I\u2019m a crow": "\ud83d\udc64\u2795\ud83d\udc41\ufe0f, \ud83d\udc49\ud83d\udc64, \u2795\ud83d\udc49\ud83d\udeb9; \u2795\ud83d\udc65, \ud83d\udc49\ud83d\udc65, \u2795\ud83d\udc49\ud83d\udc65, \ud83d\udd06\ud83d\udd06\ud83e\udd87; \u2795\ud83d\udc41\ufe0f\ud83d\udd06\ud83d\udd06\ud83e\udd85\ud83d\udda4", "What a really beautiful and chaste-looking mouth!": "'\ud83d\ude2e\u2757\ufe0f\ud83d\udc4c\ud83c\udf1f\ud83d\udc44\u2728\ud83d\udc40\ud83d\udc8e\ud83d\udc8b'", "the eightieth or ninetieth bucket came suckingly up\u2014my God!": "8\ufe0f\u20e30\ufe0f\u20e3\ud83d\udd049\ufe0f\u20e30\ufe0f\u20e3\ud83e\udea3\u2b06\ufe0f\ud83d\udc44\u2b06\ufe0f\u2796\ud83d\ude31\ud83d\ude4f\ud83d\ude4c", "one most perilous and long voyage ended, only begins a second; and a second ended, only begins a third, and so on, for ever and for aye.": "1\ufe0f\u20e3\u26a0\ufe0f\u23f3\u26f5\ufe0f\ud83d\udd1a, \ud83d\udd1c\ud83d\udd1b\ud83d\udd04\u23ed\ufe0f2\ufe0f\u20e3; 2\ufe0f\u20e3\ud83d\udd1a, \ud83d\udd1c\ud83d\udd1b\ud83d\udd04\u23ed\ufe0f3\ufe0f\u20e3, \u27a1\ufe0f\u23e9, 4\ufe0f\u20e3ever\u23ed\ufe0fand 4\ufe0f\u20e3ever\u2795.", "The path to my fixed purpose is laid with iron rails, whereon my soul is grooved to run.": "\ud83d\udee4\ufe0f\u27a1\ufe0f\ud83c\udfaf\ud83d\udca1\ud83d\udd29, \ud83d\ude82\ud83d\udca8\ud83d\udee4\ufe0f, \ud83d\udcab\ud83d\udee4\ufe0f\ud83c\udfc1\ud83c\udfc3\u200d\u2640\ufe0f\ud83d\udca8.", "far too rich to supply a substitute for butter": "\ud83d\udd2d\ud83d\udcb0\ud83d\udcb0\u27a1\ufe0f\ud83d\udd04\ud83e\uddc8", "skilfully steer clear of all adjacent, interdicted parts, and exactly divide the spine at a critical point": "\ud83c\udfaf\ud83d\udc4c\ud83d\udeab\u2b05\ufe0f\u2b07\ufe0f\u2b06\ufe0f\u27a1\ufe0f\ud83d\udeab\ud83d\udd17\ud83d\udeab\ud83e\udde9, \ud83c\udfaf\u2797\ud83e\uddb4\ud83d\udca5\ud83d\udccd", "But what plays the mischief with this masterly code is the admirable brevity of it, which necessitates a vast volume of commentaries": "\ud83e\udd14\ud83d\udcad\ud83c\udfad\ud83d\udd2e\ud83d\udc68\u200d\ud83d\udcbc\ud83d\udcdc\u2753, \ud83d\udc4c\ud83d\udcaf\ud83d\udd2e\ud83d\udde3\ufe0f\ud83e\udd0f\ud83d\udd1c\ud83d\udcda\ud83d\udcac\ud83d\ude05\ud83d\udcd6\ud83d\udca1.", "where your treasure is, there will your heart be also.": "\ud83d\udccd\ud83d\udcb0, \u2764\ufe0f\ud83d\udd1c\ud83d\udc48", "for days and days we voyaged along, through seas so wearily, lonesomely mild, that all space, in repugnance to our vengeful errand, seemed vacating itself of life before our urn-like prow": "\ud83d\udcc6\ud83d\udcc6\ud83d\udd04\ud83d\udea2, \ud83c\udf0a\ud83d\ude29\ud83d\ude14\ud83c\udf3c, \ud83c\udf0c\ud83d\udd04\ud83d\udc40\ud83d\udeab\ud83d\udc0c, \ud83d\udc7b\ud83d\udeab\ud83d\udc64\ud83e\udd12\ud83d\udeb6\u200d\u2640\ufe0f\ud83d\uddff\u26f5\ufe0f", "he is in a prodigious commotion, the water cascading all around him": "\ud83d\udc68\u200d\ud83e\uddb0\u27a1\ufe0f\ud83c\udf00\ud83c\udf0a\ud83d\udca6\ud83d\udd04\u21a9\ufe0f\ud83d\udc68\u200d\ud83e\uddb0", "not the most exhilarating conception of what the most exalted potency is": "\ud83d\udeab\ud83d\udd1d\ud83e\udd29\ud83d\udca1\ud83e\udd14\ud83d\udcad\ud83d\udcaa\ud83d\udd1d\ud83c\udf1f\ud83d\udc4a\u26a1", "Nor is the history of fanatics half so striking in respect to the measureless self-deception of the fanatic himself": "\ud83d\udeab\u27a1\ufe0f\ud83d\udcda\ud83c\udf00\ud83e\udd2a1\ufe0f\u20e3/2\ufe0f\u20e3\u26a1\ud83c\udfaf\ud83d\udccf\ud83e\udd14\ud83e\udd25\ud83c\udf00\ud83e\udd2a\ud83d\ude46\u200d\u2642\ufe0f\ud83d\udcad", "Are you a believer in ghosts, my friend? There are other ghosts than the Cock-Lane one, and far deeper men than Doctor Johnson who believe in them.": "\ud83e\udd14\u2753\ud83d\udc7b\ud83d\udc48\ud83d\udc49, \ud83d\udc65\ud83e\udd1d? \ud83d\udc7b\ud83d\udc48\ud83d\udc49\ud83d\udc65\ud83c\udfa9 \ud83d\udc7b\ud83d\udcd6\ud83d\udc49\ud83d\udee3\ufe0f\ud83c\uddec\ud83c\udde7\ud83d\udc7b, \ud83d\udc49\ud83d\udcda\ud83d\udc64\ud83d\udc68\u200d\u2695\ufe0f\ud83d\udc64\ud83d\udc49\ud83d\udcad\ud83d\udc65\ud83d\udc48\ud83d\udc49\ud83d\udc7b.", "as the swift monster drags you deeper and deeper into the frantic shoal, you bid adieu to circumspect life": "\ud83d\udd50\ud83e\udd89\ud83d\udc09\ud83d\udc4b\ud83d\udc65\ud83d\udd3d\ud83d\udd3d\u27a1\ufe0f\ud83c\udf00\ud83d\udc20\ud83d\udd3d, \ud83d\udc64\ud83d\udc4b\ud83d\udc4b\ud83d\udd04\ud83d\udcbc\ud83d\udd0d\ud83d\udd0d\ud83d\udd0d\ud83c\udf33\ud83c\udf33\ud83c\udf33\ud83c\udfde\ufe0f", "make modern history a liar": "\ud83d\udd28\ud83d\udd04\ud83d\udcda\ud83d\udd70\ufe0f\ud83e\udd25", "strange subterranean commotions": "\ud83d\udc7d\ud83d\udd73\ufe0f\ud83c\udf0e\ud83d\udd00", "this vast fleet of whales": "\ud83d\udc49\ud83c\udf0a\ud83d\udc0b\ud83d\udc0b\ud83d\udc0b", "Ahab is for ever Ahab, man. This whole act\u2019s immutably decreed.": "\ud83c\udd70\ufe0fhab\u27a1\ufe0f\ud83d\udd02\ud83c\udd70\ufe0fhab, \ud83d\udc68. \ud83c\udfad\u27a1\ufe0f\ud83d\udd12\ud83d\udcdc\ud83d\udcac.", "that pale phosphorescence, like a far away constellation of stars": "\u2728\ud83e\udd0d\ud83d\udcab\ud83c\udf1f\ud83c\udf0c\ud83d\udc40\ud83c\udf20\ud83d\udd2d\ud83c\udf1f\ud83c\udf0c\ud83c\udf20\u2b50\ud83c\udf1f\ud83c\udf0c\ud83d\udccd\ud83d\udd2d\ud83d\uddfa\ufe0f\ud83c\udf20", "I like a good grip; I like to feel something in this slippery world that can hold, man.": "\ud83d\udc4d\ud83d\udc97\ud83d\udc4c\ud83d\udcaa\ud83d\ude0a; \ud83d\udc4d\ud83d\udc97\ud83d\udc49\ud83d\udc48\ud83d\udc40\ud83c\udf0e\ud83c\udf28\ufe0f\ud83d\udeab\ud83d\udc4b,\ud83e\uddd1\u200d\ud83e\uddb1.", "so spent was he by loss of blood, that he helplessly rolled away from the wreck he had made": "\ud83d\ude2b\ud83d\udc89\ud83e\ude78\u27a1\ufe0f\ud83d\ude35\ud83d\udd04\u23e9\ud83d\udeab\ud83c\udd98\ud83d\ude97\ud83d\udca5\ud83d\udd28\ud83d\udeae", "Oh, horrible vultureism of earth! from which not the mightiest whale is free.": "\ud83d\ude31\ud83d\udc4e\ud83e\udd85\ud83c\udf0d! \u27a1\ufe0f\ud83d\udeab\ud83d\udc0b\ud83d\udd1d\ud83d\udcaa\u26d4\ud83c\udd93.", "Science! Curse thee, thou vain toy; and cursed be all the things that cast man\u2019s eyes aloft to that heaven": "\ud83d\udd2c\u2757\ufe0f\ud83e\udd2c\ud83d\udc49, \ud83d\udc49\ud83c\udfad\ud83d\udca1; \ud83e\udd2c\ud83d\udc48\ud83c\udffb\ud83d\udc40\ud83d\udc68\u200d\ud83d\udd2c, \ud83e\udd2c\u2757 \ud83c\udf43\ud83e\udd9c\ud83d\ude80\ud83d\udc68\u200d\ud83d\udd2c\ud83d\udc40\ud83d\udc46\u2b06\ufe0f\ud83d\udc49\ud83d\ude4c\ud83c\udf0c", "tumultuous business": "\ud83c\udf2a\ufe0f\ud83d\udcbc", "the invisible police officer of the Fates, who has the constant surveillance of me, and secretly dogs me": "\ud83d\udc7b\ud83d\udc6e\u200d\u2642\ufe0f\u27a1\ufe0f\ud83e\uddf5\ud83d\udd2e, \ud83d\udc41\ufe0f\u200d\ud83d\udde8\ufe0f\ud83d\udc64\ud83d\udd04, \ud83d\udd75\ufe0f\u200d\u2642\ufe0f\ud83d\ude4a\ud83d\udc36\ud83d\udc64", "and like wilful travellers in Lapland, who refuse to wear coloured and colouring glasses upon their eyes, so the wretched infidel gazes himself blind at the monumental white shroud that wraps all the prospect around him": "\ud83d\udd00\ud83d\udc4d\ud83d\udeb6\u200d\u2640\ufe0f\ud83d\udeb6\u200d\u2642\ufe0f\ud83e\uddf3\ud83e\uddca\ud83c\uddeb\ud83c\uddee, \ud83d\udeab\ud83d\udc53\ud83c\udf08\ud83d\udc41\ufe0f, \ud83d\ude41\ud83d\udd4b\ud83d\ude45\u200d\u2642\ufe0f\ud83d\udc40\ud83d\udd06\ud83d\ude35\u2b1c\u26b0\ufe0f\ud83c\udf2b\ufe0f\ud83d\udd01\ud83d\udc41\ufe0f\ud83d\udc40\ud83c\udfaf\ud83d\udc40", "with tornado brow, and eyes of red murder, and foam-glued lips, Ahab leaped after his prey": "\ud83c\udf2a\ufe0f\ud83d\udc41\ufe0f, \ud83d\udd34\ud83d\udc41\ufe0f\ud83d\udd2a, \ud83d\udca6\ud83d\udc8b, Ahab \ud83c\udfc3\u200d\u2642\ufe0f\ud83c\udff9\ud83d\udc33", "stand just where you stood before, there, over against me, and pay particular attention": "\ud83d\udd74\ufe0f\u23ea\ud83d\udccd\ud83d\udc65\ud83d\udc48\ud83d\udeb6\u200d\u2640\ufe0f\ud83e\udd14\ud83d\udc49\ud83e\udec2\ud83d\udc65\ud83d\udcb0\ud83d\udcbc\ud83d\udd0e\ud83d\udc41\ufe0f", "their wondrous voracity can be at times considerably diminished, by vigorously stirring them up": "\ud83d\udc65\ud83c\udf08\ud83d\ude32\ud83e\udd88\ud83c\udf74\ud83d\udc49\ud83d\udd70\ufe0f\u2195\ufe0f\ud83d\udcaa\ud83d\udcc9, \ud83d\udd04\ud83d\udcaa\ud83d\udd00\ud83c\udd99", "Humph! in my poor, insignificant opinion, I regard this as queer.": "\ud83d\ude24! \ud83d\udc49\ud83c\udffc\ud83d\ude14\ud83d\udc64\ud83d\udcad, \ud83d\udc41\ufe0f\ud83e\udd14\ud83d\udc48\ud83c\udffc\ud83d\udc65\ud83d\udc4d\ud83c\udffc\ud83e\udd28.", "And I\u2019m thinking Moby Dick doesn\u2019t bite so much as he swallows.": "\ud83d\udcad\ud83d\udc65\ud83e\udd14\ud83d\udc0b\ud83d\udcad Moby Dick \ud83d\udeab\ud83e\uddb7\ud83c\udf74\ud83d\udc65\ud83d\udcad\ud83d\udc4c\ud83c\udffe\ud83e\udd5b\ud83c\udf76\ud83d\udc65\ud83d\udcad", "Drat the file, and drat the bone! That is hard which should be soft, and that is soft which should be hard.": "\ud83d\ude20\ud83d\udcbe, \ud83d\ude20\ud83e\uddb4! \ud83d\ude2b\ud83d\udca2\ud83d\udc49\ud83c\udffb\ud83e\uddf1\ud83d\udd39\ud83d\ude44\ud83c\udf6e, \ud83d\ude2b\ud83c\udf6e\ud83d\udc49\ud83c\udffb\ud83d\udca2\ud83e\uddf1\ud83d\udd39\ud83d\ude44.", "amid the tornadoed Atlantic of my being, do I myself still for ever centrally disport in mute calm": "\ud83c\udf2a\ufe0f\ud83c\udf0a\ud83d\udd04\ud83c\udf10\ud83d\udc96, \ud83e\udd14\ud83d\udc64\ud83e\udd10\u270c\ufe0f\u23f0\ud83c\udf00\ud83e\udd2b\u262e\ufe0f", "little hears he or heeds he the far rush of the mighty whale, which even now with open mouth is cleaving the seas after him": "\ud83d\udc66\ud83d\udc42\u274c\ud83d\udc40\ud83d\udc42\u274c\u27a1\ufe0f\ud83d\udd2d\ud83c\udf0a\ud83d\udc0b, \ud83d\udd04\ud83d\udd52\ud83d\udc44\ud83d\udd13\ud83d\udd2a\ud83c\udf0a\ud83c\udfc3\u200d\u2642\ufe0f\ud83d\udea8", "However curious it may seem for an oil-ship to be borrowing oil on the whale-ground, and however much it may invertedly contradict the old proverb about carrying coals to Newcastle, yet sometimes such a thing really happens": "\ud83e\udd14\u2753\ud83d\udd0d\ud83d\udee2\ufe0f\u26f4\ufe0f\ud83d\udd04\u23f2\ufe0f\ud83d\udc33\ud83c\udf0a\ud83e\udd47\ud83d\udee2\ufe0f\ud83d\udeab\ud83d\udd04\ud83e\udd48\ud83d\udd25\ud83c\udf56\ud83d\udd04\ud83c\udff0\ud83d\udeb6\u200d\u2642\ufe0f\ud83c\uddec\ud83c\udde7\u23f3\ud83d\udd04\ud83c\udfb2\ud83c\udf40\ud83d\udcaf\ud83d\udd03\ud83e\udd37\u200d\u2642\ufe0f", "The sea was as a crucible of molten gold, that bubblingly leaps with light and heat.": "\ud83c\udf0a\u27a1\ufe0f\ud83d\udd25\ud83d\udd25\ud83e\udd47\ud83c\udffa, \ud83c\udf0b\ud83d\udd06\ud83d\udca1\ud83d\udca5\ud83d\udd25\ud83d\udd25\ud83d\udd25", "attending to a whale": "\ud83d\udc65\ud83d\udc49\ud83d\udc0b", "It\u2019s the first foul wind I ever knew to blow from astern": "\u261d\ufe0f\ud83e\udd47\ud83c\udf2c\ufe0f\ud83d\udc4e\ud83d\ude37\ud83c\udf2c\ufe0f\ud83d\udca8\ud83d\udd04\u2b05\ufe0f\ud83d\udea4", "by no means prevent all communications": "\ud83d\udeab\u270b\ud83d\udeab\u26d4\ufe0f\ud83d\udd01\ud83d\udc8c\ud83d\udcde\ud83d\udce1\ud83d\udce2\ud83d\udcac", "the universal thump is passed round": "\ud83c\udf0d\ud83d\udc4a\ud83d\udd04\ud83d\udd01", "a night, a day, and still another night": "\ud83c\udf03, \ud83c\udf05, \ud83c\udf03", "Posted like silent sentinels all around the town, stand thousands upon thousands of mortal men fixed in ocean reveries.": "\ud83d\udccc\ud83e\udd2b\ud83d\udc65\ud83d\udd04\ud83c\udfd8\ufe0f, \u23eb\ud83d\udd74\ufe0f\ud83d\udd74\ufe0f\ud83d\udd74\ufe0f\ud83d\udcad\ud83c\udf0a\ud83c\udf0a\ud83c\udf0a.", "showers of gore": "\ud83d\udebf\ud83d\udca7\ud83e\ude78\ud83d\ude31", "all thy strange mummeries not unmeaningly blended with the black tragedy of the melancholy ship, and mocked it": "\ud83d\udc65\ud83c\udfad\ud83d\udd2e\u274c\ud83d\udd04\ud83d\ude11\ud83c\udfad\ud83d\udd32\ud83c\udfad\ud83d\ude14\u26f5\ud83d\ude05\ud83e\udd21", "even in his lowest swoop the mountain eagle is still higher than other birds upon the plain, even though they soar": "\ud83d\udd3d\ud83e\udd85\ud83c\udfd4\ufe0f\u27a1\ufe0f\ud83d\udd1d\ud83d\udc26\ud83c\udf3e\ud83c\udf0c\ud83c\udd99\ud83d\udc26\u26f0\ufe0f\ud83d\udd1d\ud83c\udf00", "when you are close enough to a whale to get a close view of his spout, he is in a prodigious commotion, the water cascading all around him": "\ud83d\udd50\ud83d\udc49\ud83e\udd0f\ud83d\udccf\ud83d\udc0b\ud83d\udc41\ufe0f\ud83d\udd0d\ud83d\udeb0\ud83d\udca8, \ud83d\udc0b\ud83c\udf00\ud83c\udf0a\ud83c\udf2a\ufe0f\ud83d\udca6\u2935\ufe0f\u2b55\ud83d\udc0b", "She was Rachel, weeping for her children, because they were not.": "\ud83d\udc69\u200d\ud83e\uddb0\ud83d\udd1c\ud83d\udc75(Rachel)\ud83d\ude22\ud83d\ude2d\ud83d\udc69\u200d\ud83d\udc67\u200d\ud83d\udc66\ud83d\udc76,\ud83d\udc49\u274c.", "how vast, then, the burden of a whale, bearing on his back a column of two hundred fathoms of ocean!": "\ud83e\udd14\ud83c\udf0c\ud83e\udd14, \ud83d\udc49\u23f1\ufe0f, \ud83d\udc0b's \ud83d\udce6\ud83d\udd1b\ud83d\udd19, \ud83c\udfcb\ufe0f\u200d\u2642\ufe0f\ud83c\udfdb\ufe0f\ud83d\udd1d2\ufe0f\u20e30\ufe0f\u20e30\ufe0f\u20e3 \u26f2\ud83c\udf0a!", "eat him by his own light": "\ud83c\udf7d\ufe0f\ud83d\udc68\ud83d\udd6f\ufe0f\ud83d\udca1", "And for this I thank God; for all have doubts; many deny; but doubts or denials, few along with them, have intuitions.": "\ud83d\udc65\u2795\ud83d\udc49\ud83d\ude4f\ud83d\ude4c\u261d\ufe0f; \ud83d\udc65\ud83d\udc40\u2753; \ud83d\ude2e\ud83d\ude45\u200d\u2642\ufe0f; \u2753\ud83d\udeab, \ud83d\udc65\ud83e\udd0f\u2795\u2b05\ufe0f\ud83e\udde0\ud83d\udca1.", "No roses, no violets, no Cologne-water in the sea.": "\ud83d\udeab\ud83c\udf39, \ud83d\udeab\ud83d\udc9c, \ud83d\udeab\ud83c\udf7e\ud83d\udca6\ud83c\udf0a", "In the title-page of the original edition of the \u201cAdvancement of Learning\u201d you will find some curious whales.": "\ud83d\udcd6\ud83d\udca1\ud83d\udd0d\ud83d\udcda\u27a1\ufe0f\"Advancement of Learning\"\ud83d\udc40\ud83d\udd0d\u27a1\ufe0f\ud83d\udc40\ud83d\udc0b\ud83d\udc0b\ud83d\udc0b\ud83e\udd14\ud83d\udca1", "Take away the tied tendons that all over seem bursting from the marble in the carved Hercules, and its charm would be gone.": "\ud83d\udc49\ud83d\udeab\u27b0\ud83d\udcaa\ud83c\udffc\ud83d\udd00\ud83c\udf0d\ud83d\udca5\ud83d\uddff\ud83d\udd0d\ud83d\udd75\ufe0f\u200d\u2642\ufe0f\ud83c\udfad\ud83d\uded1\ud83d\udd2e\ud83c\udf0c\ud83c\udf08\ud83d\udc4b\ud83d\udd2e\ud83d\udd1a\ud83d\udd31\ud83d\udea6\u2696\ufe0f\ud83c\udfde\ufe0f\ud83c\udf0c\ud83c\udfdb\ufe0f\ud83c\udfad", "slide bravely": "\ud83d\udef7\ud83d\udcaa", "grease the bottom": "\ud83e\uddc8\u2b07\ufe0f\ud83c\udf51", "Come, why don\u2019t some of ye burst a blood-vessel?": "\ud83d\udc49\ud83e\udd37\u200d\u2640\ufe0f, \ud83e\udd14 \u2753don't\ud83d\udeab some\ud83d\udc65 of you\ud83d\udc48\ud83d\udca5 burst\ud83d\udca2 a blood-vessel\ud83c\udd71\ufe0f\ud83d\udc89?", "the luckless mate, so full of furious life, was smitten bodily into the air, and making a long arc in his descent, fell into the sea": "\ud83c\udf40\u274c\ud83d\udc6b, \ud83d\ude21\ud83d\udca5\ud83d\udcaf\ud83d\udc93, \ud83d\udca5\u2708\ufe0f\u27a1\ufe0f\ud83c\udf2c\ufe0f, \ud83c\udff9\ud83c\udf08\ud83c\udf00\ud83d\udd3b, \ud83c\udf0a\ud83c\udfaf\ud83c\udfca\u200d\u2642\ufe0f", "throbbing and heaving just below the surface of the sea": "\ud83d\udc93\ud83c\udf0a\ud83d\udcaa\ud83d\udc47\u2b07\ufe0f\ud83c\udf0a", "Away, and bring us napkins!": "\ud83c\udfc3\u200d\u2642\ufe0f\ud83d\udca8, \ud83d\udd04\ud83d\udd1c\ud83d\udd3d\ud83e\uddfb!", "Do you not marvel, then": "\u2753\ud83d\ude2e\ud83d\udeab\ud83e\udd14\u2728\ud83c\udf1f\ud83d\udc48", "In fact take my body who will, take it I say, it is not me.": "\ud83d\udcd6\u2b07\ufe0f\ud83d\udc65\ud83d\udce5\ud83e\udd32\ud83d\udc49\ud83e\uddcd\u200d\u2642\ufe0f\ud83e\udd37\u200d\u2642\ufe0f,\ud83d\udce5\ud83d\udde3\ufe0f,\ud83d\udeab\ud83d\ude4b\u200d\u2642\ufe0f\ud83d\ude46\u200d\u2642\ufe0f.", "Wish, by gor! whale eat him, \u2019stead of him eat whale. I\u2019m bressed if he ain\u2019t more of shark dan Massa Shark hisself": "\ud83c\udf20, \u2693! \ud83d\udc33\u27a1\ufe0f\ud83c\udf7d\ufe0f him, \u21a9\ufe0f of him \ud83c\udf7d\ufe0f\ud83d\udc33.  \ud83d\ude04 \ud83c\udf1f if he ain't \ud83d\udd1d of \ud83e\udd88 than \ud83d\udc71\ud83e\udd88 himself", "It is still colossal.": "\ud83d\udca1\u23f3\ud83d\udd0d\ud83d\uddfb", "So on I went.": "\ud83d\udc49\ud83d\udeb6\u200d\u2642\ufe0f\ud83d\udd1b", "He is the great prize ox of the sea, too fat to be delicately good.": "\ud83d\udc68\u200d\ud83e\uddb0\ud83c\udfc6\ud83d\udc02\ud83c\udf0a, \u2b06\ufe0f\ud83c\udf54\ud83e\udd0f\ud83d\udc4c\ud83c\udf74.", "I now know thee, thou clear spirit, and I now know that thy right worship is defiance.": "\ud83d\udca1\ud83d\udc41\ufe0f\ud83d\udc49\u2728\ud83d\udc7b\u26a1, \ud83d\udc41\ufe0f\ud83d\udca1\ud83d\udd25\ud83d\ude4f\u27a1\ufe0f\ud83d\udc49\u270a\ud83c\udd97.", "I stand alone here upon an open sea, with two oceans and a whole continent between me and law.": "\ud83d\udc64\ud83d\udd74\ufe0f\ud83d\udeb6\u200d\u2642\ufe0f\ud83d\udc64\ud83c\udf0a\ud83c\udf0a\ud83c\udf0e\ud83c\udf0d\ud83c\udf0f\ud83c\udfde\ufe0f\ud83c\udfdd\ufe0f\ud83d\uddfd\ud83c\udfdb\ufe0f\u2696\ufe0f\ud83d\udd17\ud83d\udd12\u2694\ufe0f\ud83d\udee1\ufe0f\ud83d\udec4\ud83d\udec5\ud83d\udea7\ud83d\udeaf\ud83d\udeb7\ud83d\udeb3\u26d4\ud83d\udcdb\ud83d\udd1e\ud83d\udd1a\ud83d\udd19\ud83d\uded1\ud83d\udec7\ud83d\udec8\u26a0\ufe0f\u26d4\u203c\ufe0f\ud83d\udcf5\ud83d\udeab\ud83e\uddf3\ud83d\udc6f\u200d\u2640\ufe0f\ud83d\udd16\ud83d\udcdd\ud83d\udce9\ud83d\udce8\ud83d\udce7\ud83d\udc8c\ud83d\udce5\ud83d\udce4\ud83d\udce6\ud83d\udceb\ud83d\udcea\ud83d\udcec\ud83d\udd12\ud83d\udcd1\ud83d\udcbc\ud83c\udf0a\ud83c\udf0d.", "Your hat, however, is the most convenient.": "\ud83d\udc49\ud83c\udfa9, \u27a1\ufe0f, \ud83c\udfc6\ud83e\udd47\ud83c\udfc6, \ud83d\ude4c\u23f1\ufe0f\ud83d\udc4d\ud83c\udd92.", "you cannot sit motionless in the heart of these perils, because the boat is rocking like a cradle, and you are pitched one way and the other, without the slightest warning": "\u274c\ud83d\udeab\ud83d\udcba\ud83d\udeb6\u200d\u2642\ufe0f\u27a1\ufe0f\u2764\ufe0f\ud83d\udc94\ud83c\udf0b\u26a0\ufe0f, \ud83d\udea3\u200d\u2642\ufe0f\ud83d\udd04\ud83d\udc76\ud83d\udecc, \ud83d\ude80\u2194\ufe0f\ud83d\udd04, \ud83d\udeab\u26a0\ufe0f\u23f0\ud83d\udd14", "amid the chips of chewed boats, and the sinking limbs of torn comrades, they swam out of the white curds of the whale\u2019s direful wrath into the serene, exasperating sunlight": "\ud83c\udf0a\ud83d\udee5\ufe0f\ud83d\udd73\ufe0f, \ud83e\udd14\ud83d\udcad\ud83d\udea3\u200d\u2642\ufe0f\ud83d\udeab\ud83d\udd2a\ud83d\udc65, \ud83c\udfca\u200d\u2642\ufe0f\u2b05\ufe0f\u26aa\ud83c\udf66\ud83d\udc0b's \ud83d\ude31\ud83d\ude21\u27a1\ufe0f\ud83c\udf1e\ud83d\ude0c\ud83e\udd75\ud83d\udd76\ufe0f", "even these brawny, buoyant heroes do sometimes sink.": "\ud83d\udcaa\ud83d\ude0e\ud83e\uddb8\u200d\u2642\ufe0f\ud83e\uddb8\u200d\u2640\ufe0f\u2728\ud83c\udf0a\u2b07\ufe0f\ud83d\ude14", "The urbane activity with which a man receives money is really marvellous": "\ud83c\udfd9\ufe0f\ud83c\udfc3\u200d\u2642\ufe0f\ud83d\udd01\ud83d\udc68\ud83d\udcb0\ud83d\udcab\ud83e\udd2f", "by those clanking links, the vast corpse itself, not the ship, is to be moored": "\ud83d\udc49\ud83d\udd17\ud83d\udd17, \ud83d\uddfa\ufe0f\ud83d\udc80\ud83d\ude31, \ud83d\udeab\u26f5, \ud83d\udd12\u2693\ud83d\udccc", "Such dreary streets! blocks of blackness, not houses, on either hand, and here and there a candle, like a candle moving about in a tomb.": "\ud83d\ude29\ud83c\udf27\ufe0f\ud83d\udee3\ufe0f! \u2b1b\u2b1b\u2b1b, \ud83d\udeab\ud83c\udfe0, \ud83d\udc50\ud83d\udc50, \ud83d\udccd\ud83d\udd6f\ufe0f, \ud83e\uddc8\ud83d\udd6f\ufe0f\ud83d\udeb6\u200d\u2642\ufe0f\ud83d\udd04\u26b0\ufe0f.", "man has lost that sense of the full awfulness of the sea which aboriginally belongs to it": "\ud83d\udc68\u200d\ud83e\uddb3\ud83d\udd0d\ud83e\udd37\u200d\u2642\ufe0f\ud83d\udc40\ud83d\udc49\ud83c\udf0a\ud83d\ude31\u27a1\ufe0f\ud83d\udcaf\ud83e\udd1a\ud83e\udea8\ud83d\udc48", "For truly, the Right Whale\u2019s mouth would accommodate a couple of whist-tables, and comfortably seat all the players.": "\u2611\ufe0f\ud83d\udcaf, \ud83d\udc0b\ud83d\udc44\u27a1\ufe0f\ud83c\udfaf\ud83e\ude91\ud83e\ude91\ud83c\udccf\ud83c\udccf, \ud83e\udd17\ud83d\udcba\ud83e\ude91\ud83d\ude46\u200d\u2640\ufe0f\ud83d\ude46\u200d\u2642\ufe0f\ud83d\ude46\u200d\u2640\ufe0f\ud83d\ude46\u200d\u2642\ufe0f\ud83d\udd79\ufe0f.", "But why should the King have the head, and the Queen the tail?": "\u2753\ud83d\udc51\ud83d\udcad\ud83e\udd34\ud83c\udf81\ud83d\udc64\ud83d\udca1\ud83d\udc69\u200d\ud83e\uddb2, \ud83d\udc78\ud83c\udf81\ud83d\udc64\ud83d\udc0d\ud83d\udc48?", "my body is but the lees of my better being": "\ud83d\udcad\u27a1\ufe0f\ud83d\udc64, \ud83d\udc65\ud83d\udcaa\ud83d\ude47\u200d\u2642\ufe0f\u27a1\ufe0f\u23f3\ud83c\udd9a \ud83d\ude80\ud83d\udcab\ud83d\udc98\u2600\ufe0f\ud83d\udc64\ud83d\udd1d\ud83d\ude07\ud83c\udf1f", "these scraps are called \u201cfritters\u201d; which, indeed, they greatly resemble, being brown and crisp, and smelling something like old Amsterdam housewives\u2019 dough-nuts": "\ud83d\udc49\ud83d\uddd1\ufe0f\ud83d\udd0e\ud83c\udf58 \"fritters\" \ud83d\udc48, \ud83c\udfde\ufe0f, \ud83c\udf58\ud83d\udd0d, \ud83d\udfe4\ud83e\udd50\ud83d\udd25, \ud83d\udc43 \ud83c\udf69\ud83d\udc75\ud83c\udfe0\ud83c\uddf3\ud83c\uddf1\ud83c\udf69", "There are some enterprises in which a careful disorderliness is the true method.": "\ud83d\udc65\ud83d\udd0d\ud83d\udcbc\u26a0\ufe0f\ud83c\udf10, \ud83d\udd04\ud83d\udcc8\ud83e\udde9\ud83d\udd0d\ud83d\ude4c\ud83c\udd97\u2696\ufe0f\ud83d\udc4d", "the spermaceti itself, how bland and creamy that is": "\ud83d\udc33\ud83d\udca6\u27a1\ufe0f\ud83d\udc48,\ud83e\udd14\ud83c\udf66\ud83c\udf68\ud83d\ude0b", "all the attending marvels of a thousand Patagonian sights and sounds": "\ud83d\udc40\ud83d\udc42\ud83c\udf0d\u2728\ud83c\udf08\ud83d\udcab\ud83d\udca5\u26a1\ufe0f\ud83c\udfde\ufe0f\ud83c\udf05\ud83c\udf0c\ud83d\udcaf\ud83d\udd31\ud83c\udde6\ud83c\uddf7\ud83d\udcf7\ud83c\udfb6\ud83c\udfb5\ud83c\udfa7", "Nothing will content them but the extremest limit of the land": "\ud83d\udeab\ud83e\udd32\ud83c\udd92\ud83d\udc65\ud83d\udd1d\ud83d\udd1a\ud83c\udf0d\ud83c\udf04", "For hours and hours from the almost stationary ship that hideous sight is seen.": "\u23f3\u23f3\u23f3\ud83d\udea2\ud83d\udd1b\ud83d\udd1d\u23f9\ufe0f\ud83d\ude31\ud83d\udc40\u27a1\ufe0f", "I here saw but a few disordered joints; and in place of the weighty and majestic, but boneless flukes, an utter blank!": "\ud83d\udc41\ufe0f\ud83d\udccd\ud83d\udc40\ud83d\udd0d\ud83d\udc47\ud83e\udea2\ud83e\udea2\ud83e\ude79; \u2795\ud83d\udd04\ud83d\udccd\u2696\ufe0f\ud83d\udc51\ud83d\ude0c, \ud83d\udd2e\ud83c\udf56\ud83d\udc80\ud83d\udc0b\ud83d\udc4f, \u2757\ud83d\udcac\u274c\ud83e\udd37\u200d\u2642\ufe0f\u2757", "The weaver-god, he weaves; and by that weaving is he deafened, that he hears no mortal voice": "\ud83d\udd78\ufe0f\ud83d\udc68\u200d\ud83c\udf3e\ud83d\udc7c, \ud83d\udc68\u200d\ud83c\udf3e\ud83e\uddf6; \u2795\ud83e\uddf6\ud83e\udd2b\ud83d\udc42, \ud83d\udc42\ud83d\ude45\u200d\u2642\ufe0f\ud83d\udd0a\ud83d\ude4e\u200d\u2642\ufe0f\ud83d\udde3\ufe0f", "This is a nasty night, lad.": "\ud83d\udc49\ud83e\udd2c\ud83c\udf1a\ud83e\uddd1\u200d\ud83e\uddb0", "prolonged and exhausting": "\ud83d\udd04\ud83d\udd70\ufe0f\ud83d\ude2b", "With oars apeak, and paddles down, the sheets of their sails adrift, the three boats now stilly floated, awaiting Moby Dick\u2019s reappearance.": "\ud83d\udea3\ud83c\udd99, \ud83d\udea3\u2b07\ufe0f, \u26f5\ufe0f\ud83d\udcc4\ud83d\udd00, \ud83d\udef6\ud83d\udef6\ud83d\udef6\ud83d\udd07\u26f5\ufe0f, \u23f1\ufe0f\ud83d\udc33\ud83d\udd04.", "while other ships may have gone to China from New York, and back again, touching at a score of ports, the whale-ship, in all that interval, may not have sighted one grain of soil": "\ud83d\udd70\ufe0f\u26f4\ufe0f\ud83d\udc65\ud83d\ude80\u27a1\ufe0f\ud83c\udde8\ud83c\uddf3\ud83d\uddfd\u21a9\ufe0f, \u2795\ud83d\udd19\u2935\ufe0f\ud83d\udd25, \ud83d\udd90\ufe0f\ud83d\udd22\ud83d\udea2\u2693, \ud83d\udc0b\u26f4\ufe0f, \ud83d\udd01\ud83d\udd66, \u274c\ud83d\udc41\ufe0f\ud83c\udf3d\ud83e\uddea\ud83c\udf31\ud83c\udfde\ufe0f", "\u201cSing out for him!\u201d was the impulsive rejoinder from a score of clubbed voices.": "\"\ud83c\udfb5\ud83d\udce2\ud83d\udc68\u200d\ud83c\udfa4!\" \ud83d\ude2e\ud83c\udfac\u21a9\ufe0f\ud83d\udde3\ufe0f\ud83d\udd22\u2795\ud83d\udd22\ud83d\udde3\ufe0f\ud83c\udfcf\ud83d\udce2\ud83d\udde3\ufe0f.", "hell is an idea first born on an undigested apple-dumpling": "\ud83d\udd25\ud83d\ude08\ud83d\udca1\ud83e\udd47\ud83d\udc23\ud83e\udd14\ud83c\udf4f\ud83e\udd5f", "Say you are in the country; in some high land of lakes.": "\ud83d\udde3\ufe0f\ud83d\udc49\ud83c\udffb\ud83d\udc65\ud83d\udccd\ud83c\udf33\ud83c\udfde\ufe0f; \ud83d\udccd\ud83c\udfd4\ufe0f\ud83c\udf0a\ud83c\udf0a.", "Time itself now held long breaths with keen suspense.": "\u23f3\u23f8\ufe0f\ud83d\udd70\ufe0f\ud83d\udd12\ud83d\udd35\ud83d\ude24\u23f1\ufe0f\ud83d\udd2a\ud83d\udd75\ufe0f\u200d\u2642\ufe0f\ud83d\udc40", "as if its vast tides were a conscience": "\ud83e\udd14\ud83d\udcad\ud83c\udf0a\ud83c\udf0a\ud83c\udf0a\ud83d\udd1b\ud83d\udd04\ud83d\udd04\ud83d\udd04\ud83d\udca1\ud83d\udcdc\u2764\ufe0f\ud83d\udd04\ud83d\udd04", "Human or animal, the mystical brow is as that great golden seal affixed by the German emperors to their decrees.": "\ud83d\udc68\ud83d\udc69\ud83d\udc36\ud83d\udc31, the \ud83d\udd2e\u2728\u2b50\ufe0f\ud83d\udc41\ufe0f is like the \ud83c\udff5\ufe0f\ud83d\udd31\ud83d\udd06\ud83d\udcdc\u2705 by the \ud83c\udde9\ud83c\uddea\ud83d\udc51\ud83d\udc78 to their \ud83d\udc51\ud83d\udcdc\u2757\ufe0f", "Ere this, you must have plainly seen the truth of what I started with": "'\ud83d\udc41\ufe0f\ud83d\udc48, you \ud83d\udc65 must \ud83d\udccc have \ud83d\udc4d\ud83d\udd0e seen \ud83d\udc40 the truth \ud83c\udff3\ufe0f of what \ud83e\udd37 I \ud83d\ude4b\u200d\u2642\ufe0f started \ud83c\udfc1 with \u23ed\ufe0f'", "But let us to the story.": "\ud83c\udf51, \ud83d\udcd6\u21aa\ufe0f\ud83d\udc65\ud83d\udd1b\ud83d\udcd6.", "At last his spout grew thick, and with a frightful roll and vomit, he turned upon his back a corpse": "\ud83d\udcab\ud83d\udd52, \ud83d\udc33\ud83d\udca6\ud83c\udf54\ud83d\udcc8, \ud83d\ude31\ud83c\udf00\ud83e\udd2e, \ud83d\udd04\ud83d\udd19\ud83d\udc80", "That ghastly whiteness it is which imparts such an abhorrent mildness, even more loathsome than terrific, to the dumb gloating": "\ud83d\udc7b\ud83e\udd0d\ud83d\udc48\ud83d\ude32, \ud83d\ude16\ud83c\udf66\ud83d\ude37, \u2795\ud83d\ude16\ud83e\udd2e\ud83d\ude31, \ud83e\udd10\ud83d\ude0f\ud83d\udd07.", "Mixed with these were rusty old whaling lances and harpoons all broken and deformed. Some were storied weapons.": "\ud83d\udd00\ud83d\udc65\ud83d\udc49\ud83d\udddd\ufe0f\ud83c\udfda\ufe0f\ud83d\udc33\ud83d\udd31\ud83c\udfa3\ud83d\udc7a\ud83d\udc94\ud83d\udca2\u26a0\ufe0f. \u2694\ufe0f\ud83d\udcdc\ud83d\udd2b\ud83d\ude2e.", "Art thou a silk-worm? Dost thou spin thy own shroud out of thyself?": "\ud83c\udfa8\ud83e\udd14\ud83d\udc1b? \ud83c\udf00\ud83e\uddf5\ud83d\udc80\u2b06\ufe0f\ud83d\udc49\ud83d\udc64?", "human infants while suckling will calmly and fixedly gaze away from the breast, as if leading two different lives at the time": "\ud83d\udc76\ud83c\udf7c\ud83d\ude0c\ud83d\udc40\ud83d\udd04\u27a1\ufe0f\ud83d\udeab\ud83d\udc40\ud83c\udf7c, \u23f3\u27a1\ufe0f\ud83c\udfde\ufe0f\ud83d\udd04 2\ufe0f\u20e3\ud83d\udd00\ud83c\udf0d's\u231b", "with the mad secret of his unabated rage bolted up and keyed in him, Ahab had purposely sailed upon the present voyage with the one only and all-engrossing object of hunting the White Whale": "\ud83d\ude21\ud83d\udd10\ud83e\udd2b\ud83e\udd2c\ud83d\udca2, Ahab \u26f5\ufe0f\ud83c\udf0a\ud83d\udd1b\ud83d\udc33\ud83d\udd0e\u2611\ufe0f\ud83c\udfaf\ud83d\udc0b\u26aa\ufe0f", "your noble conceptions of him are never insulted": "\ud83d\udc49\ud83d\udc51\ud83d\udcad\ud83d\udc64\ud83d\udeab\ud83d\udc4e\ud83d\udc94", "Oh, ye foolish! throw all these thunder-heads overboard, and then you will float light and right.": "\ud83d\ude2e,\ud83d\ude44\ud83e\udd26\u200d\u2642\ufe0f! \ud83e\udd32\ud83d\udd3d\ud83c\udf29\ud83d\uddd1\ufe0f\u2b06\ufe0f, \u21aa\ufe0f\ud83d\udd1c\ud83d\udef6\ud83d\udca1\u2705.", "this velvet paw but conceals a remorseless fang": "\ud83d\udc49\ud83e\uddf6\ud83d\udc3e\ud83d\ude48\ud83e\udd10\ud83d\ude08\ud83e\uddb7", "Ahab is lord over the level loadstone yet.": "\ud83c\udd70\ufe0f\ud83c\udfa9\u2934\ufe0f\ud83d\udc51\ud83d\udccf\ud83d\udd2e\ud83e\uddf2\u23e9.", "It is a way I have of driving off the spleen and regulating the circulation.": "\ud83d\udc49\ud83d\ude97\ud83d\udca81\ufe0f\u20e3\u27a1\ufe0f\ud83d\ude24\ud83d\udcad\ud83d\uddfa\ufe0f\ud83d\udd1c\u274c\ud83e\udd2c\ud83e\ude78\u23ed\ufe0f\ud83d\udc93\ud83d\udd04\ud83d\udd03\ud83d\udd04", "ye grim, phantom futures! Stand by me, hold me, bind me": "\u2620\ufe0f\ud83d\udc7b\ud83d\udd2e\ud83d\udd2e! \ud83e\udd1d\ud83d\ude4f\ud83d\udd17\ud83d\ude4b\u200d\u2642\ufe0f", "Such is the endlessness, yea, the intolerableness of all earthly effort.": "\ud83d\udd04\ud83d\udd01\ud83c\udf0d\ud83d\udcaa\ud83d\ude2b\ud83d\udeab\u26d4\ud83d\ude16", "Where, in the bottomless deeps, could he find the torn limbs of his brother?": "\ud83d\udccd,\ud83d\udd3d\u2b07\ufe0f\ud83d\udd73\ufe0f,\ud83e\udd14\ud83d\udcad,\ud83d\udd75\ufe0f\u200d\u2642\ufe0f\ud83d\udd0d\ud83d\udc94\ud83d\udcaa\ud83d\udc6c\ud83d\udc65\u2049\ufe0f", "The phantoms, for so they then seemed, were flitting on the other side of the deck, and, with a noiseless celerity, were casting loose the tackles and bands of the boat which swung there.": "\ud83d\udc7b\ud83d\udc65, \ud83d\udc65,\ud83d\udc64\ud83d\udd70\ufe0f\ud83d\udcad, \u27a1\ufe0f\ud83d\udca8\u2197\ufe0f\ud83d\udea2\ud83d\udd1b\ud83d\udd1d, \ud83d\udd07\ud83c\udfc3\u200d\u2642\ufe0f\ud83d\udca8, \ud83d\udd13\u2693\ud83d\udef6\ud83d\udd04\ud83d\udd17\ud83d\udc47.", "for a moment or two the prodigious blood-dripping mass sways to and fro as if let down from the sky": "\u23f3\ud83d\udd04\ud83d\udd70\ufe0f, \ud83e\udd2f\ud83d\udd34\ud83d\udc89\ud83e\uddf1\u2696\ufe0f\u2b05\ufe0f\u27a1\ufe0f, \ud83e\udd14\ud83d\udc47\ud83c\udf0c\ud83c\udf24\ufe0f", "one serene and moonlight night, when all the waves rolled by like scrolls of silver; and, by their soft, suffusing seethings, made what seemed a silvery silence, not a solitude; on such a silent night a silvery jet was seen": "1\ufe0f\u20e3\ud83c\udf0c\ud83c\udf15\ud83c\udf03, \ud83c\udf0a\ud83c\udf0a\ud83c\udf0a\ud83d\udcdc\ud83e\udd48; \u2795, \ud83c\udf0a\ud83e\udd2b\ud83e\udd48, \ud83d\udc40\ud83e\udd2b\ud83e\udd48, \u274c\ud83e\udd2b; \ud83c\udf0c\ud83c\udf0c\ud83e\udd2b\ud83e\udd48\u2708\ufe0f\ud83d\udc40", "Yes, a mighty change had come over the fish.": "\ud83d\udc4d, \ud83d\udcaa\ud83d\udd00\ud83d\udd04\ud83d\udd1b\ud83d\udc20.", "Then the whole world was the whale\u2019s; and, king of creation, he left his wake along the present lines of the Andes and the Himmalehs.": "\ud83d\udd1c, \ud83c\udf0d \u27a1\ufe0f \ud83d\udc0b; \ud83d\udc51\ud83c\udf3f, \ud83d\udc0b\ud83d\udee3\ufe0f \u27a1\ufe0f \ud83c\udfde\ufe0f \ud83d\udd04\ud83d\udccd\ud83d\uddfb\ud83d\uddfb (Andes) \u2795 \ud83c\udfd4\ufe0f\ud83c\udfd4\ufe0f (Himalayas).", "we were now in that enchanted calm which they say lurks at the heart of every commotion": "\ud83d\udc65\ud83d\udd70\ufe0f\ud83d\udd04\ud83d\udd1b\ud83c\udf86\u2728\ud83c\udfde\ufe0f\u27a1\ufe0f\ud83d\udc65\ud83d\udde3\ufe0f\ud83d\udc40\u26a0\ufe0f\ud83d\udc96\ud83d\udca0\ud83c\udf2a\ufe0f\ud83c\udf2a\ufe0f\ud83c\udf2a\ufe0f", "a white man standing before him seemed a white flag come to beg truce of a fortress": "\ud83d\udc68\ud83c\udffb\u200d\ud83e\uddb3\ud83d\udd74\ufe0f\ud83d\udd1b\ud83d\udd1d\ud83d\udc65\ud83d\udc40\ud83c\udff3\ufe0f\ud83d\ude4f\ud83e\udd1d\ud83c\udff0", "He lives on the sea, as prairie cocks in the prairie; he hides among the waves, he climbs them as chamois hunters climb the Alps.": "\ud83d\udc68\u200d\ud83e\uddb1\ud83c\udfe0\ud83c\udf0a, \ud83d\udc13\ud83c\udf3e\ud83c\udf3e; \ud83d\udc68\u200d\ud83e\uddb1\ud83d\ude48\ud83c\udf0a, \ud83d\udc68\u200d\ud83e\uddb1\ud83c\udfd4\ufe0f\ud83e\uddd7\u200d\u2642\ufe0f\ud83d\udc10\ud83c\udff9\ud83c\udfd4\ufe0f\ud83c\udfde\ufe0f\ud83c\udde8\ud83c\udded.", "It was unsafe to meddle with the corpses and ghosts of these creatures.": "\u2620\ufe0f\u26a0\ufe0f\ud83d\udeab\ud83d\udc49\ud83d\udd00\ud83d\udc80\ud83d\udc7b\ud83d\udc7e", "Stealing unawares upon the whale in the fancied security of the middle of solitary seas, you find him unbent from the vast corpulence of his dignity, and kitten-like, he plays on the ocean as if it were a hearth.": "\ud83d\udd75\ufe0f\u200d\u2642\ufe0f\ud83e\udd2b\ud83d\udc33\u2728\ud83d\udee1\ufe0f\ud83c\udf0a\u2194\ufe0f, \ud83d\udd0d\ud83d\udc33\ud83d\udcaa\ud83d\udd04\ud83c\udfcb\ufe0f\u200d\u2642\ufe0f\ud83c\udf0c\ud83d\udc51, \ud83d\ude3a\ud83d\udc3e\ud83c\udf0a\ud83d\udcad\ud83d\udd25\ud83c\udfe0.", "ice and icebergs all astern": "\u2744\ufe0f and \ud83e\uddca\ud83c\udfd4\ufe0f all \u2b05\ufe0f", "this ivory leg had at sea been fashioned from the polished bone of the sperm whale\u2019s jaw": "\ud83d\udc49\ud83d\udc18\ud83e\uddb5\ud83c\udf0a\ud83d\udee0\ufe0f\ud83d\udd2e\ud83e\uddb4\ud83d\udc33\ud83d\udc44", "If ye see a white one, split your lungs for him!": "\ud83d\udc40\ud83d\udd0e\u26aa\ud83d\udc48, \u2797\ud83d\udc94\ud83d\ude31\ud83d\udc4f\ud83d\udc66!", "now then, go and preach to \u2019em!": "\ud83d\udd51\u27a1\ufe0f, \ud83d\udeb6\u200d\u2642\ufe0f\ud83d\udca8, \ud83d\udde3\ufe0f\ud83d\udcd6\ud83d\udc65!", "the proper time comes": "\ud83d\udd70\ufe0f\ud83d\udc4c\u23f0\ud83d\udd1c", "In the sea, under certain circumstances, seals have more than once been mistaken for men.": "\ud83c\udf0a, \u27a1\ufe0f\u2753\ud83d\udcdd\ud83d\udd70\ufe0f, \ud83e\uddad\ud83c\ude36\u27951\ufe0f\u20e3\ud83d\udd01\ud83e\udd21\ud83d\udc64\ud83d\ude48\ud83e\udd37\u200d\u2640\ufe0f.", "I did but half fancy being committed this way to so long a voyage": "\ud83d\ude4b\u200d\u2642\ufe0f\ud83d\udc81\u200d\u2642\ufe0f\ud83d\udd28\ud83c\udf17\ud83c\udfa8\ud83d\udc6c\u2696\ufe0f\ud83d\udd00\ud83d\udc63\ud83d\udd1a\ud83c\udfde\ufe0f\u26f5 \ud83d\udd70\ufe0f\ud83d\udcc5\ud83c\udf0a", "I leave a white and turbid wake; pale waters, paler cheeks, where\u2019er I sail. The envious billows sidelong swell to whelm my track; let them; but first I pass.": "\ud83d\udc4b\u2b1c\ud83d\udca6\ud83d\udca7; \ud83c\udf2b\ufe0f\ud83d\udca6, \u26aa\ud83d\ude33, \ud83c\udf0d\u26f5\ufe0f. \ud83d\ude20\ud83c\udf0a\ud83c\udf10\u2197\ufe0f\ud83c\udf0a\ud83d\udd1c\ud83d\udd25\ud83d\udc63; \ud83d\udc4d\ud83d\udc65; \ud83d\udc46\u2b05\ufe0f\u21aa\ufe0f.", "the shrouded phantom of the whitened waters is horrible to him as a real ghost": "\ud83c\udf2b\ufe0f\ud83d\udc7b\ud83c\udf0a\u26aa\ud83d\ude31\ud83d\udc68\ud83d\udc7b\ud83d\udc80", "look at this matter in other lights; weigh it in all sorts of scales": "\ud83d\udc40\ud83d\udd1b\ud83d\udc49\ud83d\udcdd\ud83d\udd26\ud83d\udca1\ud83d\udca1; \u2696\ufe0f\ud83c\udf9a\ufe0f\ud83d\udc48\ud83d\udccf\ud83d\udd04\ud83c\udf9b\ufe0f\ud83c\udf9a\ufe0f\u2696\ufe0f\ud83d\udd04", "nigh to the man who was apt to doze over the grave always ready dug to the seaman\u2019s hand": "\ud83c\udf19\ud83d\udc49\ud83d\udc68\u200d\ud83d\udcbc\ud83d\ude34\ud83d\udca4\ud83d\udcad\u26b0\ufe0f\ud83d\udd73\ufe0f\u2693\ud83d\udc4b\ud83d\udd1c\ud83d\udd03", "there swims behind it all a mass of tremendous life": "\ud83d\udc20\ud83c\udf0a\u27a1\ufe0f\ud83d\udd19\ud83c\udf10\ud83d\udcaa\ud83c\udf33\ud83c\udf31\ud83c\udf0d\ud83c\udf3b\ud83e\udd8b\ud83d\udc1e\ud83d\udc33\ud83c\udf3c\ud83c\udf32\ud83c\udf38\ud83c\udf3f\ud83d\udc3e\ud83e\udd9c\ud83d\udc2c\ud83c\udf43\ud83d\ude2e\ud83d\udcab", "for an hour or more, a thousand fathoms in the sea, he carries a surplus stock of vitality in him": "\u23f01\ufe0f\u20e3\u23f3\u2795, 1\ufe0f\u20e30\ufe0f\u20e30\ufe0f\u20e30\ufe0f\u20e3\ud83c\udf0a\ud83d\udc47\ud83c\udf0a, \ud83e\uddd4\ud83c\udf92\u2795\ud83d\udcaa\ud83d\udca1\ud83d\udd0b\ud83d\udc47\ud83d\udc68\u200d\u2695\ufe0f.", "Of the grand order of folio leviathans, the Sperm Whale and the Right Whale are by far the most noteworthy.": "\ud83d\udcda\ud83d\udc0b\ud83c\udf10, \ud83d\udc0b\ud83d\udca6\ud83d\udc51\ud83d\udc33 & \u27a1\ufe0f\ud83d\udc33\ud83d\udc51\ud83d\udcab\ud83c\udfc6\ud83c\udf96\ufe0f\u2728", "The drama\u2019s done. Why then here does any one step forth?\u2014Because one did survive the wreck.": "\ud83c\udfad\u2705. \u2753\ud83d\udc63\ud83d\udc64\u27a1\ufe0f? \u2014\ud83e\udd141\ufe0f\u20e3\ud83d\udcaa\ud83d\udea2\ud83d\udca5.", "thousands on thousands of sharks, swarming round the dead leviathan, smackingly feasted on its fatness": "\ud83d\udd22\ud83e\udd88\ud83e\udd88\ud83e\udd88\ud83d\udd04\ud83d\udc80\ud83d\udc0b, \ud83d\udc45\ud83d\ude0b\ud83c\udf74\ud83c\udf89\ud83c\udf56\ud83e\uddc8", "Ginger-jub! you gingerly rascal!": "\ud83e\udde1\ud83c\udf89! \ud83d\udc49\ud83e\udde1\ud83d\ude3a!", "you might almost stand in it, and yet be undecided as to what it is precisely": "\ud83d\udc65\ud83e\udd14\ud83d\udcad\ud83d\udd0d\ud83e\udd37\u200d\u2642\ufe0f\ud83d\udccd\ud83d\udccf\u2753\ud83d\udd75\ufe0f\u200d\u2642\ufe0f\u200d\u2642\ufe0f", "I account no living bone of mine one jot more me, than this dead one that\u2019s lost.": "\ud83d\udca1\u270d\ufe0f\ud83d\udeab\ud83e\uddb4\ud83d\udc80\ud83d\udd0e\u27951\ufe0f\u20e3\ud83d\ude4b\u200d\u2642\ufe0f\u27a1\ufe0f\ud83e\uddb4\ud83d\udc80\ud83e\udd37\u200d\u2642\ufe0f\u274c", "the seamen went below to their dinner": "\u26f5\ud83d\udc68\u200d\ud83c\udf73\ud83d\udc47\ud83c\udf7d\ufe0f\ud83c\udf7d\ufe0f\ud83e\udd58", "wilt thou not chase the white whale? art not game for Moby Dick?": "\ud83e\udd40\u2753\ud83d\udca8\ud83d\udeab\ud83c\udfc3\u200d\u2642\ufe0f\ud83d\udc33\u2b1c\u2753\ud83c\udfa8\ud83d\udeab\ud83d\udd79\ufe0f\ud83c\udfa3\ud83d\udc33 Moby Dick\u2753", "unaccountable masses of shades and shadows": "\ud83e\udd37\u200d\u2642\ufe0f\ud83c\udf10\ud83c\udfad\ud83c\udf1a\u26ab\ud83c\udf2b\ufe0f\u2757", "Thou belongest to that hopeless, sallow tribe which no wine of this world will ever warm": "\ud83d\udc49\ud83d\udda4\ud83e\udd37\u200d\u2642\ufe0f\ud83c\udff3\ufe0f\ud83e\udd40\ud83d\udc94\ud83d\udc91\ud83c\udf77\ud83c\udf0e\ud83d\udd25\ud83d\udeab\ud83d\udd1c\ud83d\udd70\ufe0f\u23f3", "that deep, blue, bottomless soul, pervading mankind and nature": "\ud83d\ude2e\ud83c\udf1f\ud83d\udd35\u2b07\ufe0f\ud83d\udd73\ufe0f\ud83c\udf0c\ud83d\udc65\ud83c\udf0d\u26f0\ufe0f\ud83c\udf33\ud83c\udf00", "the stumps of harpoons are frequently found in the dead bodies of captured whales, with the flesh perfectly healed around them": "\ud83c\udf33\ud83e\ude93\ud83d\udd1d\ud83d\udd31\ud83d\udd0d\ud83d\udc80\ud83d\udc0b\ud83d\udc33, \ud83e\udd69\ud83d\udcaf\ud83d\udc89\ud83d\udc8a\ud83d\udd04\ud83d\udc65.", "From beneath his slouched hat Ahab dropped a tear into the sea; nor did all the Pacific contain such wealth as that one wee drop.": "\ud83d\udc47\ud83c\udfa9\ud83d\udc68Ahab\ud83d\udca7\ud83d\ude22\u27a1\ufe0f\ud83c\udf0a; \u2194\ufe0f\ud83d\udeab\ud83d\udcd6\ud83c\udf0a\ud83c\udf0f\ud83c\udf10\ud83d\udc8e\ud83d\udcb0\ud83d\udcd6\ud83d\udca7\ud83c\udf31\ud83c\udf3b\ud83d\udc4c\ud83c\udf81\ud83d\udd0d.", "The bearer looked nobler than the rider.": "\ud83d\udeb6\u200d\u2642\ufe0f\ud83d\udc51\ud83d\udd31\ud83d\udc40\ud83c\udfc7\ud83e\udd34\ud83d\udcc9", "if you take the breath out of his body how can you expect to find it there when most wanted!": "\u2757\ufe0f\ud83d\udc47\ud83d\udd01\ud83c\udf2c\ufe0f\ud83d\udd00\ud83e\uddcd\u200d\u2642\ufe0f, \u27a1\ufe0f\u2753\ud83d\udcad\u2754 \ud83d\udd0e\ud83d\udccc\ud83d\udd70\ufe0f\ud83d\udcaf\ud83d\ude4f\u2757\ufe0f", "the whale-line folds the whole boat in its complicated coils, twisting and writhing around it in almost every direction": "\ud83d\udc0b\u27b0\ud83d\udd04\ud83d\udea4\ud83e\udd0f\ud83e\udde9\ud83d\udd04\ud83c\udf00\u2935\ufe0f\u21a9\ufe0f\ud83d\udd04\ud83d\udd04\ud83d\udd00\ud83d\udd01", "What is the great globe itself but a Loose-Fish?": "\u2753\u2753\ud83c\udf0d\ud83c\udf0d\ud83c\udf0d\ud83d\ude31\u27a1\ufe0f\ud83d\udc1f\ud83c\udd93\ud83e\uddd0\u2753", "with a full grown leviathan this is impossible": "\ud83d\udc65\ud83d\udc0b\ud83c\udf86\u274c\ud83d\udeab\ud83c\udd97", "the entire ship careens over on her side; every bolt in her starts like the nail-heads of an old house in frosty weather; she trembles, quivers, and nods her frighted mast-heads to the sky": "\ud83c\udf10\ud83d\udea2\u2935\ufe0f\u21a9\ufe0f\ud83d\udc69\ud83e\udd35\u200d\u2640\ufe0f\ud83d\udc83\u200d\u2640\ufe0f; \ud83d\udd29\u2699\ufe0f\ud83d\udd27\ud83d\udd28\ud83c\udfe0\ud83c\udf2c\u2744\ufe0f\u2601\ufe0f; \ud83e\udd76\ud83d\udea2\ud83d\ude16\ud83d\udca2\ud83d\ude31\u26a0\ufe0f\ud83c\udf0c\ud83c\udf0c\ud83d\udc46\ud83c\udf24\ud83c\udf1e\u26c5\ufe0f", "there is a higher horror in this whiteness of her woe": "\u261d\ufe0f\ud83d\uddfb\ud83d\ude31\u2b06\ufe0f\ud83d\udc49\u2b1b\ufe0f\ud83d\udd4a\ufe0f\ud83d\udc94", "a minute black spot was dimly discerned, falling from that vast height into the sea": "\u23f1\ufe0f\u26ab\ufe0f\ud83d\udc40\ud83d\udd0d\ud83c\udf2b\ufe0f, \u2198\ufe0f\ud83d\uddfc\ud83d\udd1d\u2198\ufe0f\ud83c\udf0a", "that was freely": "\ud83d\udc48\u2728\ud83c\udd93\ud83d\udd01", "you now saw through this wreck, as plainly as you see through the peeled, half-unhinged, and bleaching skeleton of a horse": "\ud83d\udc49\ud83d\udc40\ud83d\udd0e\ud83d\udc40\ud83d\udca5\ud83c\udf2a\ufe0f\ud83d\udd73\ufe0f\ud83c\udfda\ufe0f\ud83d\udd0e\ud83d\udc41\ufe0f,\ud83d\udd06\ud83d\udc4d\ud83d\udd75\ufe0f\u200d\u2642\ufe0f\ud83e\uddb4\ud83d\udd0e\ud83d\udc34\ud83c\udf56.\ud83d\udeaa\ud83d\ude46\ud83d\udd06\ud83d\ude33\ud83d\udc40(1\ufe0f\u20e3/2\ufe0f\u20e3) \ud83e\uddb4\ud83c\udf56\u26aa\ud83d\udc34.", "it is not customary for such venerable leviathans to be at all social": "\u274c\ud83d\udd04\ud83d\udc74\ud83d\udc0b\ud83d\udc65\ud83d\udeab\u2696\ufe0f", "if a man made up his mind to live, mere sickness could not kill him": "\ud83e\udd14\ud83d\udcad\ud83d\udc68\ud83d\udd28\ud83e\udde0\ud83d\udca1\u270c\ufe0f\ud83c\udf08\ud83d\udecc\ud83d\ude37\ud83e\udda0\u26d4\ud83d\udc80\ud83d\udd2b", "Be it distinctly recorded here, that the Nantucketers were the first among mankind to harpoon with civilized steel the great Sperm Whale": "\ud83d\udcdd\u2705\ud83d\udccd, \ud83d\udc33\ud83c\udfde\ufe0f(Nantucketers) \ud83e\udd47\ud83d\udc65\ud83c\udf0d\ud83d\udd2d\ud83e\uddd0, \ud83d\udd31\ud83c\udfdb\ufe0f\ud83d\udd29 \ud83d\udc0b\ud83d\udcaa(Sperm Whale).", "admire the magnanimity of the sea which will permit no records": "\ud83d\udc40\ud83d\ude4f\ud83d\udc97\ud83c\udf0a\u26d4\ufe0f\ud83d\udcdc", "for days and weeks and months afterwards I lost myself in confounding attempts to explain the mystery": "\ud83d\udcc6\ud83d\udcc6\ud83d\udd04\ud83d\udcc5\ud83d\udd04\ud83c\udf1c\ud83d\udd1c\ud83c\udf1e\ud83d\udd29\ud83d\udd2d\ud83d\udd2e\ud83d\udd2e\ud83d\udc40\ud83d\ude48\ud83d\udd25\u2753\u2049\ufe0f\ud83d\udd75\ufe0f\u200d\u2642\ufe0f\ud83d\udd6f\ufe0f\ud83d\udd2c\ud83e\udde9\ud83d\udd11\ud83d\udcad\ud83d\udd2e\ud83c\udf2b\ufe0f", "A hogshead of brandy, then, to the best man.": "\ud83d\udc16\ud83d\udee2\ufe0f\ud83e\udd43, \ud83d\udd1c, \ud83d\udc49\ud83e\udd47\ud83d\udc68.", "all truth with malice in it": "\ud83c\udf10\ud83d\udcaf\u2194\ufe0f\ud83e\uddff\ud83d\udc7f\ud83d\udccc", "most young candidates for the pains and penalties of whaling stop at this same New Bedford": "\ud83c\udf1f\ud83d\udc76\ud83d\ude4b\u200d\u2642\ufe0f\ud83d\udd1c\ud83d\udd25\ud83d\ude16\ud83d\udc0b\ud83d\uded1\u3030\ufe0f\ud83d\udccd\ud83c\udd95\ud83d\udecf\ufe0f", "Thou sea-mark! thou high and mighty Pilot! thou tellest me truly where I am\u2014but canst thou cast the least hint where I shall be?": "\ud83d\udde3\ufe0f\u2693! \ud83d\udde3\ufe0f\ud83c\udfd4\ufe0f\ud83d\ude81! \ud83d\udde3\ufe0f\ud83d\udc49\ud83d\udc40\ud83d\udcaf\ud83c\udf10\ud83d\udccc\ud83d\udccdI am\u2014\ud83e\udd14\ud83d\udcad\ud83d\udc49\ud83d\udc40\ud83d\udd0d\ud83e\udd37\u200d\u2642\ufe0f\ud83d\udca1\ud83c\udf10\ud83d\udccc\ud83d\udccdI shall be?", "in general shape the noble Sperm Whale\u2019s head may be compared to a Roman war-chariot": "\u27a1\ufe0f\ud83d\udc68\u200d\u2696\ufe0f\ud83d\udcd0, \ud83c\udfa9\ud83d\udc33\ud83d\udc0b\ud83d\udc64\ud83d\udd0d\ud83c\udffa \u27a1\ufe0f\ud83d\udee1\ufe0f \ud83c\udfdb\ufe0f\ud83c\uddee\ud83c\uddf9\u2694\ufe0f\ud83c\udfce\ufe0f", "Nothing more happened on the passage worthy the mentioning": "\ud83d\udeab\u2795\ud83c\udfad\ud83d\udd1b\ud83d\udee4\ufe0f\ud83c\udfc6\ud83d\udde3\ufe0f", "unspeakable horror": "\ud83d\ude31\ud83d\udc79\ud83d\udc7b\ud83d\udc80\ud83d\udd2a\ud83d\udd1e", "let\u2019s drink shame upon all cowards! I name no names. Shame upon them!": "\ud83e\udd42\ud83d\udc14\ud83d\ude48\ud83d\ude21\ud83d\udeab\ud83d\udcdb\ud83d\ude21\ud83d\udd1b\ud83d\udc65\u2757", "Quoin is not a Euclidean term. It belongs to the pure nautical mathematics.": "\ud83d\udd38\ud83d\udeab\u274c\ud83d\udcd0\ud83d\udd20. \ud83d\udd38\ud83d\udd00\ud83d\udd35\ud83d\udee5\ufe0f\ud83d\udd22\ud83d\udd20.", "the mother dived down into the long church-yard grass": "\ud83d\udc69\u200d\ud83e\uddb0\u2b07\ufe0f\ud83c\udfca\u200d\u2640\ufe0f\ud83d\udd3d\u27a1\ufe0f\ud83c\udfde\ufe0f\u26ea\ud83c\udf31", "no wonder that to many ship owners, whaling is but a losing concern": "\ud83d\udeab\u2753\ud83c\udf00\ud83d\udc65\ud83d\udea2\ud83d\udc51\ud83d\udc0b\ud83e\udd37\u200d\u2642\ufe0f\ud83d\udcb8\ud83d\udeab\ud83c\udfc6", "in the soul of man there lies one insular Tahiti, full of peace and joy, but encompassed by all the horrors of the half known life": "\u27a1\ufe0f\ud83d\udc68\u200d\ud83d\udcbc\ud83d\udcad\ud83d\udd78\ufe0f1\ufe0f\u20e3\ud83c\udfdd\ufe0f\ud83d\uddfa\ufe0f, \ud83d\ude00\ud83d\ude0c\ud83c\udfdd\ufe0f, \ud83d\udccc\u26a1\ud83c\udf11\ud83d\ude28\ud83d\uddc3\ufe0f\ud83d\udd79\ufe0f\ud83c\udfad\ud83c\udf17\ud83d\udca1\ud83c\udf0a\ud83c\udfaf\ud83c\udfa2.", "a wondrous fearlessness and confidence": "\u2728\ud83d\ude31\ud83d\udcaa\ud83e\uddb8\u200d\u2642\ufe0f\ud83d\udcbc\u26a1\ud83d\ude4c\ud83d\udcab", "damn your eyes, you mustn\u2019t swear that way when you\u2019re preaching": "\ud83d\ude20\ud83d\udc49\ud83d\udc40, \ud83d\udeab\u26a0\ufe0f\ud83e\udd2c\ud83d\udc48\ud83d\udde3\ufe0f\ud83d\ude4f", "our vocation amounts to a butchering sort of business": "\ud83d\udc65\ud83d\udcbc\u27a1\ufe0f\ud83d\udd2a\ud83d\udcbc", "What bitter blanks in those black-bordered marbles which cover no ashes!": "\u2753\ud83c\udf4b\u2753\u2b1c\u2b1b\ud83d\udfe9\u26ab\ud83d\udd04\u2b1b\ud83d\udd33\ud83d\udfeb\ud83d\udd1d\ud83d\udd33\ud83d\udeac\u2757", "And there\u2019s a mighty difference between a living thump and a dead thump.": "'\ud83d\udd00, \ud83e\udd14\ud83d\udcaa\ud83d\udc4d\ud83c\udd9a \ud83e\udd1d\ud83d\udc64\u2764\ufe0f\ud83d\udc4a \ud83c\udd9a \ud83d\udc80\ud83d\udc4a.'", "You is sharks, sartin; but if you gobern de shark in you, why den you be angel; for all angel is not\u2019ing more dan de shark well goberned.": "\ud83d\udc49\ud83c\udffd\ud83e\udd88, \u2714\ufe0f; \u27a1\ufe0f\u2696\ufe0f\ud83e\udd88\ud83d\udc49\ud83c\udffd, \ud83d\udd1c\ud83d\udc49\ud83c\udffd\ud83d\udc7c; \ud83d\udc7c\u23e9\ud83d\udeab\ud83d\udd25\u23ed\ufe0f\ud83e\udd88\ud83d\udc4c\u2696\ufe0f.", "the mightiest elephant is but a terrier to Leviathan": "\ud83d\udcaa\ud83d\udc18 \u27a1\ufe0f \ud83d\udc15 \ud83d\udc49 \ud83d\udc0b", "hooped round by the gloom of the night they seemed the last men in a flooded world": "\ud83d\udfe4\ud83d\udd35\ud83c\udf0c\u26ab\ud83c\udf1a\ud83d\udc65\ud83d\udc40\ud83d\udc48\ud83d\udd1a\ud83d\udc68\u200d\ud83d\udc68\u200d\ud83d\udc66\u200d\ud83d\udc66\ud83c\udf0e\ud83c\udf0a\ud83c\udf10", "into the hole itself you can hardly insert a quill, so wondrously minute is it": "\ud83d\udd73\ufe0f\ud83e\udd0f\ud83d\udcdd\u26d4\ufe0f\ud83d\udd2c\ud83e\udd2f\ud83d\udc4c\ud83d\udd0d", "heroes, saints, demigods, and prophets alone comprise the whole roll of our order": "\ud83e\uddb8\u200d\u2642\ufe0f\ud83e\uddb8\u200d\u2640\ufe0f, \ud83d\ude4f\ud83d\udc7c, \ud83d\udc51\u26a1\ud83c\udf08, \ud83d\udd2e\ud83d\udde3\ufe0f \u261d\ufe0f\u2696\ufe0f \ud83c\udf10 \ud83d\udd01 \ud83d\udcdc\ud83d\udcda \ud83d\udee1\ufe0f\ud83d\udd25", "she was so far to windward, and shooting by, apparently making a passage to some other ground, the Pequod could not hope to reach her": "\ud83d\udc69\u200d\ud83e\uddb0\u2b05\ufe0f\u26f5\ud83c\udf2c\ufe0f\ud83c\udff9\u27a1\ufe0f\u2611\ufe0f\ud83d\ude80\ud83d\udd73\ufe0f\u2197\ufe0f\ud83c\udf0d\ud83d\udc0b\ud83d\udeab\ud83c\udfaf\ud83e\udd1e\ud83d\udc81\u200d\u2640\ufe0f\ud83d\udd1c", "\u201cCan\u2019st not read it?\u201d cried Ahab.": "\"\u2753\ud83d\udeab\ud83d\udcd6\u2753\" \ud83d\ude31 Ahab.", "In a word, Frederick Cuvier\u2019s Sperm Whale is not a Sperm Whale, but a squash.": "\ud83d\udcd8\ud83d\udc49, Frederick Cuvier's \ud83d\udc0b\ud83c\udf46\u274c\ud83d\udc0b\ud83c\udf46, \u27a1\ufe0f\ud83c\udf83.", "with two legs man is but a hobbling wight in all times of danger": "\ud83e\uddb5\ud83e\uddb5\ud83d\udeb6\u200d\u2642\ufe0f\ud83d\udc68\u26a0\ufe0f\u231b\u23f3\ud83c\udd98", "continue hanging there a while": "\ud83d\udd01\ud83e\uddd7\u200d\u2642\ufe0f\u23f0\ud83d\udd1b", "Where is the foundling\u2019s father hidden?": "\u2753\ud83d\udc76\ud83d\udc68\ud83d\udd0d\u2753", "And there they stand\u2014miles of them\u2014leagues.": "\ud83e\uddcd\u200d\u2642\ufe0f\ud83e\uddcd\u200d\u2640\ufe0f\ud83e\uddcd\u200d\u2642\ufe0f\ud83e\uddcd\u200d\u2640\ufe0f\u2014\ud83d\udccf\ud83d\udccf\ud83d\udccf\u2014\ud83c\udf0d", "in the wild conceits that swayed me to my purpose, two and two there floated into my inmost soul, endless processions of the whale": "\ud83c\udf3f\ud83e\udd2f\ud83d\udc49\ud83d\udee4\ufe0f, 2\ufe0f\u20e3\u27952\ufe0f\u20e3\ud83c\udf00\u27a1\ufe0f\ud83d\udcad\ud83d\udcad\ud83d\udd04\ud83d\udc0b", "idolatrous dotings": "\ud83d\ude35\u200d\ud83d\udcab\u2764\ufe0f\u200d\ud83d\udd25\u2728", "the whale rushed round in a sudden maelstrom; seized the swimmer between his jaws; and rearing high up with him, plunged headlong again, and went down": "\ud83c\udf00\ud83d\udc0b\ud83d\udca8\ud83d\udd04\u26a1\ud83d\udc5f\ud83d\udc44; \ud83e\uddb7\ud83e\uddb8\u200d\u2642\ufe0f; \ud83c\udfd4\ufe0f\u2b06\ufe0f\u2b06\ufe0f\ud83c\udd99\ud83d\udd04, \ud83c\udf0a\ud83d\udd01, \u2b07\ufe0f", "almost all the tapers, lamps, and candles that burn round the globe, burn, as before so many shrines, to our glory!": "\ud83c\udf0d\ud83d\udd6f\ufe0f\ud83d\udca1\ud83d\udd6f\ufe0f\ud83d\udd25\u2728\ud83d\udd6f\ufe0f\ud83c\udf0d, \ud83d\udd25\u2728, \ud83c\udf1f\ud83d\ude4f\u2728\u26e9\ufe0f\u26ea\ud83d\udc96!", "Ye are not other men, but my arms and my legs; and so obey me.": "\ud83d\ude4b\u200d\u2642\ufe0f\ud83d\udc65\ud83d\udeab\ud83d\udc6b, \ud83d\ude4f\ud83d\udcaa\ud83e\uddb5; \u27a1\ufe0f\ud83d\ude4f\ud83d\udcdc\ud83d\udd1b.", "investigate it now with the sole view of forming to yourself some unexaggerated, intelligent estimate of whatever battering-ram power may be lodged there": "\ud83d\udd0d it \ud83d\udd52 with the \ud83c\udfaf of forming to yourself some \ud83d\udcc9, \ud83e\udde0 estimate of whatever \ud83c\udfd7\ufe0f power may be lodged there", "Man may, in effect, be said to look out on the world from a sentry-box with two joined sashes for his window.": "\ud83d\udc68\u27a1\ufe0f\ud83c\udf0d\ud83d\udc40\ud83d\udce6\ud83e\ude9f", "you find some of these Nantucketers who have a genuine relish for that particular part of the Sperm Whale designated by Stubb; comprising the tapering extremity of the body": "\ud83e\udef5 \ud83d\udef3\ufe0f some of these \ud83c\udfdd\ufe0f\ud83d\udc0bers who have a \ud83d\ude0b for that part of the \ud83d\udc33 designated by Stubb; \ud83c\udfcb\ufe0f\u200d close to the \ud83c\udf51=\".", "a hermit and a crucifix were within": "\ud83e\uddd8\u200d\u2642\ufe0f\u271d\ufe0f\ud83e\ude84", "Many are the men, small and great, old and new, landsmen and seamen, who have at large or in little, written of the whale.": "\ud83d\udc68\u27a1\ufe0f\ud83d\udc65, \ud83d\udc0b\ud83d\udcd6\u270d\ufe0f...", "his stump as unquestionable a stump as any you will find in the western clearings": "\ud83e\uddb5\ud83e\udd1a\ud83e\udd14\ud83e\uddb5\ud83e\udd1a\ud83d\udd0d\ud83e\uddb5\ud83c\udf84\u2b05\ufe0f\ud83c\uddfa\ud83c\uddf8\ud83c\udf32", "We work by the month, or by the job, or by the profit; not for us to ask the why and wherefore of our work": "\ud83d\udc77\u200d\u2642\ufe0f\ud83d\udc69\u200d\ud83d\udcbc We work \ud83d\udcc5 by the month, \u270d\ufe0f or \ud83d\udee0 by the job, \ud83d\udcb5 or \ud83d\udcc8 by the profit; \ud83d\udeab not for us to ask \u2753 the why and wherefore \ud83e\udd14 of our work \ud83d\udcbc", "But no more of this.": "\ud83d\ude45\u200d\u2642\ufe0f\u274c\ud83d\udde3\ufe0f", "It was a humorously perilous business": "\ud83d\ude02\u26a0\ufe0f\ud83d\udcbc", "What is it, what nameless, inscrutable, unearthly thing is it": "\ud83e\udd14\ud83e\udd37\u200d\u2642\ufe0f\ud83e\udd14, \ud83e\udd37\u200d\u2642\ufe0f\u2753, \ud83e\udd37\u200d\u2642\ufe0f\u2753\ud83e\udd14\ud83d\udc7d\u2728\ud83e\udd14\u2753", "a mighty pleasant zephyr": "\ud83d\udcaa\ud83d\ude0a\ud83c\udf2c\ufe0f", "a thick curled bush of white mist": "\ud83c\udf2b\ufe0f\u2b1c\ufe0f\ud83c\udf3f\ud83d\udd04", "It\u2019s a ticklish business, but must be done, or else it\u2019s no go.": "\ud83e\udeb6\ud83d\ude04\ud83d\udcc8, \u2139\ufe0f\ud83c\udf55\ud83e\udd47\u2708\ufe0f\ud83d\udd1c, \ud83d\udcc9 it's \ud83d\udeab\ud83c\udfc3\u200d\u2642\ufe0f.", "Let him go. I know little more of him, nor does anybody else.": "\ud83e\udef1\ud83e\udd1a\u27a1\ufe0f\ud83e\uddd4. \ud83e\udd37\u200d\u2640\ufe0fI know \ud83e\udd0f more of \ud83e\uddd4, nor does anybody else.", "This Right Whale I take to have been a Stoic; the Sperm Whale, a Platonian, who might have taken up Spinoza in his latter years.": "\ud83d\udc33\u27a1\ufe0f\ud83e\uddd8\u200d\u2642\ufe0f; \ud83d\udc0b\u27a1\ufe0f\ud83c\udfdb\ufe0f, \ud83d\udcdc\ud83c\udf00\ud83d\udd70\ufe0f", "we go the gait that leaves no dust behind": "\ud83d\udeb6\u200d\u2642\ufe0f\ud83d\udeb6\u200d\u2640\ufe0f\u27a1\ufe0f\ud83d\udc63\ud83e\uddf9\u2b05\ufe0f\u274c", "at last I was continually squeezing their hands, and looking up into their eyes sentimentally": "\ud83d\ude4c\u2764\ufe0f\ud83d\udc91\ud83d\ude22\ud83d\udc40\u2728", "I\u2019m demoniac, I am madness maddened!": "\ud83d\ude08\ud83d\ude35\u200d\ud83d\udcab\ud83c\udf00", "It\u2019s only his outside; a man can be honest in any sort of skin.": "\ud83d\udc68\ud83d\udd04\ud83d\udc65; \ud83d\udc68\u200d\ud83e\uddb2\ud83e\udd1d\u2714\ufe0f\ud83d\udd1c\ud83d\udc54\ud83d\udc57\ud83e\udde5.", "ponderous things": "\ud83e\udd14\ud83d\udcda\ud83e\udea8", "Methuselah seems a school-boy.": "\ud83d\udcda\ud83d\udc66 Methuselah seems a school-boy.", "concentric circles seized the lone boat itself, and all its crew, and each floating oar, and every lance-pole": "\ud83d\udd35\ud83d\udd35\ud83d\udd35 \u26f5\ufe0f \u2693\ufe0f \ud83d\udc64  \ud83d\udef6 \ud83d\udd04 \u270b \ud83d\udccf\u2694", "wandering from all mortal reason, man comes at last to that celestial thought": "\ud83d\udeb6\ud83e\uddcd\u200d\u2642\ufe0f\ud83c\udf0f\u2753\ud83e\udd14\u27a1\ufe0f\ud83d\udd4a\ufe0f\u2728\ud83c\udf1f", "in his large, deep eyes, fiery black and bold, there seemed tokens of a spirit that would dare a thousand devils": "\ud83d\udc40\ud83d\udd25\ud83d\udda4\ud83d\ude20\ud83d\udc79\ud83d\udcaa\ud83d\udd1f\u2757", "God keep thee! Push not off from that isle, thou canst never return!": "\ud83d\ude4f\ud83d\ude07! \ud83d\udeab\ud83c\udfdd\ud83d\uded1\u27a1\ufe0f, \u26d4\ufe0f\u21a9\ufe0f!", "there stands the vast arched bone of the whale\u2019s jaw, so wide, a coach might almost drive beneath it.": "\ud83d\udc0b\ud83d\udc41\ufe0f \ud83d\udd0d \u27a1\ufe0f \ud83d\udeaa \ud83d\udc49\ud83c\udffd \ud83e\uddb4 \u27a1\ufe0f \ud83d\udc0b's \ud83d\ude03 \ud83d\udeaa, \ud83c\udf0c, \ud83d\ude8c \ud83d\udd1c \ud83d\udcad \ud83d\udee3\ufe0f\u2b07\ufe0f \ud83d\ude8d", "This aspect is sublime.": "\u2728\ud83c\udf1f This aspect is sublime. \ud83c\udf1f\u2728", "I now and then jerked the poor fellow from too close a vicinity to the maw of what seemed a peculiarly ferocious shark": "\ud83e\udd14\ud83d\udc66\u27a1\ufe0f\ud83e\udd88\ud83d\ude31 (sometimes)\u27a1\ufe0f\ud83d\udc4b\ud83d\udca6\ud83d\udeb6\ud83d\ude2c", "being laid upon the printed page, I have sometimes pleased myself with fancying it exerted a magnifying influence": "\ud83d\udc40\ud83d\udcd6\u2728, \ud83d\ude0c\ud83d\udcad\ud83d\udd0d\u2728", "It is a place also for profound mathematical meditation.": "\ud83d\udd22\ud83e\uddd8\u200d\u2642\ufe0f\ud83c\udfde\ufe0f\ud83e\udde0\ud83e\uddee", "For the height of this sort of deliciousness is to have nothing but the blanket between you and your snugness": "\ud83d\udecf\ufe0f\u2728\ud83e\udd70\ud83d\udccf\ud83e\udd47\ud83e\uddf6\ud83c\udf6b\ud83d\udca4", "according to Genesis, the angels indeed consorted with the daughters of men, the devils also, add the uncanonical Rabbins, indulged in mundane amours": "\ud83d\udd4a\ufe0f\ud83d\udcd6 says \ud83d\udc7c\ud83d\udc91\ud83d\udc69, \ud83d\ude08 too, add \ud83d\udcdc Rabbins, had \ud83c\udf0d\u2764\ufe0f", "Thou art too damned jolly. Sail on.": "\ud83e\udef5\ud83d\ude08\ud83d\ude04\u26f5\u27a1\ufe0f", "in all seasons and all oceans declared everlasting war with the mightiest animated mass that has survived the flood": "\ud83c\udf26\ufe0f\ud83c\udf0a\u2728\ud83d\udde3\ufe0f\u2694\ufe0f\ud83c\udf0d\ud83c\udf90\ud83d\udc51\ud83d\udca5\ud83c\udf0a\ud83d\udcaa\ud83c\udf0a\u23f3", "In life, the visible surface of the Sperm Whale is not the least among the many marvels he presents.": "\ud83e\uddec\ud83c\udf0a, \ud83d\udc40\ud83d\uddfa\ufe0f \ud83c\udf0a\ud83d\udc0b is \u2728\ud83d\udcda \ud83e\udde9 \ud83e\udd2f \ud83c\udf08 \ud83d\udd75\ufe0f\u200d\u2642\ufe0f\ud83d\udcda.", "sleights of hand and countless subtleties": "\ud83e\ude84\ud83d\udc50\u2728 and \ud83d\udd22\ud83d\udd0d", "those entrails seemed swallowed over and over again by the same mouth, to be oppositely voided by the gaping wound": "\ud83e\udd2f\u2728\ud83c\udf00\ud83d\udc44\ud83d\udcab\ud83c\udf00\u27a1\ufe0f\ud83d\udc44\ud83e\ude78\ud83d\ude31", "The ungracious and ungrateful dog!": "\ud83d\ude20\ud83d\udc15", "in landscape gardening, a spire, cupola, monument, or tower of some sort, is deemed almost indispensable to the completion of the scene": "\ud83c\udf33\ud83c\udfde\ufe0f\ud83c\udfe1, \ud83d\uddfc\ud83c\udff0\ud83d\uddff, \u26ea\ufe0f\ud83c\udf1f\ud83c\udfe2 \ud83c\udfaf, \u2705 \ud83d\udee0\ufe0f\ud83d\udc40\u2699\ufe0f\u2b1c\ufe0f \ud83d\udcf8", "the stranger in question waved his hand": "\ud83d\udc4b\ud83e\udd14 ", "he profoundly saw a white living spot no bigger than a white weasel, with wonderful celerity uprising, and magnifying as it rose": "\ud83e\uddd2\ud83d\udc40\ud83d\udd0d\u2b1c\u2b06\ufe0f\ud83d\udc3e\u2754\u23f3\ud83d\udca8\u2b06\ufe0f\ud83d\udca5\u2764\ufe0f\u200d\ud83d\udd25", "the sight of those bleak tablets sympathetically caused the old wounds to bleed afresh": "\ud83e\udea6\ud83d\ude14\ud83e\ude78", "Look here, Beelzebub, you don\u2019t do it": "\ud83d\udc40\u27a1\ufe0f, \ud83d\ude08, \u274c\ud83d\udcdb", "Where lies the final harbor, whence we unmoor no more?": "\ud83c\udf05\u2693\u2753", "They asked him, then, whether to live or die was a matter of his own sovereign will and pleasure.": "\ud83d\udde3\ufe0f\u2753\ud83d\udc64\ud83d\udcad\u2696\ufe0f\ud83d\udc51\ud83d\udc4c\ud83d\udd04\ud83d\udc4e\ud83d\udc80", "Had the trump of judgment blown, they could not have quivered more": "\ud83d\udce3\ud83e\udea6\u2696\ufe0f, \ud83d\ude28\ud83d\ude4c\ud83c\udf00\ud83d\udc80", "There\u2019s a clue somewhere; wait a bit; hist\u2014hark!": "\ud83d\udd75\ufe0f\u200d\u2642\ufe0f\ud83d\udd0d\u2754\u23f3\ud83e\udd2b\ud83d\udc42", "a series of small whirlwinds": "\ud83c\udf2a\ufe0f\ud83c\udf2a\ufe0f\ud83c\udf2a\ufe0f (or you could use) \ud83c\udf43\ud83c\udf43\ud83c\udf43", "a somewhat similar circumstance that befell me; whether it was a reality or a dream, I never could entirely settle.": "\ud83e\uddd0\ud83e\udd14\ud83c\udf19\u2728\ud83e\udd37\u200d\u2642\ufe0f", "Remember what I say; be kicked by him; account his kicks honors; and on no account kick back": "\ud83d\udcdd\ud83d\udcad \"Remember what I say; \ud83d\udc42 be kicked by him; \ud83e\uddb5 account his kicks honors; \ud83c\udfc5 and on no account kick back. \ud83d\udeab\"", "If you flatter yourself that you are all over comfortable, and have been so a long time, then you cannot be said to be comfortable any more.": "\ud83e\ude9e\ud83d\ude0c\u27a1\ufe0f\ud83d\ude07\u23f3\u2728\u27a1\ufe0f\u274c\ud83d\ude0c", "Is it not curious, that so vast a being as the whale should see the world through so small an eye": "\ud83e\uddd0 \ud83d\udc0b\ud83d\udc41\ufe0f \ud83c\udf0d", "Never dream with thy hand on the helm! Turn not thy back to the compass": "\ud83d\udecc\ud83d\udeab\ud83d\udca4\ud83d\udc4b\ud83d\udef3\ufe0f\ud83d\udee0\ufe0f! \ud83d\udd04\ud83d\udeab\ud83d\udd19\ud83e\udded", "the practices of whalemen soon convinced him that even Christians could be both miserable and wicked": "\ud83d\udee5\ufe0f\ud83d\udcbc\ud83d\udc0b\u26f4\ufe0f\ud83c\udf0a\u27a1\ufe0f\ud83e\udd14\u2728\ud83d\ude4f\ud83c\udffb\ud83d\uded0\ud83d\udd4a\ufe0f\u2795\ud83d\ude1e\ud83d\udc94\ud83e\udde5\ud83d\ude4f\ud83c\udffb\ud83d\udcad\ud83d\ude45\u200d\u2642\ufe0f", "stunsail on stunsail": "\u26f5\ufe0f\u26f5\ufe0f", "most seamen are beginning to learn, tar in general by no means adds to the rope\u2019s durability or strength": "\ud83d\udea2\ud83d\udc68\u200d\u2708\ufe0f\u26f4\ufe0f are beginning to \ud83d\udcd6\ud83e\udde0, \ud83e\ude9d in \u2693\ufe0f by \ud83d\uded1 means \u2795 to the \ud83e\udea2\u2019s \ud83d\udd70\ufe0f\u23f3 or \ud83d\udcaa\ud83e\uddbe", "that white whale must be the same that some call Moby Dick": "\ud83d\udc33\u26aa\ufe0f \u27a1\ufe0f \ud83d\udc0b \ud83d\udcdb \"Moby Dick\"", "dive into this matter of whaling": "\ud83e\udd3f\ud83d\udc0b\ud83d\udcda", "And what do you pick your teeth with, after devouring that fat goose? With a feather of the same fowl.": "\ud83e\uddb7\u27a1\ufe0f\ud83e\udd14\ud83e\udeb6\u27a1\ufe0f\ud83c\udf7d\ufe0f\ud83c\udf57\ud83e\udeb6\ud83e\udda2", "he now depresses his head altogether beneath the surface, and anon swims with it high elevated out of the water": "\ud83c\udf0a\u2b07\ufe0f\ud83e\udd15\ud83d\uded1\u2198\ufe0f\ud83c\udf0a, \ud83c\udfca\u200d\u2642\ufe0f\u2b06\ufe0f\ud83d\ude0a\ud83c\udf0a", "who ever heard that the devil was dead?": "\ud83d\udde3\ufe0f\ud83d\udc42\u2753\ud83d\udc7f\ud83d\udc80", "I must be content with a hint.": "\ud83d\udc4d\ud83d\ude0c\ud83d\udcad", "Yet this is life.": "\ud83e\udee4\ud83d\udcc8\ud83d\ude4c", "My soul is more than matched; she\u2019s overmanned; and by a madman!": "\ud83e\udec0\ud83d\ude22 \ud83d\udcaa \u2795 \ud83d\udc78\ud83d\udc81\u200d\u2640\ufe0f \ud83d\udc6b \ud83d\udea2\ud83d\udca8 \ud83c\udf2a\ud83e\uddd4", "And there is a Catskill eagle in some souls that can alike dive down into the blackest gorges, and soar out of them again": "\ud83e\udd85\ud83d\ude3a\u26f0\ufe0f\ud83c\udf0c\ud83d\udcab\ud83e\udde0\ud83d\udd04\u26ab\ufe0f\ud83c\udf0a,\u2b07\ufe0f\u2b06\ufe0f\u2728", "a fine, boisterous something about everything": "\u2728\ud83d\ude4c\ud83d\udd06\ud83c\udf2a\ufe0f\ud83d\udd04\u2728", "Old age is always wakeful; as if, the longer linked with life, the less man has to do with aught that looks like death.": "\ud83d\udc74\ud83c\udf19 is always \ud83d\udc40; as if, the longer \ud83d\udd17 with \ud83c\udf0d, the less \ud83d\udc68 has to do with aught that looks like \ud83d\udc80.", "I made no more ado, but jumped out of my pantaloons and boots": "\ud83d\ude45\ud83c\udffd\u200d\u2642\ufe0f\ud83e\udd39\ud83c\udffc\u200d\u2642\ufe0f\ud83d\udc56\ud83e\udd7e\u2b07\ufe0f", "what but their smooth, flaky whiteness makes them the transcendent horrors they are?": "\ud83e\udd14\u2753\u2744\ufe0f\u2728\ud83d\ude31\u2b1c\ufe0f\u2753\ud83d\udc80\ud83d\ude80", "some hitherto unknown and unsuspected connexion": "\ud83d\udd0d\ud83c\udd95\u2753\ud83e\udd2f\ud83e\udde9", "they began capering about most obstreperously": "\ud83d\udd7a\ud83d\udc83\ud83c\udf89\ud83c\udf8a", "Starbuck seemed prepared to endure for long ages to come, and to endure always": "\ud83c\udf1f\ud83e\udd8c seemed \ud83e\udd14 prepared to \ud83c\udf04\ud83d\udd1c for \u23f3 ages to come, and to \ud83c\udf04 always", "true to each other, when heaven seemed false to them": "\ud83e\udd1d\ud83d\udc96 , \u2601\ufe0f\ud83d\udc94", "AND I ONLY AM ESCAPED ALONE TO TELL THEE": "\ud83c\udd70\ufe0f\ud83c\udfb5\ud83c\udf05\ud83c\udd7e\ufe0f\ud83c\udfb5\ud83d\udc62\ud83c\udf78 \ud83c\udd70\ufe0f\u303d\ufe0f \ud83d\udcd3\ud83d\udce7\ud83d\udcb2\ud83c\udf1c\ud83c\udd70\ufe0f\ud83c\udd7f\ufe0f\ud83d\udce7\ud83c\udf1b \ud83d\udce7\ud83d\udc62\ud83c\udf1c\ud83c\udf90\u2696\ufe0f\ud83c\udf90\ud83c\udf1c\ud83d\udde3\ufe0f \ud83c\udd7f\ufe0f \ud83d\udca3\ud83d\udeaa\u270b \ud83d\udcdc\ud83d\udce7\ud83d\udc62\ud83d\udc62 \ud83c\udf34\ud83c\udf1e \ud83c\udf34\ud83d\udce7\ud83d\udc62\ud83d\udc62  \ud83c\udf34\ud83c\udf40\ud83d\udce7\ud83d\udce7", "There now": "\ud83e\udef4\ud83d\ude0a", "The dead, blind wall butts all inquiring heads at last.": "\ud83d\udc80\ud83d\ude36\u200d\ud83c\udf2b\ufe0f\ud83e\uddf1\u27a1\ufe0f\ud83e\udd14\ud83e\udd2f\ud83d\udd1a", "I know not": "\ud83e\udd37\u200d\u2642\ufe0f\ud83d\udcad\u2753", "Now, mark.": "\ud83d\udd70\ufe0f\u270d\ufe0f", "did you yourself feel such a mystical vibration, when first told that you and your ship were now out of sight of land?": "\ud83e\udef5\ud83c\udf0a\ud83d\udd2e, \ud83d\udde3\ufe0f\u26f5\u27a1\ufe0f\ud83c\udf0d?", "several tubs had been filled with the fragrant sperm": "\ud83d\udec1\ud83d\udec1\ud83d\udec1 \u27a1\ufe0f \ud83c\udfe0 \ud83c\udf3a\ud83d\ude0c", "Let me try to explain them.": "\ud83d\udcdd\u27a1\ufe0f\ud83e\udd14\ud83d\udde3\ufe0f\ud83d\udd0d\ud83d\udcc3", "A nose to the whale would have been impertinent.": "\ud83d\udc43\u27a1\ufe0f\ud83d\udc0b\u2757\ufe0f", "something obscurely in reference to his incarcerated body and the whale\u2019s gastric juices": "\ud83d\udd0d\ud83e\uddd1\u200d\u2696\ufe0f\ud83c\udf42\ud83d\udc33\ud83c\udf72", "it blew very fresh": "\ud83d\udca8\ud83c\udf2c\ufe0f\ud83d\ude0a", "by exceeding caution, you may possibly escape these and the multitudinous other evil chances of life": "\ud83d\udeab\u26a0\ufe0f\ud83d\ude0a\ud83c\udfc3\u200d\u2642\ufe0f\ud83d\udca8\ud83d\udcc9\ud83d\ude45\u200d\u2642\ufe0f\ud83d\udd00\ud83d\ude08\ud83d\udcc9\ud83d\udcc9\ud83d\udcc9\ud83d\ude25\ud83c\udf10", "he was nothing but a humbug, trying to be a bugbear.": "\ud83d\udc68\u274c\ud83e\udde2\ud83d\udc1e\u27a1\ufe0f\ud83d\udc7a", "the Right Whale\u2019s head bears a rather inelegant resemblance to a gigantic galliot-toed shoe.": "\ud83d\udc0b\u27a1\ufe0f\ud83d\udc5f\ud83d\udd0d\ud83d\udca1", "The permanent constitutional condition of the manufactured man, thought Ahab, is sordidness.": "\ud83d\udcdd\ud83e\udd14 \"The permanent constitutional condition of the manufactured man, thought Ahab, is sordidness.\"", "What business have I with this pipe?": "\ud83e\udd14\ud83d\udcef\u2753", "Haul in the chains! Let the carcase go astern!": "\u2693\ufe0f\ud83d\udd17 Haul in the chains! \ud83d\udc0b\u2b07\ufe0f Let the carcase go astern! \ud83d\udea2", "to learn all about these recondite matters, your best way is at once to descend into the blubber-room, and have a long talk with its inmates": "\ud83d\udcda\ud83d\udca1\ud83e\udd14\u2b07\ufe0f\ud83d\udeaa\ud83d\udef3\ufe0f\ud83d\udd0d\ud83d\udc0b\u27a1\ufe0f\ud83d\udde3\ufe0f\ud83e\uddd1\u200d\ud83c\udfeb\ud83d\udcac\ud83d\udcd8", "in that full front view, you feel the Deity and the dread powers more forcibly than in beholding any other object in living nature": "\ud83c\udf05\ud83d\udc41\ufe0f\ud83d\ude32\ud83d\ude4f\u26a1\ufe0f\ud83d\udcaa\ud83c\udfde\ufe0f\ud83e\uddd1\u200d\ud83e\udd1d\u200d\ud83e\uddd1", "I\u2019ve studied signs, and know their marks": "\ud83d\udcda\ud83d\udd0d\u2728 \u2795 \ud83e\uddd0\ud83d\udd8a\ufe0f, \ud83e\uddd0\u27a1\ufe0f \ud83d\udccc\ud83d\udd0d\ud83d\udd16", "it\u2019s better to sail with a moody good captain than a laughing bad one": "\u26f5\ufe0f\ud83d\ude24\ud83d\udc68\u200d\u2708\ufe0f> \ud83d\ude02\ud83d\udc68\u200d\u2708\ufe0f", "And heaved and heaved, still unrestingly heaved the black sea, as if its vast tides were a conscience; and the great mundane soul were in anguish and remorse for the long sin and suffering it had bred.": "\ud83c\udf0a\u2795\ud83c\udf0a, \ud83c\udfcb\ufe0f\u200d\u2642\ufe0f\ud83c\udf0a\ud83c\udf0a, \u27a1\ufe0f\ud83d\udeab\ud83d\ude47\u200d\u2640\ufe0f\ud83c\udf0a\ud83d\udd35\ud83c\udf0a, \u26ab\ufe0f\ud83c\udf0a, \ud83c\udf2b\ufe0f\u2696\ufe0f\u2708\ufe0f, \u2795\ud83d\ude26\u2728\ud83e\udeb6\ud83c\udf0a\ud83c\udf0a, \u27a1\ufe0f\ud83d\udc41\ufe0f\u26a1\ud83c\udf0a\ud83e\ude9e\u2693\ud83d\udc4e\u2728\ud83d\ude13\ud83c\udf2b\ufe0f\u2696\ufe0f\u2795\ud83d\ude1e\ud83c\udf0a\ud83d\udecc\ud83e\udea6\u2795\ud83e\udebb\ud83c\udf0a\ud83d\udecc\ud83d\udc94\ud83d\udcad\u0964", "and the last whale, like the last man, smoke his last pipe, and then himself evaporate in the final puff": "\ud83c\udf00\ud83d\udc0b, \ud83e\uddd4\ud83d\udeac, \ud83d\udca8\u2196\ufe0f\ud83d\udca8, \ud83c\udf2b\ufe0f", "a long, limber, portentous, black mass of something": "\ud83d\udda4\ud83d\udc0d\ud83d\udccf\ud83c\udf00", "Thus, gentlemen, though an inlander, Steelkilt was wild-ocean born, and wild-ocean nurtured": "\ud83c\udf0a\ud83d\udc68\u200d\ud83d\ude80, \ud83d\udc68\u200d\u2696\ufe0f\ud83c\udf10, \ud83c\udf0a\ud83c\udf3f, \ud83c\udf0a\ud83c\udf0a\ud83c\udf0a\ud83c\udf0a", "Into this hole, the end of the second alternating great tackle is then hooked so as to retain a hold upon the blubber, in order to prepare for what follows.": "\ud83d\udd73\ufe0f\u27a1\ufe0f\u2693\ufe0f\ud83d\udc0b\ud83d\udd04\ud83d\udccc\ud83d\udd27\ud83d\udccd\ud83d\udee0\ufe0f\ud83d\udc33\u27a1\ufe0f\ud83d\udd1c", "embellished with all the gay flags of all the known nations of the world": "\ud83c\udf89\ud83c\udff3\ufe0f\u200d\ud83c\udf08\ud83c\udf0d\u26f5\u2728", "often possession is the whole of the law": "\ud83d\udd01\ud83d\udd11\u27a1\ufe0f\u2696\ufe0f", "I began to be sensible of strange feelings. I felt a melting in me.": "\ud83e\udde0\u2728\ud83d\ude33\ud83d\ude36\u200d\ud83c\udf2b\ufe0f\ud83d\udca7\ud83e\udee0", "I claim him for one of our clan.": "\ud83d\udde3\ufe0f\ud83d\ude4b\u200d\u2642\ufe0f\ud83d\udc68\u200d\ud83d\udc69\u200d\ud83d\udc67\u200d\ud83d\udc66\u27a1\ufe0f\ud83d\udc68\u200d\ud83d\udc68\u200d\ud83d\udc66", "To-morrow, in the natural sun, the skies will be bright": "\ud83c\udf1e\u2728, \u2600\ufe0f\ud83c\udfde\ufe0f, \ud83c\udf0c\ud83c\udf24\ufe0f", "Let me make a clean breast of it here, and frankly admit that I kept but sorry guard.": "\ud83d\udde3\ufe0f\ud83d\udcac \"\ud83e\udec0\u2728\u27a1\ufe0f\ud83e\udd1d\ud83d\ude0a\ud83e\udee3, \ud83e\udd14\ud83d\ude48\ud83d\ude14\ud83d\udee1\ufe0f\"", "so you suppose I\u2019m afraid of the devil?": "\ud83d\ude05\ud83e\udd14\ud83d\udcad \"\ud83d\ude08?\"", "The jaw is afterwards sawn into slabs, and piled away like joists for building houses.": "\ud83e\udd88\u2702\ufe0f\u27a1\ufe0f\ud83e\ude9a\u27a1\ufe0f\ud83d\udccf\u27a1\ufe0f\ud83c\udfe0", "Surely this was a touch of fine philosophy; though no doubt he had never heard there was such a thing as that.": "\ud83d\udc4d\ud83e\udd14\ud83e\uddd0\ud83d\udcda\ud83e\udd14\ud83d\ude49\ud83e\udd37\u200d\u2642\ufe0f\ud83e\udd14", "methinks it rings most vast, but hollow": "\ud83e\udd14\ud83d\udd14\ud83c\udf0c\u2757\ufe0f\ud83d\udcad\u27a1\ufe0f\ud83d\udd73\ufe0f", "He minds you somewhat of a juggler, balancing a long staff on his chin.": "\ud83e\uddd4\u200d\u2642\ufe0f\ud83e\udd39\u200d\u2642\ufe0f\ud83c\udfa9\ud83e\ude84, \ud83e\udd39\u200d\u2642\ufe0f\ud83d\udc68\ud83e\uddaf\ud83e\ude7b", "spinning, animate and inanimate, all round and round in one vortex, carried the smallest chip of the Pequod out of sight": "\ud83c\udf00, \ud83c\udf00\ud83d\udc83\ud83d\udeab \ud83d\udc83, \ud83d\udea2\u27a1\ufe0f\u267e\ufe0f, \ud83d\udea2\u26d4, \ud83c\udf0a, \ud83c\udf0a\ud83c\udfde, \ud83d\udea4\u27a1\ufe0f\ud83d\udd2d", "But as in landlessness alone resides highest truth, shoreless, indefinite as God": "\ud83c\udf0a\ud83e\udd14\ud83d\udd0d\u2693\ufe0f\ud83d\udcdd\ud83c\udf1f\ud83d\udeab\ud83d\udee4\ufe0f\ud83c\udfdd\ufe0f\u27a1\ufe0f\ud83c\udf0c\ud83d\udd1d\ud83d\udc4c\ud83c\udf3f\ud83c\udf2b\ufe0f\ud83c\udf0d\ud83d\udc53\ud83d\ude4f", "is his brain so much more comprehensive, combining, and subtle than man\u2019s, that he can at the same moment of time attentively examine two distinct prospects, one on one side of him, and the other in an exactly opposite direction?": "\ud83e\udd14\ud83e\udde0\u2795\ud83d\udd0d\ud83e\udd28\ud83e\udd2f\ud83d\udc49\ud83d\udc68\u200d\ud83e\uddb1\u2753\ud83d\udcca\ud83d\udd70\ufe0f\u23f1\ufe0f\ud83d\udc40\u27a1\ufe0f1\ufe0f\u20e3\u2b50\ud83d\udee4\ufe0f\u270b\ud83d\udd04\u2194\ufe0f\u2b50", "a supernatural hand seemed placed in mine.": "\ud83d\udd90\u2728\ud83d\udc7b\ud83d\udd2e\ud83d\udd90", "See how elastic our prejudices grow when once love comes to bend them.": "\ud83d\udc40\u27a1\ufe0f\ud83c\udf31\ud83d\udccf\ud83d\udd04\ud83d\udcc8\ud83d\udcac\u2753\u2764\ufe0f\u27a1\ufe0f\ud83e\udde0\u26a1\ud83c\udf3f", "they drag out these teeth, as Michigan oxen drag stumps of old oaks out of wild wood lands": "\ud83d\udd17\ud83e\uddb7\ud83d\ude9c\ud83d\udc02\ud83d\udccf\ud83c\udf33\ud83c\udd9a\ud83c\udf32\ud83c\udfde\ufe0f", "the one visible quality in the aspect of the dead which most appals the gazer, is the marble pallor lingering there": "\ud83d\udc41\ufe0f\ud83d\udc64\ud83e\udea6\ud83e\uddca\ud83d\ude31", "And lo! close under our lee, not forty fathoms off, a gigantic Sperm Whale lay rolling in the water like the capsized hull of a frigate": "\ud83d\udc0b\ud83c\udf0a\ud83d\udc40! \ud83d\udd0d\u2b07\ufe0f\ud83d\udef3\ufe0f\ud83d\udd1c\ud83d\ude2e, \ud83c\udf0a\ud83d\udea24\ufe0f\u20e30\ufe0f\u20e3\u3030\ufe0f\ud83d\ude45\u200d\u2642\ufe0f\ud83c\udfca\u200d\u2642\ufe0f, \ud83d\udc0b\u2728\u2693\ufe0f, \ud83d\udef3\ufe0f\ud83d\udd04\ud83c\udf0a\ud83c\udfa2\u2693\ufe0f", "it floats more and more away, the water round it torn and splashed by the insatiate sharks": "\ud83c\udf0a\ud83d\udea4\u23e9\u23e9\u27a1\ufe0f, \ud83e\udd88\ud83d\udca6\ud83c\udf0a\ud83d\udca2\ud83d\udcc8\ud83e\udd88\n", "Who ain\u2019t a slave? Tell me that.": "\ud83d\ude4b\u200d\u2642\ufe0f\ud83d\ude4b\u200d\u2640\ufe0f \u2753 \ud83d\uded1 \ud83d\udd17 \u2757\ufe0f \ud83d\udde3\ufe0f", "descend upon the monster\u2019s back for the special purpose referred to": "\u2b07\ufe0f\ud83e\udd87\ud83e\uddcc\ud83d\udd19for\u2b50\ud83d\udee0\ud83e\udef0", "Surely all this is not without meaning.": "\ud83d\udd0d\ud83e\udd14\ud83d\udcd6\u2753\ud83d\udcad\ud83d\udcac", "I, Ishmael, was one of that crew; my shouts had gone up with the rest; my oath had been welded with theirs; and stronger I shouted, and more did I hammer and clinch my oath, because of the dread in my soul.": "\ud83e\uddd4\ud83e\udd1a\ud83c\udf0a\ud83d\udc65; \ud83d\udd0a\ud83d\udce2\u2b06\ufe0f\ud83d\udc46; \u270b\ud83e\udd1d\ud83d\udd12\ud83d\udde3\ufe0f; \ud83d\udcaa\ud83d\udce2, \ud83d\udd28\ud83d\udcac\ud83d\udcaa, \ud83d\udcdd, \ud83d\ude31\ud83d\udc80.", "For the present other matters press, and the best we can do now for the head, is to pray heaven the tackles may hold.": "\ud83d\udcda\ud83e\udd14\u23f3\ud83d\udcdd\ud83d\udcbc\ud83d\udd04\ud83d\udcc5\ud83d\ude47\u200d\u2642\ufe0f\ud83d\ude4f\ud83c\udf0c\ud83d\udccc\ud83d\ude4f\ud83d\udc4f", "Come, Almanack!": "\ud83d\udece\ufe0f\ud83d\udcc5", "we are curing the wound, when whang come the arrows all round; Sagittarius, or the Archer, is amusing himself": "\ud83e\ude79\ud83c\udff9\u27a1\ufe0f\ud83c\udfaf \u2650\ud83d\ude06", "If the wind only held": "\ud83c\udf2c\ufe0f\ud83e\udd1e", "because he could not grasp the tormenting, mild image he saw in the fountain, plunged into it and was drowned": "\ud83d\udcdd\ud83d\ude35\u200d\ud83d\udcab\ud83d\udeab\ud83e\udd32\ud83d\ude16\ud83d\uddbc\ufe0f\ud83d\udeb0\ud83e\udd3f\ud83c\udf0a\ud83d\udc80", "I have ye": "\ud83d\udc41\ufe0f\u27a1\ufe0f\u26f5", "an unendurable length of time": "\u23f3\ud83d\ude2b\ud83d\udd70\ufe0f", "Instantly I felt a shock running through all my frame; nothing was to be seen, and nothing was to be heard": "\u26a1\ud83d\ude31 Instantly I felt a shock running through all my frame; nothing was to be seen \ud83d\udc40 and nothing was to be heard \ud83d\udc42\u274c", "The glittering mouth yawned beneath the boat like an open-doored marble tomb": "\u2728\ud83d\udc44\ud83e\uddb7\ud83d\ude2e\ud83d\udc8e\ud83d\udea4\u2b07\ufe0f\ud83d\udce5\ud83c\udfdb\ufe0f\u26b0\ufe0f", "Do thou, too, remain warm among ice.": "\ud83e\udef5\u2744\ufe0f2\ufe0f\u20e3\ud83d\ude0c\ud83d\udd25\ud83c\udf2c\ufe0f\u2744\ufe0f", "whiteness is not so much a colour as the visible absence of colour": "\u26aa\ufe0f is not so much a \ud83d\udd8d\ufe0f as the \ud83d\udc40 absence of \ud83d\udd8d\ufe0f", "the fear of this vast dumb brute of the sea, was chained up and enchanted in him; he had no voice": "\ud83d\ude28\ud83c\udf0a\ud83e\udd88\ud83d\udd17\u2728\ud83e\udd10", "beyond all hum of human weal or woe": "\ud83c\udf0c\ud83d\udce3\ud83d\udeb6\u200d\u2642\ufe0f\u274c\ud83d\ude02\ud83d\ude2d", "a prayer so deeply devout that he seemed kneeling and praying at the bottom of the sea": "\ud83d\ude4f\ud83c\udf0a\ud83e\udd32\ud83c\udf0a\n\n", "The gallant Perseus, a son of Jupiter, was the first whaleman": "\ud83d\udde1\ufe0f\ud83d\udc51 Perseus, \ud83d\udc76\ud83d\udd31 son of Jupiter, \ud83d\udef3\ufe0f\ud83d\uddfa\ufe0f was the 1\ufe0f\u20e3st \ud83d\udc0b\ud83e\uddd4", "the Evil One himself": "\ud83d\ude08\u27a1\ufe0f\ud83d\udc64", "Usually the dead Sperm Whale floats with great buoyancy, with its side or belly considerably elevated above the surface.": "\ud83d\udc0b\u26aa\ufe0f\u26f4\ufe0f\ud83d\udd1d\n", "The ivory Pequod was turned into what seemed a shamble; every sailor a butcher.": "\ud83d\udde1\ufe0f\u2693\ufe0f\ud83d\udc33\u2728\n\nThe \ud83e\udda6 ship \ud83d\udef3\ufe0f\u2693\ufe0f was transformed \ud83c\udf00 into what seemed like a mess \ud83e\ude78; every \ud83e\uddd1\u200d\u2708\ufe0f a butcher \ud83d\udd2a.", "now that the creature was dead, some vague dissatisfaction, or impatience, or despair, seemed working in him": "\ud83d\udc3e\ud83d\udc80\ud83d\ude1e\ud83e\udd14\ud83d\udcad\ud83d\ude23\ud83d\udd70\ufe0f\ud83d\udeab\ud83d\udcc8\ud83d\udc94", "it needs a strong, nervous arm to strike the first iron into the fish": "\ud83d\udcaa\ud83d\ude2c\ud83e\udd1c\ud83d\udc1f\u27a1\ufe0f\u2692\ufe0f", "he had but little learning except what he had picked up from the sun and the sea": "\ud83d\udc68\ud83c\udffe\u200d\ud83c\udfeb\ud83d\udcda\ud83c\udf1e\ud83c\udf0a", "the vast body had at last been stripped of its fathom-deep enfoldings, and the bones become dust dry in the sun": "\ud83d\udc0b\u27a1\ufe0f\ud83c\udf1e\ud83d\udc80\u27a1\ufe0f\ud83e\uddb4\ud83d\udca8", "every moment whole tons of ponderosity seemed added to the sinking bulk, and the ship seemed on the point of going over": "\ud83c\udf0a\u2693\ud83d\udea2\u2696\ufe0f\ud83d\ude31\u23f3\u27a1\ufe0f\ud83d\udcc9\u2696\ufe0f\u2b06\ufe0f\u23f3\u27a1\ufe0f\u26d4\ufe0f\ud83c\udf0a", "Woe to him who would not be true, even though to be false were salvation!": "\ud83d\ude14\u27a1\ufe0f\ud83e\udd25\u274c\u2764\ufe0f, \ud83d\udeab\ud83c\udf08\u27a1\ufe0f\u26b0\ufe0f", "Top-heavy was the ship as a dinnerless student with all Aristotle in his head.": "\ud83d\udea2\ud83d\udcab\ud83c\udf7d\ufe0f\ud83d\udcda\ud83d\udca1\ud83d\udc68\u200d\ud83c\udf93\ud83e\udd2f\ud83e\udde0\ud83d\udcd6", "Look at his hump": "\ud83d\udc40\u27a1\ufe0f\ud83d\udc2b", "From that hour I clove to Queequeg like a barnacle; yea, till poor Queequeg took his last long dive.": "\ud83d\udd70\ufe0f\ud83d\ude0c\ud83e\udd1d\ud83e\udd91\u27a1\ufe0f\ud83e\uddad\ud83c\udf0a\ud83d\udd1a", "numerous nations of them had sworn solemn league and covenant for mutual assistance and protection": "\ud83c\udf0d\u2694\ufe0f\ud83d\udee1\ufe0f\ud83e\udd1d\ud83d\udcdc\u2728", "hardly had the blinding vapor cleared away, when a naked figure with a boarding-sword in his hand, was for one swift moment seen hovering over the bulwarks": "\ud83e\uddd1\u200d\ud83d\ude80\ud83d\udca8\u27a1\ufe0f\ud83d\udc40\ud83d\udc64\ud83d\udd2a\ud83c\udf2c\ufe0f\u2693", "all hands were preparing to cast anchor in the deep; for heavy chains are being dragged along the deck, and thrust rattling out of the port-holes": "\ud83d\udc50\u2693\ud83d\udd27\ud83c\udf0a; \u26d3\ufe0f\ud83d\udcc9\ud83d\udef3\ufe0f, \ud83c\udfa3\ud83d\udd0a\ud83d\udce4\ud83d\udea2", "this corner-anchored old ark rocked so furiously": "\ud83d\udcd0\ud83c\udfe0\ud83d\udef3\ufe0f\ud83d\udcdc\ud83c\udf00", "the frenzy, the boiling blood and the smoking brow, with which, for a thousand lowerings old Ahab has furiously, foamingly chased his prey": "\ud83d\udd25\ud83d\ude21\ud83d\udc89\ud83d\udca6\ud83d\udc80\u26c5\ufe0f\ud83e\udd2f\ud83d\ude24\ud83c\udf0a\u27a1\ufe0f1\ufe0f\u20e30\ufe0f\u20e30\ufe0f\u20e30\ufe0f\u20e3\ud83d\udcc5\u2693\ufe0f\ud83d\udc0b\ud83d\udca8", "Nor was this all. It was unsafe to meddle with the corpses and ghosts of these creatures.": "\ud83d\udc7b\ud83d\ude45\u200d\u2642\ufe0f\ud83d\udc80\ud83d\udcdb\ud83d\udeab\ud83e\udea6", "Believe ye, men, in the things called omens? Then laugh aloud, and cry encore!": "\ud83e\udd14\ud83d\ude4b\u200d\u2642\ufe0f, \ud83d\udc40 \ud83e\ude84\ud83d\udcdc\ud83d\udcc9? \ud83d\ude02\ud83e\udd23, & \ud83d\ude4f\ud83d\udd01!", "with a lantern we might descend into the great Kentucky Mammoth Cave of his stomach": "\ud83e\ude94\u27a1\ufe0f\ud83d\udd73\ufe0f\u2b07\ufe0f\u27a1\ufe0f\ud83d\uddfa\ufe0f\ud83d\udc18\ud83d\udd73\ufe0f\ud83d\udccd\ud83d\udc0e\ud83e\udd87\u26c5", "It was the devious-cruising Rachel, that in her retracing search after her missing children, only found another orphan.": "\ud83d\udef3\ufe0f\ud83d\udc40 Rachel, in her search for her missing children, found another orphan. \ud83d\udc94", "Sometimes these tufts impart a rather brigandish expression to his otherwise solemn countenance.": "\ud83d\udd74\ufe0f\ud83d\udeb6\u200d\u2642\ufe0f\ud83d\udd0d\ud83d\udd1d\ud83d\udff0\ud83d\ude10\ud83d\udd04\ud83d\udeb5\ud83d\ude20\u2728\ud83d\udca5", "I feel deadly faint, bowed, and humped, as though I were Adam, staggering beneath the piled centuries since Paradise.": "\ud83d\ude35\u200d\ud83d\udcab\ud83d\ude29\ud83d\udd3b\ud83d\udd73\ufe0f, \ud83d\ude47\u200d\u2642\ufe0f, \ud83c\udfcb\ufe0f, \ud83d\ude1e\ud83d\udc6b, \ud83e\udd2f\u23f3\ud83c\udf3f\ud83d\udd70\ufe0f\ud83e\udd2f", "T\u2019gallant sails!\u2014stunsails! alow and aloft, and on both sides!": "\ud83e\udee1\u26f5\ufe0f\ud83d\udea9 Mainsails!\u2014Studding sails! below and above, and on both sides!", "It is an ineffably oozy, stringy affair, most frequently found in the tubs of sperm, after a prolonged squeezing, and subsequent decanting.": "\ud83d\udd0d\ud83d\udc40\u2194\ufe0f\ud83d\udca6\ud83e\uddf5\ud83c\udfad, \ud83e\uddfd\ud83e\udd37\u200d\u2642\ufe0f\ud83e\udd14, \ud83d\udec1\ud83d\udd75\ufe0f\u200d\u2642\ufe0f\u2697\ufe0f, \ud83d\udd70\ufe0f\ud83d\udc50, \ud83d\uded2\ud83c\udf77\ud83e\uddea.", "they themselves may have either seen or heard of some one\u2019s falling into a cistern ashore": "\ud83d\udc65\ud83d\udc42\ud83d\udc41\ufe0f\u27a1\ufe0f\ud83e\udd37\u200d\u2642\ufe0f\u2b07\ufe0f\u2b06\ufe0f\u27a1\ufe0f\ud83d\udca7\ud83d\udd73\ufe0f\ud83c\udfdd\ufe0f", "Yet is there hope. Time and tide flow wide.": "\ud83d\udd70\ufe0f\ud83c\udf0a\u2728\ud83d\ude0c\ud83d\ude4f \ud83c\udf0a\ud83d\udd52\u27a1\ufe0f\ud83c\udf0d", "Oh, thou clear spirit, of thy fire thou madest me, and like a true child of fire, I breathe it back to thee.": "\ud83d\ude2e, \ud83c\udf1f\ud83c\udf2c\ufe0f, \ud83d\udd25\ud83d\udc76, \ud83d\udd25\ud83c\udf2c\ufe0f", "When that wicked king was slain, the dogs, did they not lick his blood?": "\ud83d\udc51\ud83d\udd2a\ud83d\udc80\ud83d\udc36\ud83e\ude78", "In less than half a minute, this entire thing happened.": "\u23f3\ud83d\udd1c\u2b07\ufe0f 1/2\u20e3\ud83d\udd5b, \ud83d\udff0\u2728all\ud83e\uddb8\u27a1\ufe0f\ud83d\udd1a.", "the monster perpendicularly flitted his tail forty feet into the air, and then sank out of sight like a tower swallowed up": "\ud83d\udc79\u2b06\ufe0f40\ufe0f\u20e3\ud83e\uddb5\u27a1\ufe0f\u2b07\ufe0f\ud83c\udfe2\ud83c\udf00", "it is a damp, drizzly November in my soul": "\ud83c\udf27\ufe0f\ud83c\udf42\ud83d\ude14", "Lit up by the moon, it looked celestial; seemed some plumed and glittering god uprising from the sea.": "\ud83c\udf15\u2728\ud83c\udf0c\ud83d\ude07\ud83c\udf0a", "What is yonder undetected villain\u2019s marble mansion with a door-plate for a waif; what is that but a Fast-Fish?": "\ud83e\udd14\ud83c\udff0\ud83d\udc79\ud83d\udd0d\ud83c\udfe0\ud83d\udeaa\ud83d\udd16\ud83d\udc76\u27a1\ufe0f\ud83d\udc21\ud83d\udea4\ud83c\udfa3", "the sea is his; he owns it, as Emperors own empires": "\ud83c\udf0a\ud83d\udc0b\ud83d\udc51; \ud83e\udd34\ud83c\udf0a, \ud83d\udd31\ud83d\udc51\ud83c\udf0e", "Is the steward an apothecary, sir?": "\ud83e\uddd0\ud83d\udc49\ud83e\udd35\ud83d\udc8a\u2753", "the full terror of the voyage must be kept withdrawn into the obscure background": "\ud83d\ude31\ud83d\udea2\u2728 must \u27a1\ufe0f be \u21a9\ufe0f\ud83d\udd19\ud83d\udce5 into the \ud83c\udf11\u2b1b\ufe0f background", "then all this desolate vacuity of life went away": "\ud83d\udd70\ufe0f\u27a1\ufe0f\ud83c\udf0c\ud83e\udd37\u200d\u2642\ufe0f\u27a1\ufe0f\ud83d\ude14\ud83c\udf00\u27a1\ufe0f\ud83d\udc4b", "Whole Atlantics and Pacifics seemed passed as they shot on their way, till at length the whale somewhat slackened his flight.": "\ud83c\udf0a\ud83c\udf0a\ud83c\udf0a\ud83c\udf0a\ud83c\udf0a\ud83c\udf0a\ud83d\udc0b\u23e9\ud83d\udee4\ufe0f, \ud83d\udee4\ufe0f\u23e9\ud83d\udcc9\ud83d\udca8\ud83c\udf0a", "A thin joist of a spine never yet upheld a full and noble soul.": "\ud83e\udeb5\u27a1\ufe0f\ud83e\udd0f\ud83c\udffe\ud83e\uddcd\u200d\u2642\ufe0f\u27a1\ufe0f\ud83e\uddb4\u2728\u27a1\ufe0f\ud83d\udc4e\u27a1\ufe0f\ud83d\udc4f\ud83d\ude07\ud83d\udd4a\ufe0f", "he would have been deified by their child-magian thoughts": "\ud83d\ude47\u2728\ud83d\udc7c \ud83e\udd14\ud83d\udcad\ud83d\udeb8=>\ud83d\udd74\ufe0f\ud83d\udd2e", "millions of mixed shades and shadows, drowned dreams, somnambulisms, reveries; all that we call lives and souls, lie dreaming, dreaming": "\ud83c\udf08\ud83d\udda4\ud83c\udf2b\ud83d\udcad\ud83d\udca4\ud83c\udf19\u2728; \ud83c\udf0d\ud83d\ude34\ud83c\udf00\ud83c\udf0c, \ud83d\udc7b\ud83d\udcad; \ud83c\udf1c\u2728\ud83c\udf1f\ud83d\udcad\ud83d\udcad", "He loved to dust his old grammars; it somehow mildly reminded him of his mortality.": "\ud83d\udc68\u2764\ufe0f\u27a1\ufe0f\ud83e\uddf9\ud83d\udcda\ud83d\udcd6; \ud83d\udc74\ud83d\udd19\ud83e\udde0\u27a1\ufe0f\ud83d\udd70\ufe0f\ud83e\udea6", "all whose creatures prey upon each other, carrying on eternal war since the world began": "\ud83e\udd81\ud83d\udd04\ud83d\udc07\ud83e\udd85\n\ud83c\udf0f\ud83d\udde1\ufe0f\n\u23f3", "many is the time the poor fellows, just buttoning the necks of their clean frocks, are startled by the cry of \u201cThere she blows!\u201d and away they fly to fight another whale": "\ud83d\udc0b\u231a\ud83d\ude2e\u200d\ud83d\udca8\ud83d\udc66\ud83d\ude1f\ud83d\udc55\u2728\ud83e\udde5\ud83d\udd18\ud83d\ude32\ud83d\udce3\ud83d\udc42\u2708\ufe0f\ud83d\udc33\u2694\ufe0f", "in the ordinary swimming position of the Sperm Whale, the front of his head presents an almost wholly vertical plane to the water": "\ud83d\udc0b\u27a1\ufe0f\ud83c\udf0a\ud83d\udccf\ud83d\udca7", "For unless you own the whale, you are but a provincial and sentimentalist in Truth.": "\ud83c\udf0a\ud83d\udc0b\u27a1\ufe0f\u274c\ud83d\udc64\ud83c\udf0d, \ud83e\udef5=\ud83d\udc94\ud83c\udfde\ufe0f\ud83d\udcad\u27a1\ufe0f\ud83e\uddd0\u2712\ufe0f", "keep cool, keep cool\u2014cucumbers is the word": "\ud83c\udd92\ud83c\udd92\ud83e\udd52\ud83d\udde3\ufe0f", "Right and left, the streets take you waterward.": "\u27a1\ufe0f\u2194\ufe0f\u2b05\ufe0f \ud83d\udee3\ufe0f \ud83c\udfd9\ufe0f\ud83d\udeb6\u200d\u2642\ufe0f\ud83d\udeb6\u200d\u2640\ufe0f\ud83c\udf0a", "all these are but subtile deceits, not actually inherent in substances, but only laid on from without": "\ud83d\udd0d\ud83c\udf10\ud83c\udfad\u2728 not actually \ud83d\udce6\ud83e\uddec, but \ud83d\udeab\ud83d\udd1c\ud83c\udfa8\ud83d\udd8c\ufe0f\ud83c\udf10", "And that the great monster is indomitable, you will yet have reason to know.": "\ud83e\udee2 \ud83d\udc09 \ud83e\udd96 \u27a1\ufe0f \ud83d\ude24, \u23f3 \ud83d\ude47\u200d\u2642\ufe0f \ud83d\udca1", "With books the same. The truest of all men was the Man of Sorrows, and the truest of all books is Solomon\u2019s": "\ud83d\udcda\ud83e\udd14 \ud83d\udcda\u2728\ud83d\udc64\u2728\ud83d\ude22, \u2728\ud83d\udcda\u2728\ud83d\udcd6\u2728\ud83d\udc51\ud83d\udcdd", "any man unaccustomed to such sights, to have looked over her side that night, would have almost thought": "\ud83e\uddcd\u200d\u2642\ufe0f\u274c\ud83d\udc40\ud83d\udc41\ufe0f\ud83d\udc40\ud83d\udcc5\ud83c\udf1a,\ud83d\udc40\u2b07\ufe0f\u2b06\ufe0f\u26f5\ud83c\udf03,\ud83d\udc40\ud83d\udcad\ud83e\udde0", "the stricken whale, without at all sounding, still continued his horizontal flight, with added fleetness": "\ud83d\udc0b\ud83d\udca2, \u26d4\ud83d\udd0a, \u27a1\ufe0f\ud83d\udd04\u2194\ufe0f\ud83d\udeeb, \u2795\u26a1\ud83d\udca8", "Dash the nose from Phidias\u2019s marble Jove, and what a sorry remainder!": "\ud83c\udf00\ud83d\udc43\ud83d\uddffPhidias\u2019s\ud83e\udea8\ud83e\uddff, and \ud83d\ude22\ud83d\udd1a!", "these spiritual throes in him heaved his being up from its base, and a chasm seemed opening in him": "\ud83c\udf0c\ud83d\udcab these \ud83d\ude4f\ud83d\udd25 in him \ud83c\udf2a\ufe0f his \ud83c\udf0d\ud83c\udf1f up from its \ud83c\udfde\ufe0f\ud83d\udd3d, and a \ud83c\udf0b seemed \u26cf\ufe0f in him", "Here Saturn\u2019s grey chaos rolls over me, and I obtain dim, shuddering glimpses into those Polar eternities": "\ud83c\udf0c\ud83e\ude90\ud83c\udf2b\ufe0f rolls over me, and I obtain \ud83c\udf2b\ufe0f\ud83d\ude31 glimpses into those \ud83c\udf0c\u2744\ufe0f\u231b", "But neither great Washington, nor Napoleon, nor Nelson, will answer a single hail from below": "\ud83d\ude45\u200d\u2642\ufe0f\ud83d\udde3\ufe0f\ud83c\uddfa\ud83c\uddf8\ud83e\udd35\ud83e\ude96\ud83d\udd31\ud83d\udcac\ud83d\udc42\u2b07\ufe0f", "all the coopers in creation couldn\u2019t show hoops enough to make oughts enough": "\ud83e\udeb5\ud83d\udd28\ud83c\udf0d \ud83e\udd7d\ud83e\udd37\u200d\u2642\ufe0f\u2b06\ufe0f\ud83d\udd04\ud83d\udcaf\ud83e\ude85\u2b55\u27a1\ufe0f\ud83d\udc4c", "they deemed our ship some drifting, uninhabited craft; a thing appointed to desolation": "\ud83d\udc65\ud83d\udd0d\ud83d\udef3\ufe0f\u27a1\ufe0f\ud83c\udf0a\ud83d\udee0\ufe0f\u27a1\ufe0f\ud83c\udfdd\ufe0f\ud83d\udeab\ud83c\udfe0; \ud83d\udcdc\u27a1\ufe0f\ud83d\udc80", "athirst in the great American desert": "\ud83e\uddd1\u200d\ud83e\udd20\ud83d\udca7\ud83c\udfdc\ufe0f\ud83c\udf35\ud83c\uddfa\ud83c\uddf8", "when the second iron is thrown overboard, it becomes a dangling, sharp-edged terror, skittishly curvetting about both boat and whale": "\ud83d\udd04\ud83e\ude93\u2757\u2693\ufe0f\ud83d\udee5\ud83d\udc0b", "these were words best omitted here; for you live under the blessed light of the evangelical land": "\ud83d\udcac\u274c\ud83d\udd24\u2b07\ufe0f\ud83d\udde3\ufe0f; \ud83c\udf0d\ud83c\udf1e\ud83d\ude4c\ud83d\udcd6\u271d\ufe0f", "if thou could\u2019st, blacksmith, glad enough would I lay my head upon thy anvil, and feel thy heaviest hammer between my eyes": "\ud83d\ude47\u200d\u2642\ufe0f\ud83e\udd32\ud83d\udee0\ufe0f\u2728\ud83d\ude0c\ud83d\udd28\ud83d\udca5\ud83d\udc40", "if you have anything important to tell us, out with it; but if you are only trying to bamboozle us, you are mistaken in your game": "\ud83d\udde3\ufe0f\ud83d\udcac\u2757\ufe0f\ud83e\udd14\ud83e\udd2b\ud83d\ude07\ud83d\uded1\ud83e\udd25\ud83c\udccf\ud83e\udee2\ud83d\ude0f\ud83c\udfb2", "the long tension of Ahab\u2019s bodily strength did crack, and helplessly he yielded to his body\u2019s doom": "\n\ud83e\uddd3\ud83d\udcaa\ud83d\udca5\ud83d\udc94\ud83d\ude1e\ud83d\udc50\u27a1\ufe0f\ud83e\udea6", "Nantucket was her great original\u2014the Tyre of this Carthage;\u2014the place where the first dead American whale was stranded.": "\ud83c\udfdd\ufe0f\ud83d\udd70\ufe0f\u27a1\ufe0f\ud83c\udff4\u200d\u2620\ufe0f\ud83d\udccd\ud83d\udc0b\u2620\ufe0f\ud83c\uddfa\ud83c\uddf8\u2b05\ufe0f", "they all disappeared far to leeward, still in bold, hopeful chase": "\ud83d\udc65\u2728\ud83c\udfc3\u200d\u2642\ufe0f\ud83c\udfc3\u200d\u2640\ufe0f\ud83d\udca8\ud83d\udd19 \u27a1\ufe0f\ud83c\udf43\ud83d\udc3e\ud83d\udcaa\ud83d\udcab", "How it is, there is no telling": "\ud83e\udd37\u200d\u2642\ufe0f\ud83e\udd37\u200d\u2640\ufe0f\u2753\ud83d\udd2e", "He became a nameless terror to the ship.": "\ud83d\udc64\u27a1\ufe0f\ud83d\ude28\u2693\ud83d\udea2", "This vigilance was not long without reward.": "\ud83d\udd0d\u23f3\u27a1\ufe0f\ud83c\udfc6", "keep a bright look-out": "\ud83d\udc40\u2728\ud83d\udeb6\u200d\u2642\ufe0f", "his head was phrenologically an excellent one": "\ud83e\uddd1\u200d\ud83e\uddb2\ud83e\udde0\ud83d\udc4d", "I thought I might as well go below and make a rough draft of my will.": "\ud83e\udd14\u27a1\ufe0f\ud83d\udc47\ud83d\udcdd\ud83d\udcc4\ud83d\udd8b\ufe0f", "like man, the whale has lungs and warm blood. Freeze his blood, and he dies.": "\ud83d\udc4d\ud83d\udc68, \ud83d\udc33 \ud83e\udec1 \ud83d\udd25\ud83e\ude78. \u2744\ufe0f\ud83e\ude78, \ud83d\udc80.", "there were some boobies and bumpkins there, who, by their intense greenness, must have come from the heart and centre of all verdure": "\ud83e\udda4\ud83d\udc62\ud83c\udf3f\u2728, \ud83c\udf31\ud83d\udee4\ud83d\udc9a\ud83d\udd0d\u27a1\ufe0f\ud83d\udcdd\ud83c\udf32\u2728", "let us now have a good long look": "\ud83d\udc40\ud83d\udcd6\ud83d\ude0a\ud83d\udd0d", "It is as though the forehead of the Sperm Whale were paved with horses\u2019 hoofs. I do not think that any sensation lurks in it.": "\ud83d\udc0b \u27a1\ufe0f \ud83e\udd14 \ud83d\udcad \u27a1\ufe0f \ud83e\udd2f \u2692\ufe0f \ud83d\udc0e \ud83e\uddb6. \u274c \ud83d\udcac \ud83e\udde0 \u27a1\ufe0f", "treacherously hidden beneath the loveliest tints of azure": "\ud83d\ude08\ud83d\udd04\ud83c\udf3f\ud83c\udf43\ud83c\udf38\ud83d\udd35", "I believe that much of a man\u2019s character will be found betokened in his backbone.": "\ud83e\udde0\u2728\ud83d\udcad\n\ud83d\ude4b\u200d\u2642\ufe0f\ud83c\udf1f\ud83d\udc64\ud83e\uddd0\ud83d\udc4d\n\ud83d\ude4c\ud83d\udcda\ud83c\udf43\ud83e\uddb4\u2728", "better answer": "\ud83d\udc4d\u2728", "how may unlettered Ishmael hope to read the awful Chaldee of the Sperm Whale\u2019s brow?": "\ud83e\udd14\ud83d\udcd6\u2753\ud83d\udfe2\ud83d\udd75\ufe0f\u200d\u2642\ufe0f\ud83c\udf0a\ud83d\udc0b\ud83d\udcdd\ud83d\udc40\ud83d\ude31", "Still, we can hypothesize, even if we cannot prove and establish.": "\ud83e\udd14\ud83d\udcad\ud83d\udd0d, we can \ud83e\udde9, even if we cannot \u2705\ud83d\udcdc.", "Of all divers, thou hast dived the deepest.": "\ud83c\udf0a\ud83e\udd3f Of all divers, thou hast dived the deepest. \ud83c\udf0a\ud83e\udd88", "what has been promiscuously said, thought, fancied, and sung of Leviathan": "\ud83d\udd0a\ud83e\udd14\ud83d\udcad\ud83c\udfb6\ud83d\udc0b", "he still hugged me tightly, as though naught but death should part us twain": "\ud83d\udc6b\ud83d\udc94\ud83e\udd17\ud83d\udc80", "diving under the ultimate glassy barriers and walls there, come up among icy fields and floes": "\ud83e\udd3f\u2b07\ufe0f \ud83c\udf0a\ud83e\ude9f\u26d4\ufe0f\ud83e\uddf1\u2795\ud83e\uddf1 \ud83e\uddf1\u2194\ufe0f\ud83c\udfd4\ufe0f\u2744\ufe0f\ud83c\udfd4\ufe0f \ud83d\udc49 \u2b06\ufe0f \ud83c\udf28\ufe0f\u2744\ufe0f\ud83c\udfd4\ufe0f \u2744\ufe0f\ud83e\uddca", "where, I should like to know, will you obtain a better chance to study practical cetology than here?": "\ud83c\udf0d\u2753\ud83e\udd14\u27a1\ufe0f\ud83d\udcda\ud83d\udc0b\ud83d\udca1\ud83d\udd0e\ud83c\udfeb\ud83d\udc49\ud83c\udffe\u231b", "Some unknown conduits from the unknown worlds must empty into thee!": "\ud83c\udf0c\u2753\ud83c\udf10\ud83c\udf0c\u2753\u2794\ud83d\udca7\ud83d\udc49\ud83e\udef5", "odds and ends of strange nations come up from the unknown nooks and ash-holes of the earth to man these floating outlaws of whalers": "\ud83e\udde9\ud83c\udf0d\u2753\ud83d\udc73\u200d\u2642\ufe0f\ud83e\udd98\ud83c\udf11\ud83d\udd73\ufe0f\ud83d\udef3\ufe0f\ud83d\udc0b", "Yet what depths of the soul does Jonah\u2019s deep sealine sound!": "\ud83c\udf00\ud83d\ude31\ud83c\udf0a\ud83d\udc0b\ud83e\udd3f\ud83d\udd73\ufe0f", "this consciousness at last glided away from me": "\ud83e\udde0\u27a1\ufe0f\ud83d\ude0c\u23f3\ud83d\udeb6\u200d\u2642\ufe0f", "'Tis July's immortal Fourth; all fountains must run wine today!": "\ud83c\udf87\ud83c\udf77\ud83c\udf1f 'Tis July's immortal Fourth; all fountains must run wine today! \ud83c\udf1f\ud83c\udf77\ud83c\udf87", "In truth, a mature man who uses hair-oil, unless medicinally, that man has probably got a quoggy spot in him somewhere.": "\ud83d\udd0d\ud83e\udd14\ud83d\udc68\u200d\ud83e\uddb3\ud83e\uddb9\u200d\u2642\ufe0f\ud83e\uddf4\ud83d\udee2\ufe0f, \u274c\ud83d\udc8a, \ud83e\uddd4\u27a1\ufe0f\ud83e\udd2f\ud83d\udcad\ud83d\udfe4\ud83d\udc64\ud83d\ude2c\ud83d\udd0e", "embracing one half of the level horizon, a continuous chain of whale-jets were up-playing and sparkling in the noon-day air": "\ud83e\udec2 \u2797 \ud83c\udf06 = \ud83e\udd2f\ud83d\udcc8 a continuous chain of \ud83d\udc0b\ud83d\udca6 were \ud83c\udf0a\u2728 in the \ud83c\udf1e-day \ud83c\udf2c\ufe0f", "are you the man to snap your spine": "\ud83d\udc68\u2753\ud83e\udef5\ud83d\udc68\u200d\ud83e\uddb2\ud83d\udc49\ud83d\udcf8\ud83e\uddb4", "Gabriel, ascending to the main-royal mast-head, was tossing one arm in frantic gestures, and hurling forth prophecies of speedy doom to the sacrilegious assailants of his divinity.": "\ud83d\udc68\u200d\ud83e\uddb1\u2b06\ufe0f\u26f5\ufe0f\ud83c\udf1f\ud83d\udca8\ud83d\ude4b\u200d\u2642\ufe0f\ud83d\ude31\u26a1\ufe0f\ud83d\udce2\ud83c\udff4\u200d\u2620\ufe0f\ud83d\udca3\ud83d\udc40\u26d4\ufe0f\ud83d\uded0", "Yet this is nothing": "\ud83d\udfe1\u2795\ud83d\udfe1\ud83d\udd1c\ud83d\udd19\u27a1\ufe0f\ud83c\udd7e\ufe0f", "spouting all over the sea, and sprinkling and mistifying the gardens of the deep": "\ud83d\udc33\ud83d\udca6\ud83c\udf0a, \ud83c\udf2c\ufe0f\ud83d\udca7\ud83c\udf38\ud83c\udfdd\ufe0f", "We try to reach Virtue, when lo! comes Cancer the Crab, and drags us back": "\ud83d\udd1c\u2728\u2196\ufe0f\ud83c\udf1f, \ud83d\ude32\ud83e\udd80\u23ea", "lo! a broad white shadow rose from the sea; by its quick, fanning motion, temporarily taking the breath out of the bodies of the oarsmen": "\ud83c\udf0a\u2757\ud83d\udc50\ud83c\udf0c\ud83d\udc7b\u2b06\ufe0f\ud83c\udf05;\ud83c\udf2c\ufe0f\u26a1\ud83d\udea3\u200d\u2642\ufe0f\ud83d\udcf4", "Gabriel once more started to his feet, glaring upon the old man, and vehemently exclaimed, with downward pointed finger\u2014\u201cThink, think of the blasphemer\u2014dead, and down there!\u2014beware of the blasphemer\u2019s end!\u201d": "\ud83d\ude24\ud83e\uddd4\u200d\u2642\ufe0f\u27a1\ufe0f\ud83c\udfc3\u200d\u2642\ufe0f\u2b06\ufe0f\ud83d\udc40\ud83d\udc74\ud83d\udca2\u261d\ufe0f\ud83d\udc47\ud83d\udcac \"\ud83e\udd14\ud83e\udd14\ud83d\ude08\u2620\ufe0f\u2b07\ufe0f!\u26a0\ufe0f\ud83d\ude08's\ud83d\udd1a!\"", "An intense copper calm, like a universal yellow lotus, was more and more unfolding its noiseless measureless leaves upon the sea.": "\ud83c\udf05\ud83d\udc9b\ud83c\udf3c\ud83c\udf0a", "away with child\u2019s play; no more gaffs and pikes to-day": "\ud83d\udeab\ud83c\udfad; \ud83d\udeab\ud83e\ude93\ud83c\udfa3\ud83d\udcc5", "he too lives like a Czar in an ice palace made of frozen sighs": "\ud83d\udc51\u2744\ufe0f\ud83c\udff0\ud83c\udfd4\ufe0f\ud83d\udca8", "these queer proceedings increased my uncomfortableness": "\ud83d\ude30\ud83d\udc40 these \ud83c\udff3\ufe0f\u200d\ud83c\udf08\ud83e\udd14 proceedings \ud83d\udcc8 increased \u2795 my \ud83d\ude23 uncomfortableness", "Consider the subtleness of the sea": "\ud83c\udf0a\u2728\ud83e\udd14", "washed by waves, and cooled by breezes": "\ud83c\udf0a\ud83c\udf00 \ud83c\udf2c\ufe0f\ud83c\udf43", "Days, weeks passed, and under easy sail, the ivory Pequod had slowly swept across four several cruising-grounds": "\ud83d\uddd3\ufe0f\u27a1\ufe0f\ud83d\uddd3\ufe0f\ud83d\udcc5\u23f3, \ud83c\udf0a\u26f5, \ud83d\udc18\u2693\ud83d\udea2 \ud83d\udc33\ud83d\udca8 \ud83d\udc22\ud83c\udf10\ud83d\uddfa\ufe0f4\u20e3 \ud83d\udef3\ufe0f\ud83d\udc33", "Yet Dives himself, he too lives like a Czar in an ice palace made of frozen sighs": "\ud83e\udd11\u2744\ufe0f\ud83d\udc51\ud83c\udff0\ud83d\ude22", "this were as vain a thing as to attempt weighing a Dutch barn in jewellers\u2019 scales": "\ud83d\udd04\u2696\ufe0f\ud83d\uded6\ud83d\udc8e\u2696\ufe0f", "\u201cAye? Well, now, that\u2019s cheering,\u201d cried Ahab, suddenly erecting himself, while whole thunder-clouds swept aside from his brow.": "\"\ud83d\udde3\ufe0f? Well, now, that\u2019s \ud83d\ude00,\" cried \ud83e\uddd4\u200d\u2642\ufe0f, suddenly \ud83d\udeb6\u200d\u2642\ufe0f, while whole \ud83c\udf29\ufe0f swept aside from his brow.", "almost squared by the enormous superincumbent mass of the junk and sperm": "\ud83d\udfe7\u2753 by the \ud83c\udfd4\ufe0f\ud83d\udfe9 \u2b1b\ufe0f of the \ud83d\uddd1\ufe0f\ud83e\uddca and \ud83e\udd96\ud83e\uddb4", "It makes a stranger stare.": "\ud83d\ude32\ud83d\udc40\ud83d\udc64", "The white whale is their demigorgon.": "\ud83e\udd88\ud83d\udc7b\n**\n**The white whale is their demigorgon.**\nNote: In this conversion, \ud83e\udd88 represents \"whale,\" and \ud83d\udc7b represents \"demigorgon.\" This translation captures the essence of the phrase but may not convey the exact literary reference.", "surrounded by five dusky phantoms that seemed fresh formed out of air": "\ud83c\udf2b\ufe0f\ud83e\udddf\u200d\u2642\ufe0f\ud83e\udddf\ud83e\udddf\u200d\u2640\ufe0f\ud83e\udddf\u200d\u2642\ufe0f\ud83e\udddf\u200d\u2640\ufe0f \ud83c\udf2b\ufe0f", "and beyond, a black Angel of Doom was beating a book in a pulpit.": "\ud83d\udcd6\u2728, \ud83d\ude08\ud83d\udc7c \ud83c\udf11 \u23f3 \ud83d\udcd6 \ud83c\udf29\ufe0f\ud83d\udcd6 \ud83d\ude07", "he may be deemed a sort of involuntary whaleman; at any rate the whale caught him, if he did not the whale": "\ud83d\udc64\ud83e\udd37\u200d\u2642\ufe0f\ud83d\udc0b\u2192\ud83d\udc68\u200d\u2708\ufe0f; \ud83d\udc0b\ud83c\udfa3\ud83d\udc66, \ud83e\uddcd\u200d\u2642\ufe0f\ud83d\udeab\ud83c\udfa3\ud83d\udc0b", "Interweaving in its proper place this darker thread with the story as publicly narrated on the ship, the whole of this strange affair I now proceed to put on lasting record.": "\ud83e\uddf5\ud83d\udda4\ud83d\udef3\ufe0f\ud83d\udcd6\u2728\ud83d\udd0d\u270d\ufe0f\ud83d\udcdc", "the boat was still booming through the mist, the waves curling and hissing around us like the erected crests of enraged serpents": "\ud83d\udea4\ud83c\udf2b\ufe0f\ud83c\udf0a\ud83d\udd0a\ud83c\udf2c\ufe0f\ud83d\udc0d\ud83d\udca2", "In short, he is what the fishermen technically call a \u201cgrey-headed whale.\u201d": "\ud83d\udcdd\ud83d\udeb6\ud83d\udc1f\ud83d\udd0d\ud83d\udc68\u200d\ud83e\uddb3\ud83d\udc0b", "I have the satisfaction of knowing that it is all right; that everybody else is one way or other served in much the same way": "\ud83d\ude0a\ud83e\udd14\ud83d\udc4d\ud83d\ude0c; \ud83e\uddd1\u200d\ud83e\udd1d\u200d\ud83e\uddd1\ud83d\udc69\u200d\ud83e\udd1d\u200d\ud83d\udc68\ud83d\udc68\u200d\ud83d\udc69\u200d\ud83d\udc66\u200d\ud83d\udc66\u27a1\ufe0f\ud83d\udc48\u27a1\ufe0f\ud83d\ude4c\u2728", "In life but few of them would have helped the whale, I ween, if peradventure he had needed it; but upon the banquet of his funeral they most piously do pounce.": "\ud83c\udf0a\ud83d\udc64\ud83d\udcad\ud83d\udc0b\u2753\ud83d\udeab\ud83c\udd98\ud83d\ude45\u200d\u2642\ufe0f\ud83d\udcad\ud83c\udf7d\ufe0f\u26b0\ufe0f\ud83d\ude47\u200d\u2642\ufe0f\ud83c\udf74", "The Nut.": "\ud83e\udd5c", "be a philosopher": "\ud83e\udd14\ud83d\udcda", "Close to our bows, strange forms in the water darted hither and thither before us; while thick in our rear flew the inscrutable sea-ravens.": "\ud83d\udef6\ud83c\udf0a\ud83e\udd14\ud83d\udc7d\ud83d\udc1f\ud83d\udca6\u27a1\ufe0f\u2b05\ufe0f\ud83d\udd19\ud83d\udc41\ufe0f\u200d\ud83d\udde8\ufe0f\ud83d\udd4a\ufe0f\ud83c\udf0a", "I once saw a large herd of whales in the east, all heading towards the sun, and for a moment vibrating in concert with peaked flukes.": "\ud83d\udc0b\ud83c\udfde\ufe0f\u27a1\ufe0f\ud83c\udf05, \ud83c\udfb6\u2728\ud83d\udc40\ud83d\udc49\ud83c\udfb5\ud83c\udfb6\ud83d\udd1d\ud83d\udc0b", "The Nantucketer, he alone resides and riots on the sea": "\ud83e\uddd4\u2693\ufe0f, \ud83c\udf0a\ud83c\udfdd\ufe0f, \ud83c\udfe0\ud83d\udd39 \ud83c\udf89\ud83d\udd39 \u26f5\ufe0f", "your bill of fare is immutable": "\ud83c\udf7d\ufe0f\ud83d\udcdc\ud83d\udd12", "And God created great whales.": "\ud83c\udf0c\ud83d\ude4f\ud83c\udf0a\ud83d\udc0b", "All thy unnamable imminglings float beneath me here": "\ud83d\udd2e All thy unnamable \ud83c\udf2b\ufe0f imminglings float beneath me here \ud83c\udf0a", "Like the great dome of St. Peter\u2019s, and like the great whale, retain, O man! in all seasons a temperature of thine own.": "\ud83d\udc4d\ud83c\udfdb\ud83d\udd4a, \ud83d\udc0b, \ud83e\uddca\ud83c\udf21\ud83d\ude0a\ud83d\udd70\ud83d\udcaa\ud83d\udc68!", "I now prophesy that I will dismember my dismemberer.": "\ud83d\udd2e\u27a1\ufe0f\ud83e\udd3a\u2702\ufe0f\u2194\ufe0f\ud83e\ude93", "Over this lip, as over a slippery threshold, we now slide into the mouth.": "\ud83d\udc44\u2b06\ufe0f\ud83d\udc48\u27a1\ufe0f\ud83e\ude9c\ud83d\udeaa\ud83d\udee4\ufe0f\u27a1\ufe0f\ud83d\ude0a", "so the wretched infidel gazes himself blind at the monumental white shroud that wraps all the prospect around him": "\ud83e\uddd4\u200d\u2642\ufe0f\u27a1\ufe0f\ud83d\udc40\u274c\ud83d\udcdc\ud83c\udff3\ufe0f\ud83c\udfd4\ud83d\uddfa", "\u201cI will have no man in my boat,\u201d said Starbuck, \u201cwho is not afraid of a whale.\u201d": "\ud83d\udde3\ufe0f\ud83d\udeab\ud83d\udc68\u200d\u2708\ufe0f\ud83d\udea3\u200d\u2642\ufe0f, \ud83d\udde3\ufe0f\u2b50\ud83e\udd8c, \ud83d\udde3\ufe0f\ud83d\udde3\ufe0f, \"\ud83d\uded1\u2693\ufe0f\ud83d\udc0b\".", "If man will strike, strike through the mask!": "\ud83d\udc68\u26a1\ud83c\udfad", "With a frigate\u2019s anchors for my bridle-bitts and fasces of harpoons for spurs, would I could mount that whale and leap the topmost skies": "\u2693\ud83d\udc0b\ud83c\udf0c", "So with stun-sail piled on stun-sail, we sailed along, driving these leviathans before us": "\ud83d\udcdc\ud83d\udef3\ufe0f\u27a1\ufe0f\ud83d\udef3\ufe0f\ud83c\udf2c\ufe0f\u27a1\ufe0f\u27a1\ufe0f\ud83e\udd88\u2b06\ufe0f\u27a1\ufe0f\u27a1\ufe0f\ud83c\udf0a", "the great floodgates of the wonder-world swung open": "\ud83c\udf0a\ud83d\udeaa\u2728\ud83c\udf0d opened", "he followed these fish for the fun of it; and a three years\u2019 voyage round Cape Horn was only a jolly joke that lasted that length of time": "\ud83e\uddd4\u27a1\ufe0f\ud83d\udc1f\ud83c\udfa3\ud83d\ude02; \u26f5\ud83c\udf0e\ud83c\udf0a\ud83c\udf0d\u26933\ufe0f\u20e3\ud83d\udcc5\ud83e\udd23\ud83d\udd70\ufe0f", "I remember the first albatross I ever saw.": "\ud83d\ude0a\ud83d\udcad\ud83d\udd70\ufe0f1\ufe0f\u20e3\ud83e\udda4\ud83d\udc40", "Curses throttle thee!": "\ud83e\udd2c\ud83e\udd2f\ud83d\udde3\ufe0f\ud83c\udf00", "go down to the fiery pit itself, in order to keep out this frost": "\u2b07\ufe0f\ud83d\udd25\ud83d\udd73\ufe0f\u27a1\ufe0f\u2744\ufe0f\ud83d\udeab", "seize hold of the nearest oarsman\u2019s hair, and hold on there like grim death": "\ud83d\udcaa\ud83d\udef6\ud83d\udc64\ud83d\udc4b\ud83e\uddb1\u26d3\ufe0f\ud83d\udc80", "What of it, if some old hunks of a sea-captain orders me to get a broom and sweep down the decks?": "\ud83e\udd14 \ud83c\udf0a \u26f5\ufe0f\ud83e\uddf9\u2728", "all ye nations before my prow, I bring the sun to ye": "\ud83c\udf0d\ud83c\udf10\ud83d\udea2\u26f4\ufe0f\ud83d\udce2\ud83d\udd06\u27a1\ufe0f\ud83c\udf1e\ud83e\udef5", "I have sometimes pleased myself": "\ud83d\ude4b\u200d\u2642\ufe0f\ud83d\ude0a\ud83d\udc4c\ud83d\ude0c", "The sailors, mostly poor devils, cringed, and some of them fawned before him; in obedience to his instructions, sometimes rendering him personal homage, as to a god.": "\ud83d\udc68\u200d\u2708\ufe0f\ud83e\uddd4\u200d\u2642\ufe0f\ud83d\udea2, \ud83d\ude1f\ud83d\udc7f\ud83d\udc65, \ud83d\ude16, \ud83d\ude27\ud83d\uded0\ud83d\udc68\u200d\u2708\ufe0f; \ud83d\udc47\ud83d\udcdc\ud83e\uddd4\u200d\u2642\ufe0f\ud83c\udf1f, \ud83d\udd04\ud83d\ude47\u200d\u2642\ufe0f\ud83c\udfdb\ufe0f, \ud83d\uded0\ud83c\udd98\ud83c\udf1f, \ud83d\ude4f\ud83d\udd31.", "into this noiselessness came Ahab alone": "\ud83c\udf0c\ud83e\uddb6\ud83d\udc68\u200d\ud83e\uddb3\u26f5", "playing upon this crimson pond in the sea": "\ud83c\udfad \ud83c\udf0a \ud83d\udd34 \ud83c\udf05 \ud83d\udc1f", "For what are the comprehensible terrors of man compared with the interlinked terrors and wonders of God!": "\ud83c\udf0d\ud83e\udd14\u27a1\ufe0f\ud83d\ude31\ud83e\udd37\u200d\u2642\ufe0fvs\ud83d\udd17\ud83d\ude28\u2728\ud83d\ude4f\ud83d\udc40", "\u201cthe tall pale man\u201d of the Hartz forests, whose changeless pallor unrustlingly glides through the green of the groves\u2014why is this phantom more terrible than all the whooping imps of the Blocksburg?": "\ud83c\udf32\ud83d\udc64\"the tall pale man\" of the \ud83c\udf33Hartz forests, whose \ud83c\udff3\ufe0fchangeless pallor unrustlingly glides through the \ud83c\udf3fgreen of the groves\u2014\u2753why is this \ud83d\udc7bphantom more \ud83d\ude28terrible than all the \ud83c\udfd4\ufe0fwhooping imps of the \ud83c\udfde\ufe0fBlocksburg?", "full of barbaric spirit and suggestiveness, as the prints of that fine old Dutch savage, Albert Durer": "\ud83e\udd81\u2728 \ud83c\udff0\u2694\ufe0f \ud83c\udf0d\ud83e\udded \ud83c\udfa8\ud83d\uddbc\ufe0f \ud83c\uddf3\ud83c\uddf1\ud83e\uddd4\u200d\ud83c\udfa8 \ud83d\udd25\ud83d\udcdc\n\n(Note: Albert Durer is presumably referring to Albrecht D\u00fcrer, a renowned German artist, often mistakenly identified as Dutch in some contexts. For accuracy, you might adjust the flag to \ud83c\udde9\ud83c\uddea. The reference has been adapted in emojis to reflect an old-world, artistic, and somewhat fierce spirit.)", "the most exhilarating conception of what the most exalted potency is": "\ud83c\udf1f\ud83e\udd29\ud83d\udca1\ud83e\udd14\ud83e\udde0\ud83c\udf0c\ud83d\udcaa\u2728", "a tone so strangely compounded of fun and fury, and the fury seemed so calculated merely as a spice to the fun": "\ud83c\udfb6\ud83d\ude06\ud83d\udca5\ud83d\ude06, \ud83d\udca5\ud83d\udccf\ud83c\udf36\ufe0f\ud83c\udf89", "the certainty of this criterion is far from demonstrable": "\ud83d\udd0d\u2753\ud83d\udccf \ud83d\udd04\ud83d\udee4\ufe0f \ud83d\udcc9 \ud83d\udc4e\ud83d\udd2c", "Oh! my friends, but this is man-killing! Yet this is life.": "\ud83d\ude2e! \ud83d\ude4b\u200d\u2642\ufe0f\ud83d\ude4b\u200d\u2640\ufe0f, \ud83d\udc4dthis is \ud83d\udeb6\u200d\u2642\ufe0f\ud83d\udc80! Yet \ud83c\udf31.", "the reason why the grave-digger made music must have been because there was none in his spade": "\ud83d\udcad\ud83d\udd0e\u26b0\ufe0f\ud83d\udd28\ud83c\udfb6\ud83e\udd14\u2795\u274c\ud83d\udc7b\ud83d\udd04\ud83d\udee0\ufe0f", "no wonder that so many hapless harpooneers are madly cursed": "\ud83d\ude45\u200d\u2642\ufe0f\ud83c\udf1f\ud83e\udd14\ud83e\udd37\u200d\u2642\ufe0f\ud83c\udfaf\ud83d\udd1d\ud83d\ude25\ud83d\udef6\ud83d\udc94\ud83d\udde3\ud83d\ude21\ud83d\udc4e", "Thou shalt see my back parts, my tail, he seems to say, but my face shall not be seen.": "\ud83d\udc33\ud83d\udca8\ud83d\udc0b, \ud83d\udc33\ud83c\udf90\ud83e\udd2d, \ud83d\udc64\u2049\ufe0f\ud83d\ude36\ud83d\udeab\ud83d\udc40", "for forty years has Ahab forsaken the peaceful land, for forty years to make war on the horrors of the deep!": "\u26f5\ufe0f\ud83c\udf0a\ud83d\udd31 For 40 years, Ahab abandoned the \ud83c\udfde\ufe0f peaceful land, for 40 years to wage war \u2694\ufe0f on the horrors of the deep! \ud83c\udf0a\ud83e\udd88", "But these are all landsmen; of week days pent up in lath and plaster\u2014tied to counters, nailed to benches, clinched to desks.": "\ud83d\udc68\u200d\ud83d\udcbc\ud83d\udd12\ud83c\udfe2\u27a1\ufe0f\ud83c\udfd8\ufe0f\ud83c\udfe2\ud83d\udcc6\ud83d\udee0\ufe0f\ud83d\udd28\ud83e\ude91\ud83d\udcce\ud83d\udcbc\ud83d\udd29\u270f\ufe0f\ud83d\udcbb", "To begin: there\u2019s Aries, or the Ram\u2014lecherous dog, he begets us; then, Taurus, or the Bull\u2014he bumps us the first thing": "\ud83d\udd1c: \ud83d\udc0f\u2648\ufe0f\u2014\ud83d\udc36\u2764\ufe0f, he \ud83d\udc76 us; then, \ud83d\udc02\u2649\ufe0f\u2014he \ud83e\udd15 us 1\ufe0f\u20e3st thing", "they might scout at Moby Dick as a monstrous fable, or still worse and more detestable, a hideous and intolerable allegory": "\ud83d\udc65\ud83e\udd14\ud83e\uddd0\ud83d\udc33\ud83d\udcd6\ud83e\udd2f\ud83d\udc79\ud83d\ude33\ud83d\udc49\ud83d\udcd5\ud83d\udeab\ud83d\udc4e\ud83e\udd22\ud83e\udd2c\ud83d\udc7a\ud83e\udde9", "Look at your knife-handle, there, my civilized and enlightened gourmand dining off that roast beef, what is that handle made of?\u2014what but the bones of the brother of the very ox you are eating?": "\ud83d\udc40\ud83d\udd2a\u27a1\ufe0f\ud83d\ude4c, \ud83e\uddd1\u200d\ud83c\udf93\ud83c\udf7d\ufe0f\u2728\ud83e\udd69, \ud83e\uddb4\u27a1\ufe0f\ud83d\udc02\ud83c\udf7d\ufe0f\ud83c\udf3f?", "while ponderous planets of unwaning woe revolve round me, deep down and deep inland there I still bathe me in eternal mildness of joy": "\ud83c\udf0c\ud83c\udf0d\ud83d\udcab\ud83d\ude14\ud83d\udd04\ud83d\udd01\ud83d\ude2b\ud83d\udd04\ud83d\udd04\u26ab\ufe0f, \ud83c\udf0a\u2b07\ufe0f\ud83d\udd0d\u2b07\ufe0f\ud83c\udfde\ufe0f\ud83c\udfdd\ufe0f\ud83c\udfd4\ufe0f\ud83c\udf3f\ud83d\ude0c\ud83d\udec0\ud83c\udf1e\ud83d\ude07\u2728\ud83d\ude0a", "its profounder and more subtle meanings": "\ud83d\udd0d\ud83d\udcda\u2728\ud83c\udfad\u21a9\ufe0f\ud83e\udd14\ud83e\udde0\ud83d\udca1", "When in the Southern Fishery, a captured Sperm Whale, after long and weary toil, is brought alongside late at night, it is not, as a general thing at least, customary to proceed at once to the business of cutting him in.": "\ud83d\udc33\ud83c\udf0c\ud83d\udcaa\u23f3\ud83c\udf0a\ud83d\ude45\u200d\u2642\ufe0f\ud83d\udd2a\u23f0\ud83d\udd52\u2702\ufe0f", "Death to Moby Dick! God hunt us all, if we do not hunt Moby Dick to his death!": "\u2620\ufe0f\ud83d\udd2a\ud83d\udc0b! \ud83d\ude4f\ud83d\udd75\ufe0f\u200d\u2642\ufe0f\ud83d\udc41\ufe0f\ud83e\uddd1\u200d\u2708\ufe0f\u26f5\ufe0f, \ud83d\udd25\u274c\ud83d\udeab\ud83d\udd0d\ud83d\udc0b\u2620\ufe0f!", "However, a good laugh is a mighty good thing, and rather too scarce a good thing; the more\u2019s the pity.": "\ud83d\ude02\u27a1\ufe0f\ud83d\ude04\ud83d\udcaa\ud83d\udd1d\ud83d\udc4d, \u2795\ud83e\udd0f\ud83d\ude1f\ud83e\udd84\ud83d\udd1d\ud83d\udc4d; \u2795\ud83d\ude2d\ud83d\ude14.", "Already you know what his blubber is.": "\ud83e\udd14\ud83e\uddd0 \u2753 \ud83d\udc0b\u2795\ud83d\ude04\ud83d\udd0d\ud83d\udcd6", "Whether he had lost that fin in battle, or had been born without it, it were hard to say.": "\ud83e\udd14\ud83e\udd88\u2753\u2694\ufe0f\ud83e\udd15\ud83e\udd37\u200d\u2642\ufe0f", "last night\u2019s thunder turned our compasses": "\ud83c\udf29\ufe0f\u23f0\ud83c\udf19 \ud83d\udd04\ud83e\udded", "no longer will I guide my earthly way by thee": "\ud83d\udeab\u23f3\ud83d\udeb6\u200d\u2640\ufe0f\ud83c\udf0f\u27a1\ufe0f\ud83d\uddfa\ufe0f\ud83d\udd0d\ud83d\udc49\u2728", "the villanous green goggling glasses deceitfully tapered downwards to a cheating bottom": "\ud83d\ude08\ud83d\udfe2\ud83d\udc53\ud83d\udd0d\ud83d\udcc9\ud83d\udd3d\u27a1\ufe0f\ud83d\udd1a\ud83c\udccf", "But, perhaps, to be true philosophers, we mortals should not be conscious of so living or so striving.": "\ud83e\udd14\ud83e\udde0\ud83d\udcad\u27a1\ufe0f\ud83d\udc65\ud83e\uddd1\u200d\ud83c\udf93\ud83d\udc69\u200d\ud83c\udf93\ud83d\udc49\ud83d\ude07\ud83d\ude48\ud83d\udcaa\ud83d\udd25\u274c\ud83c\udfc6\ud83d\ude4c", "her companions swim around her with every token of concern, sometimes lingering so near her and so long, as themselves to fall a prey": "\ud83d\udc65 \ud83d\udc20 \ud83c\udfca\u200d\u2640\ufe0f \ud83e\udd14 \u2764\ufe0f \ud83d\ude1f, \ud83d\udd70\ufe0f \ud83c\udf00 \ud83e\udd17 \u2194\ufe0f \u23f3, \ud83d\ude30 \ud83d\udd70\ufe0f \u231b\ufe0f, \ud83d\udc20 \ud83c\udfa3", "his great genius is declared in his doing nothing particular to prove it": "\ud83d\udc68\u200d\ud83c\udfa8\u2728\ud83e\udd14 \u27a1\ufe0f \ud83d\udc4c\u274c\ud83d\udcdc\ud83e\udde0\u2714\ufe0f", "And thus the work proceeds; the two tackles hoisting and lowering simultaneously; both whale and windlass heaving, the heavers singing, the blubber-room gentlemen coiling, the mates scarfing, the ship straining, and all hands swearing occasionally": "\ud83d\udc33\u26d3\ufe0f\u2195\ufe0f\ud83c\udfb6\ud83d\udd27\ud83d\udcaa\ud83c\udfb5\ud83c\udfb6\ud83d\udce6\u2693\ud83e\udd2c", "is this Moby Dick?": "\ud83d\udc0b\u2753", "Who can tell how appalling to the wounded whale must have been such huge phantoms flitting over his head!": "\ud83e\uddd0\ud83d\udcad\ud83d\udc0b\ud83d\ude28\ud83e\udd15\ud83d\udcad\ud83d\udc7b\ud83d\udef8\ud83e\udd2f\ud83d\udc0b\u2b06\ufe0f", "Ever and anon a bright, but, alas, deceptive idea would dart you through.": "\u23f0\ud83c\udf1f\ud83d\udcad\u27a1\ufe0f\ud83d\ude14\ud83d\udca1\u27a1\ufe0f\u26a1\ufe0f", "if all the blood in a man could be aerated with one breath, he might then seal up his nostrils and not fetch another for a considerable time": "\ud83d\udc68\u200d\ud83e\uddb3\ud83d\udca8\u2764\ufe0f\u2795\ud83d\udc43\ud83d\uded1\u23f3", "from the unmarred dead body of the whale, you may scrape off with your hand an infinitely thin, transparent substance, somewhat resembling the thinnest shreds of isinglass, only it is almost as flexible and soft as satin": "\ud83d\udc0b\u27a1\ufe0f\ud83d\udc50\ud83c\udd93\ud83e\uddca\ud83c\udf0a\ud83c\udf9b\ufe0f\u2728\ud83d\udd0d\ud83d\udd0e\ud83e\uded9\ud83e\ude9e\ud83e\uddf5\ud83e\ude9e\ud83d\udc57", "a sudden stop was put to further discoveries": "\ud83d\udeab\u23f9\ufe0f\ud83d\udd75\ufe0f\u200d\u2642\ufe0f\ud83d\udd0d\u261d\ufe0f\u26d4\u2728", "wondrous": "\u2728\ud83c\udf1f\ud83d\ude4c", "Book! you lie there; the fact is, you books must know your places.": "\ud83d\udcda! You lie there; the fact is, you \ud83d\udcda must know your places.", "while the wildest winds of heaven and earth conspire to cast her on the treacherous, slavish shore?": "\ud83c\udf2a\ufe0f\ud83c\udf2c\ufe0f\ud83e\udd1d\ud83c\udf0d\ud83d\udd04\ud83c\udf0a\u27a1\ufe0f\ud83c\udfdd\ufe0f\u2753", "Like noiseless nautilus shells, their light prows sped through the sea; but only slowly they neared the foe.": "\ud83d\udc1a\ud83d\udea4\ud83c\udf0a\ud83d\udc22\u27a1\ufe0f\u2694\ufe0f", "you must not, in every case at least, take the higgledy-piggledy whale statements, however authentic, in these extracts, for veritable gospel cetology.": "\ud83d\udd0d\u274c\ud83d\udc0b\ud83d\udcdc\ud83d\udd00\ud83d\udcaf\ud83d\udcd6\u2693\ud83e\uddb7", "From his mighty bulk the whale affords a most congenial theme whereon to enlarge, amplify, and generally expatiate.": "\ud83d\udc0b\u27a1\ufe0f\ud83d\udcda\u2728 The whale's impressive size offers a perfect topic to expand, amplify, and discuss. \ud83d\udcac\ud83d\udde3\ufe0f", "beneath the effulgent Antarctic skies I have boarded the Argo-Navis, and joined the chase against the starry Cetus": "\u2600\ufe0f\ud83c\udf0c\u2744\ufe0f\ud83e\uddd1\u200d\u2708\ufe0f\ud83d\udea2\ud83c\udf1f\u27a1\ufe0f\ud83d\udc0b\u2728", "we undressed and went to bed, at peace with our own consciences and all the world": "\ud83d\udc57\u27a1\ufe0f\ud83d\udecf\ufe0f, \u262e\ufe0f\ud83e\udde0\ud83c\udf0d", "Wrapped, for that interval, in darkness myself, I but the better saw the redness, the madness, the ghastliness of others.": "\ud83d\udda4\ud83c\udf11\ud83d\udd12, \ud83c\udf0c\ud83d\udd52, \ud83d\udda4\ud83c\udf11\ud83d\udd01, \ud83c\udf1a\ud83d\udc40\ud83d\udcc8, \ud83c\udf08\ud83d\udd34, \ud83e\udd2a, \ud83e\udddf\u200d\u2642\ufe0f\ud83d\ude31\ud83d\ude28\ud83d\udc65.", "the slippered waves whispered together as they softly ran on": "\ud83c\udf0a\ud83d\udc42\ud83e\udd2b\ud83e\udd1d\ud83d\udca8", "Signs and wonders, eh? Pity if there is nothing wonderful in signs, and significant in wonders!": "\ud83d\udd2e\u2728\ud83e\udd14\ud83e\udd37\u200d\u2642\ufe0f\ud83d\ude41\u2753\ud83c\udf1f\u274c\ud83d\udd24\u2728, \ud83d\udd04\ud83d\udccc\ud83d\udd0d\ud83d\udc4f\ud83d\udd2e", "I cherish the greatest respect towards everybody\u2019s religious obligations, never mind how comical": "\u2764\ufe0f\u26ea\ufe0f\ud83d\ude4f\ud83d\udc73\u200d\u2642\ufe0f\ud83d\ude02\ud83e\udd1d", "with one half-throttled shriek you drop through that transparent air into the summer sea, no more to rise for ever": "\ud83d\ude31\u2708\ufe0f\ud83c\udf0a\u2600\ufe0f\u26f5\ufe0f\ud83d\udcab\u2728", "Look you, Doubloon, your zodiac here is the life of man in one round chapter": "\ud83d\udd0d\ud83e\udd14, \ud83d\udcb0, \u2652\ud83c\udf0c, \ud83d\udc64\u27a1\ufe0f\ud83d\udcd6\ud83d\udd04", "But strangest of all is the circumstance, that in more instances than one, when the body has been recovered, not a single mark of violence is discernible; the man being stark dead.": "\ud83e\udd14\ud83e\udd2f\ud83e\udd14\ud83d\udc80 \u27a1\ufe0f \ud83d\udcbc, \ud83d\udd75\ufe0f\u200d\u2642\ufe0f, \ud83d\ude2e\ud83d\ude2e\ud83d\ude2e\ud83d\ude2e, \u27a1\ufe0f \ud83e\udd14\ud83e\uddd0, \ud83e\uddcd\u200d\u2642\ufe0f\ud83d\udc80 \u23e9 \ud83d\udd75\ufe0f\u200d\u2642\ufe0f\ud83d\udd0d, \u274c\ud83d\udd0d\ud83d\udd0d\ud83d\udd0d\u2757\ufe0f \ud83d\udeb6\u200d\u2642\ufe0f = \ud83d\ude35\ud83d\udc80", "he can never see an object which is exactly ahead, no more than he can one exactly astern": "\ud83d\udeab\ud83d\udc41\ufe0f\u200d\ud83d\udde8\ufe0f\u27a1\ufe0f\ud83d\udd0d\ud83d\udd35,\ud83d\udd04\ud83d\udeab\ud83d\udc41\ufe0f\u200d\ud83d\udde8\ufe0f\u2b05\ufe0f\ud83d\udd0d\ud83d\udd19", "Out of the trunk, the branches grow; out of them, the twigs. So, in productive subjects, grow the chapters.": "\ud83c\udf33\u27a1\ufe0f\ud83c\udf3f\u27a1\ufe0f\ud83c\udf31 (\ud83c\udf3f\u27a1\ufe0f\ud83c\udf31) \ud83d\udcda\u27a1\ufe0f\ud83d\udcd6\u270d\ufe0f", "Ecclesiastes is the fine hammered steel of woe. \u201cAll is vanity.\u201d ALL.": "\ud83d\udcdc\ud83d\udd28\ud83d\ude14 \"All is vanity.\" \ud83e\ude9e\ud83d\udd04 ALL.", "with a great swash the ship rolls upwards and backwards from the whale, and the triumphant tackle rises into sight dragging after it the disengaged semicircular end of the first strip of blubber": "\ud83d\udea2\ud83c\udf0a\u2b06\ufe0f\u2b05\ufe0f\ud83d\udc0b, \ud83c\udf89\u2699\ufe0f\ud83d\udc41\ufe0f\u200d\ud83d\udde8\ufe0f\ud83e\ude9d\ud83d\udd1b\u27a1\ufe0f\ud83e\ude931\ufe0f\u20e3\ud83d\udfe6\ud83d\udee2\ufe0f", "That\u2019s no way to convert sinners, cook!": "\ud83d\ude2e\u274c\u27a1\ufe0f\ud83d\ude07, \ud83d\udc68\u200d\ud83c\udf73!", "A good laugh is a mighty good thing, and rather too scarce a good thing\u2014mores the pity.": "\ud83d\ude02\ud83d\udc4d is a mighty \ud83d\udc4d thing, and rather too \u274c a \ud83d\udc4d thing\u2014\ud83d\ude14", "tell him to paint me a sign, with\u2014\u201cno suicides permitted here, and no smoking in the parlor;\u201d": "\ud83d\udde3\ufe0f\u27a1\ufe0f\ud83c\udfa8\ud83d\udd8c\ufe0f\ud83d\udcdc\ud83d\uddbc\ufe0f: \"\ud83d\udeab\ud83d\udc80\u2705\ud83d\udeab\ud83d\udeac\ud83c\udfe0\ud83d\udcac\"", "Oh, man! admire and model thyself after the whale!": "\ud83d\ude2e\ud83e\uddd4! \ud83d\udc4f \ud83d\udc33 \ud83d\udd75\ufe0f\u200d\u2642\ufe0f \ud83e\uddcd \u27a1\ufe0f \ud83d\udc0b!", "His tormented body rolled not in brine but in blood, which bubbled and seethed for furlongs behind in their wake.": "\ud83e\uddcd\u200d\u2642\ufe0f\ud83d\udc94\ud83e\udd2f\ud83d\udca6\u274c\ud83d\udd04\ud83d\udd34\ud83d\udca7\ud83d\udd04\ud83e\ude78\ud83c\udf0a\ud83e\udd75\ud83d\ude24\u2194\ufe0f\ud83d\udd19", "out of fifty fair chances for a dart, not five are successful": "\ud83c\udfaf Out of 50 \ud83c\udfb2 fair chances for a \ud83c\udfaf, not 5 are \u2705\ud83c\udfaf", "But lazily undulating in the trough of the sea, and ever and anon tranquilly spouting his vapory jet, the whale looked like a portly burgher smoking his pipe of a warm afternoon.": "\ud83d\udc0b\ud83c\udf0a\ud83d\ude0c\ud83d\udca8\u27a1\ufe0f\ud83c\udfd9\ufe0f\ud83d\udc68\u200d\ud83e\uddb3\ud83d\udeac\u2600\ufe0f\ud83c\udf42", "Here ye strike but splintered hearts together\u2014there, ye shall strike unsplinterable glasses!": "\ud83d\udc42\u2694\ufe0f\u2764\ufe0f\ud83d\udc94\u27a1\ufe0f\ud83c\udf77\u270a\ud83c\udf7e\ud83d\udcaa", "deformities floundering in seas of blood and blue paint": "\ud83d\udc20\ud83d\udd04\ud83c\udf0a\ud83e\ude78\ud83d\udd35\ud83c\udfa8", "copied verbatim from my right arm, where I had them tattooed": "\ud83d\udccb\u27a1\ufe0f\u270d\ufe0f\ud83d\udcaa\ud83d\udd8b\ufe0f\ud83d\udd8b\ufe0f", "For as this appalling ocean surrounds the verdant land, so in the soul of man there lies one insular Tahiti": "\ud83c\udf0a\ud83c\udf0d\u27a1\ufe0f\ud83c\udf3f\ud83c\udfdd\ufe0f, \ud83d\ude0a\ud83d\udc49\ud83e\udde0\ud83d\udc64\ud83d\udd0d\ud83c\udfdd\ufe0f", "the thunderous concussion resounds for miles": "\ud83c\udf29\ufe0f\ud83d\udca5\ud83d\udd0a\ud83d\udccf\ud83c\udfde\ufe0f", "the whale has no voice": "\ud83d\udc0b\u274c\ud83d\udd0a", "to the eternal honor of our calling be it said, that the first whale attacked by our brotherhood was not killed with any sordid intent": "\ud83d\udc0b\ud83c\udff4\u200d\u2620\ufe0f\u2728\u270b\ud83d\udde3\ufe0f\ud83d\udde8\ufe0f\ud83e\udd1d\ud83d\udc65\ud83d\udcdc, \ud83d\udeab\ud83d\udc80\u2694\ufe0f\ud83c\udfaf\ud83d\udcb0\ud83d\udcad", "every gasping heave of the windlass is answered by a helping heave from the billows": "\ud83c\udf2c\ufe0f\u26d3\ufe0f\u2b06\ufe0f\u2795\ud83c\udf0a\u2b06\ufe0f", "my mother dragged me by the legs out of the chimney and packed me off to bed": "\ud83d\udc69\u200d\ud83d\udc66\ud83d\udcaa\ud83e\uddb5\ud83d\udeaa\ud83c\udfe0\u27a1\ufe0f\ud83d\udecf\ufe0f\ud83d\ude34", "a sound so strange, long drawn, and musically wild and unearthly, that the ball of free will dropped from my hand": "\ud83c\udfb5\ud83d\udd0a\ud83d\ude32\ud83c\udf0c\ud83c\udfb6\ud83c\udf00\ud83c\udfad\ud83d\udc49\ud83e\udea6\ud83e\udd1a\ud83e\udea9", "It was a black and hooded head; and hanging there in the midst of so intense a calm, it seemed the Sphynx\u2019s in the desert. \u201cSpeak, thou vast and venerable head,\u201d muttered Ahab": "\ud83d\udc0b\ud83c\udf11\ud83d\udc64\ud83d\udda4 \ud83c\udf0c\ud83e\udd85\u27a1\ufe0f \ud83c\udfdc\ufe0f\ud83e\udd14\ud83c\udfdc\ufe0f. \u201c\ud83d\udde3\ufe0f\ud83d\udce3, \ud83e\udd2f\ud83d\udc74\ud83d\udd2e\ud83d\uddff,\u201d \ud83d\udde3\ufe0f\ud83e\uddd4\u200d\ud83e\uddb1", "Let not the modern paintings of this scene mislead us": "\ud83d\uddbc\ufe0f\ud83d\udeab\ud83d\udd8c\ufe0f\ud83c\udd95\ud83c\udfa8\u26a0\ufe0f\ud83d\udc40", "so mystical and well nigh ineffable was it, that I almost despair of putting it in a comprehensible form": "\ud83c\udf0c\ud83e\uddd9\u200d\u2642\ufe0f\u2728 & \ud83d\udd2e\ud83d\ude36\u200d\ud83c\udf2b\ufe0f\ud83d\udcdc was it, that I almost \ud83d\ude29\ud83e\udd14 of \ud83d\udcdd\ud83d\udca1 it in a \ud83e\udd13\ud83d\udde3\ufe0f form", "I went to my little room in the third floor, undressed myself as slowly as possible so as to kill time, and with a bitter sigh got between the sheets.": "\ud83c\udfe0\u27a1\ufe0f\ud83d\udecc3\ufe0f\u20e3rd\u2b06\ufe0f\u2b06\ufe0f, \ud83d\udeb6\u200d\u2642\ufe0f\ud83d\ude0c, \ud83e\udde5\ud83d\udc22\u231b\u2796\u2796\ud83d\ude13\ud83d\udc49\ud83d\udecf\ufe0f\ud83d\udcad\ud83d\ude2b", "what just before might have seemed to him a thing most momentous, now seems but a part of the general joke": "\ud83e\udd14\u27a1\ufe0f\ud83e\udd2f\u27a1\ufe0f\ud83d\ude02 Now feels like *just* part of the joke!", "I am game for his crooked jaw, and for the jaws of Death too, Captain Ahab": "\ud83d\ude03\ud83c\udfae\ud83d\udc64\ud83d\udc49\ud83d\udc68\u200d\u2708\ufe0f\ud83d\ude2e\ud83d\udc44\ud83d\udd25\ud83d\udc80\ud83d\udccc\ud83d\udc0b", "by three such thin threads the great Leviathan was suspended like the big weight to an eight day clock": "\ud83d\udd70\ufe0f\ud83d\udd17\ud83d\udd17\ud83d\udd17\ud83d\udc0b\u2696\ufe0f", "the madness, the frenzy, the boiling blood and the smoking brow": "\ud83d\ude1c\ud83e\udd2a\ud83d\udd25\ud83d\udc89\ud83d\ude24\ud83d\udca2", "if I wake thee not to death, old man, who can tell to what unsounded deeps Starbuck\u2019s body this day week may sink, with all the crew": "\ud83d\udc74\ud83c\udf04\u274c\ud83d\udc80, \ud83d\udc74\u2753\u27a1\ufe0f\ud83c\udf0a\u2754\u2b50\ud83e\udd8c\ud83d\udc68\u200d\u2708\ufe0f\ud83d\udcaa\ud83c\udffd\ud83d\udd70\ufe0f\ud83d\udd1c\ud83d\udcc5\ud83c\udf42\u2b07\ufe0f\ud83d\udea2\u2753", "Physiognomically regarded, the Sperm Whale is an anomalous creature.": "\ud83d\udc0b\ud83d\udc40\u2753\ud83e\udd14, \ud83d\udc33\ud83d\udc49\ud83e\udd37\u200d\u2642\ufe0f\ud83d\udd0d\u2728.", "under his very pillow rush herds of walruses and whales": "\ud83d\udecf\ufe0f\u27a1\ufe0f\ud83e\udd76\ud83d\udc18\ud83d\udc0b", "by its indefiniteness it shadows forth the heartless voids and immensities of the universe, and thus stabs us from behind with the thought of annihilation": "\ud83c\udf0c\u2753\ud83d\udc94\ud83c\udf0c\ud83d\udeab\ud83e\udd2f\ud83c\udf0c, \ud83d\udde1\ufe0f\u27a1\ufe0f\ud83d\udcad\ud83d\udcab\ud83c\udf0c", "tar in general by no means adds to the rope\u2019s durability or strength, however much it may give it compactness and gloss": "\ud83e\udea2\ud83c\udffa \u274c\u2795 \u23e9 \ud83e\udea2\ud83d\udcaa\ud83d\udee1\ufe0f, \ud83e\udd14 \u2795\u2728 & \ud83d\udc8e", "we occasionally hear of English and American vessels, which, in those waters, have been remorselessly boarded and pillaged": "\u26f5\ufe0f\ud83d\udc42\ud83d\udd04\ud83c\uddec\ud83c\udde7\ud83d\udea2\ud83c\uddfa\ud83c\uddf8, \ud83c\udf0a, \ud83d\udc94\ud83d\udde1\ufe0f\ud83d\udef3\ufe0f\ud83d\udcb0", "as the blubber envelopes the whale precisely as the rind does an orange, so is it stripped off from the body precisely as an orange is sometimes stripped by spiralizing it": "\ud83d\udc0b\u27a1\ufe0f\ud83c\udf4a\u26d1\ufe0f\u27a1\ufe0f\ud83d\udd2a\ud83c\udf4a\ud83d\udd04", "Now that the incorruption of this most fragrant ambergris should be found in the heart of such decay; is this nothing?": "\n\ud83d\ude49 \u27a1\ufe0f \ud83d\udd70\ufe0f \u2795 \u2696\ufe0f \u27a1\ufe0f \ud83c\udf38 \ud83c\udf3a \ud83d\udca8 \ud83d\udc43\ud83c\udffc \ud83c\udf05 \ud83e\udde0 \ud83e\udde9 \ud83d\udc94 \ud83e\uddb4 \ud83d\ude15 \ud83d\udc40 \ud83c\udf0c \ud83d\udd0d \ud83d\ude15 \ud83e\udd14\u2757", "But the mingled, mingling threads of life are woven by warp and woof": "\ud83e\uddf6 But the intertwined, mixing threads of life are woven by warp and woof \u26a1\ufe0f", "In much the same way do the commonalty lead their leaders in many other things, at the same time that the leaders little suspect it.": "\ud83d\udc65\u27a1\ufe0f\ud83d\udc68\u200d\ud83c\udfeb\ud83d\udc69\u200d\ud83c\udfeb\ud83d\udd04\ud83d\udcda\ud83e\udd14\ud83e\udd37\u200d\u2642\ufe0f\ud83d\udc65", "no face can be physiognomically in keeping without the elevated open-work belfry of the nose": "\ud83d\udeab\ud83d\ude42 \u27a1\ufe0f \ud83d\udc43\u27a1\ufe0f \ud83c\udff0\u26ea\ufe0f\ud83c\udf2c\ufe0f\ud83d\udd14", "To accomplish his object Ahab must use tools; and of all tools used in the shadow of the moon, men are most apt to get out of order.": "\ud83d\udd28\ud83c\udf12\u27a1\ufe0f\u2693\ufe0f\ud83d\udc68\u200d\u2708\ufe0f\ud83d\udca1\ud83d\udee0\ufe0f\u2757\ufe0f\ud83d\udc68\ud83d\udc68\u200d\ud83e\uddb1\ud83d\udc68\u200d\ud83e\uddb0\ud83d\udd27\u26a0\ufe0f\ud83d\udeab\u2600\ufe0f", "you at last come to the conclusion that such an idea, however wild, might not be altogether unwarranted": "\ud83d\udc64\ud83e\udd14\u27a1\ufe0f\ud83e\udd37\u200d\u2642\ufe0f\ud83d\udcad\ud83e\udd14\ud83d\udca1\ud83d\ude1c, \u2753\ud83d\ude2f, \ud83d\udcad\ud83d\udcad\ud83d\udcad\ud83d\udd0d\ud83d\udeab\ud83d\uded1", "The great Leviathan that maketh the seas to seethe like boiling pan.": "\ud83d\udc0b\ud83d\udd25\ud83c\udf0a The great Leviathan that maketh the seas to seethe like boiling pan \ud83c\udf0a\ud83d\udd25\ud83d\udc0b", "a herd of remorseless wild pirates and inhuman atheistical devils were infernally cheering him on with their curses": "\ud83e\uddd4\u200d\u2620\ufe0f\ud83d\udc11\ud83d\ude08\ud83e\uddb9\u200d\u2642\ufe0f\ud83c\udff4\u200d\u2620\ufe0f\ud83d\udc4f\ud83d\udc79\ud83d\ude08\ud83d\udd0a\ud83d\udc80", "other fish are found exceedingly brisk in those Hyperborean waters; but these, be it observed, are your cold-blooded, lungless fish": "\ud83d\udc1f\u2744\ufe0f\ud83d\udc20\ud83d\udca8\ud83c\udf0a\ud83c\udf0c; \ud83d\udc1f\u26c4\ufe0f\ud83e\udd14\ud83d\udcac\ud83d\udc1f\ud83e\udd76\ud83e\ude78, \ud83d\udeab\ud83e\udec1\ud83d\udc1f", "this is one of those disheartening instances where truth requires full as much bolstering as error": "\ud83d\udd39\ud83d\ude1e\ud83d\udcd6 \u27a1\ufe0f \ud83d\udcaf\ud83d\udc94 \ud83d\udccd\ud83d\udd0d\ud83d\udd0d \u2696\ufe0f\ud83e\udd14 \u2795\ud83c\udd99\ud83d\udcc8\ud83d\udca1\u274c", "all at once a queer accident happened": "\ud83d\udd04\ud83e\udd14\ud83d\udca5\ud83e\udd2f\u27a1\ufe0f\ud83d\udea8", "Physiognomy, like every other human science, is but a passing fable.": "\ud83d\udd0d\ud83d\ude42\ud83d\udcd6\u2795\ud83d\udc68\u200d\ud83d\udd2c\ud83d\udd2c\u27a1\ufe0f\u23f3\ud83d\udcda\u27a1\ufe0f\ud83d\udde8\ufe0f\ud83d\udeb6\u200d\u2642\ufe0f\ud83d\udcdc", "Ah, mortal! then, be heedful; for so, in all this din of the great world\u2019s loom, thy subtlest thinkings may be overheard afar.": "\u26a0\ufe0f\ud83d\ude31\ud83c\udf0d\ud83e\udde0\ud83d\udd0d\ud83d\udc42\ud83c\udf0c", "most appalling beauty": "\ud83e\udd2f\ud83e\uddd1\u200d\ud83c\udfa4\u2728", "Glimpses do ye seem to see of that mortally intolerable truth": "\ud83d\udc40\u2728 do you \ud83e\uddda\u200d\u2640\ufe0f seem to \ud83d\udc40 of that \u2620\ufe0f unbearably \ud83c\udfad truth", "with a rapid, nameless impulse, in a superb lofty arch the bright steel spans the foaming distance, and quivers in the life spot of the whale": "\ud83c\udfc3\u200d\u2642\ufe0f\ud83d\udca5\ud83d\udd0e\ud83c\udf08\ud83c\udff9\ud83c\udf0a\ud83d\udc0b\ud83d\udcab\u2764\ufe0f", "who against the proud gods and commodores of this earth, ever stands forth his own inexorable self.": "\ud83e\uddcd\u200d\u2642\ufe0f\ud83e\udd1c\ud83e\udd9a\ud83d\uddff\ud83c\udf0d\ud83c\udf0a\ud83e\uddd4\u200d\u2642\ufe0f\ud83d\udcaa\u26d3\ufe0f\ud83c\udf1f", "How many barrels will thy vengeance yield thee even if thou gettest it, Captain Ahab?": "\ud83e\uddd0\u2693\ufe0f\u27a1\ufe0f\ud83e\udd43\u2753\ud83e\udd14\ud83d\ude20\ud83d\udcc8\u27a1\ufe0f\ud83d\udc68\u200d\u2708\ufe0f\ud83e\uddb5\ud83c\udff4\u200d\u2620\ufe0f", "By Jove, I have it!": "\ud83c\udf1f\ud83d\ude32\u2728 I've got it!", "the precise origin of ambergris remained, like amber itself, a problem to the learned": "\ud83e\uddd0\u2753\ud83d\udcad\ud83d\udc0b\ud83c\udf0a\ud83c\udffa\ud83c\udfa8, \ud83d\udd75\ufe0f\u200d\u2642\ufe0f\ud83d\udca1\ud83e\udd14\ud83d\udc1a, \u2699\ufe0f\u2754\ud83d\udcda\ud83e\udde0", "The whale has no famous author, and whaling no famous chronicler": "\ud83d\udc0b\u274c\ud83d\udcda\ud83d\udd1d\u270d\ufe0f, \ud83d\udc33\u274c\ud83d\udcd6\ud83d\udd1d\ud83d\udcdc", "No perceptible face or front did it have; no conceivable token of either sensation or instinct": "\ud83d\udeab\ud83d\udc40\ud83d\ude10\ud83d\udd04\ud83d\udd0d\ud83e\udd16\ud83d\udeab\ud83e\udde0\ud83d\udca1", "\u201cAh! poor fellow! he\u2019ll have to die now,\u201d ejaculated the Long Island sailor.": "\"Ah! \ud83d\ude22\ud83d\udc68\u200d\u2708\ufe0f\ud83d\udc94\ud83d\udc80\" exclaimed the \ud83c\udfdd\ufe0f\ud83d\udc68\u200d\u2708\ufe0f.", "All professions have their own little peculiarities of detail; so has the whale fishery.": "\ud83e\uddd1\u200d\ud83d\udcbc\ud83d\udc68\u200d\ud83d\ude80\ud83d\udc68\u200d\ud83c\udf73\ud83d\udc69\u200d\u2695\ufe0f\ud83d\udcda\ud83d\udd0d\ud83d\udd0d\ud83d\udd0d; \ud83d\udc0b\ud83d\udc33\u2693\ud83c\udfa3", "his ship, which, like Satan, would not sink to hell till she had dragged a living part of heaven along with her": "\ud83d\udea2\ud83d\ude08\u2b07\ufe0f\ud83c\udff4\u200d\u2620\ufe0f\u27a1\ufe0f\ud83d\udd25\ud83c\udf0a\ud83d\udc7c\u2601\ufe0f", "He tasks me; he heaps me": "\ud83d\udd28\ud83d\ude20; \ud83d\udd3c\ud83e\uddf1\u2b06\ufe0f\u2696\ufe0f", "till he spouts black blood and rolls fin out": "\ud83d\udc33\ud83e\udd15\ud83d\udd2a\ud83e\ude78\u27a1\ufe0f\u26ab\ud83c\udf0a\ud83d\udc1f\ud83d\udd1a", "there is all the difference in the world between paying and being paid": "\ud83d\udcb8\u2b05\ufe0f\ud83c\udf0d\ud83d\udd04\ud83d\udcb0\u27a1\ufe0f", "Had any one of his old acquaintances on shore but half dreamed of what was lurking in him then, how soon would their aghast and righteous souls have wrenched the ship from such a fiendish man!": "\ud83e\uddd4\u26f5\ufe0f\u2753\ud83c\udf0a\ud83e\udd14\ud83d\ude34\ud83d\udcad\ud83d\udc40\ud83d\ude40\ud83d\ude07\ud83d\udee1\ufe0f\ud83d\udcaa\ud83d\udea2\ud83d\udca8\ud83d\ude08\ud83d\udc68\u200d\u2708\ufe0f", "Let us fly, let us fly! Old Nick take me if it is not Leviathan described by the noble prophet Moses in the life of patient Job.": "\u2708\ufe0f\ud83d\udd4a\ufe0f\u2728 Let's fly, let's fly! \ud83c\udf0a\ud83d\udc09\ud83d\ude08 Take me if it isn't Leviathan as described by \ud83d\udc74\ud83d\udcdc Moses in Job's life.", "How it was that they so aboundingly responded to the old man\u2019s ire\u2014by what evil magic their souls were possessed, that at times his hate seemed almost theirs": "\ud83e\udd14\u2753\ud83d\udc74\ud83d\ude21\u27a1\ufe0f\ud83d\udc65\ud83d\udca5\u27a1\ufe0f\ud83e\uddd9\u200d\u2642\ufe0f\ud83e\udde0\ud83e\udd2f\ud83e\udd14\u2764\ufe0f\u2795\ud83d\ude20\u26a1\u27a1\ufe0f\ud83d\ude43", "I sang out, I could not help it now; and giving a sudden grunt of astonishment he began feeling me.": "\ud83c\udfa4\ud83c\udfb6\ud83d\ude2e\ud83d\udc37\ud83d\ude32\ud83e\udd1a\ud83d\udc50", "Away! let us away!\u2014this instant let me alter the course!": "\ud83c\udfc3\u200d\u2642\ufe0f\ud83d\udca8 Let's go! \ud83d\ude80\u23f0 Change direction now!", "Oh God! that man should be a thing for immortal souls to sieve through!": "\ud83d\ude2e\ud83d\ude4f\ud83d\ude31\ud83d\ude4d\u200d\u2642\ufe0f\u27a1\ufe0f\u2728\ud83d\udc7b\ud83d\udc94\ud83d\udd73\ufe0f\ud83d\udd0e", "But gulp down your tears and hie aloft to the royal-mast with your hearts": "\ud83e\udd10\ud83d\ude22\u27a1\ufe0f\u23eb\ud83d\udc51\u26f5\ufe0f\u2764\ufe0f", "The French are the lads for painting action.": "\ud83c\uddeb\ud83c\uddf7\ud83d\udc68\u200d\ud83c\udfa8\ud83c\udfa8\ud83d\udca5\ud83d\udc68\u200d\ud83c\udfa8", "But if I know not even the tail of this whale, how understand his head?": "\ud83e\udd14\u27a1\ufe0f\ud83d\udc0b\u2753\u26d4\ufe0f\ud83e\udde0", "heavy chains are being dragged along the deck": "\ud83d\udd17\u26d3\ufe0f\u2796\ud83d\udea2\ud83d\udef3\ufe0f\ud83d\udee0\ufe0f\ud83d\udce6", "There is his home; there lies his business, which a Noah\u2019s flood would not interrupt, though it overwhelmed all the millions in China.": "\ud83c\udfe0\u27a1\ufe0f\ud83c\udfe2\ud83c\udf0a\u26f5\ufe0f\u274c\ud83d\uded1, \ud83c\udf0f\ud83c\udf0a\ud83d\udcb0\ud83c\udde8\ud83c\uddf3", "Had these Leviathans been but a flock of simple sheep, pursued over the pasture by three fierce wolves": "\ud83d\udc0f\ud83d\udc0f\ud83d\udc0f \u27a1\ufe0f \ud83d\udc11\ud83d\udc11\ud83d\udc11, \ud83c\udfc3\u200d\u2b07\ufe0f \ud83c\udf3e\ud83c\udf3f \u2139\ufe0f \ud83d\udccd 3\ufe0f\u20e3 \ud83d\udc3a\ud83d\udc3a\ud83d\udc3a", "among the joyous, heartless, ever-juvenile eternities, Pip saw the multitudinous, God-omnipresent, coral insects": "\ud83d\ude0a\ud83d\udc83\ud83d\ude10\ud83d\udc94\ud83c\udf1f\ud83d\udd04\ud83d\udc76\ud83c\udf0c, \ud83d\udc33\ud83d\udc40\ud83e\udda0\ud83e\udd32\ud83d\ude4f\ud83d\udc1a\ud83d\udc1c", "upon the banquet of his funeral they most piously do pounce": "\ud83e\udea6\ud83c\udf7d\ufe0f\ud83d\ude4f\ud83e\udd85\u2757", "your friends who have gone before are clearing out the seven-storied heavens": "\ud83c\udf1f\ud83d\udc6f\u200d\u2642\ufe0f\ud83d\udc6b\u2728\ud83c\udf08\ud83d\udc7c\u27a1\ufe0f\ud83e\uddf9\u2601\ufe0f7\ufe0f\u20e3\ud83c\udfe2\u26c5", "how wonderful that he should be found at home, immersed to his lips for life in those Arctic waters!": "\ud83d\ude4c\ud83c\udfe0\u2744\ufe0f\ud83e\uddca\ud83c\udf0a\ud83d\ude32\ud83d\ude04", "A soul\u2019s a sort of a fifth wheel to a wagon.": "\ud83e\uddff\ud83d\udfe0\u2795\ud83d\udd04\ud83d\udede\ud83d\udce6\u27a1\ufe0f\ud83d\udefa", "the calm is but the wrapper and envelope of the storm; and contains it in itself, as the seemingly harmless rifle holds the fatal powder": "\ud83e\uddd8\u200d\u2642\ufe0f\ud83c\udf0c \u27a1\ufe0f \ud83c\udf81\ud83c\udf2b\ufe0f\u26c8\ufe0f; \ud83d\udce6\ud83c\udf2a\ufe0f\ud83c\udf0c, \ud83c\udfaf\ud83c\udf2b\ufe0f\ud83d\udd2b \u27a1\ufe0f\ud83c\udfaf\u26a0\ufe0f\ud83d\udca5", "man is a money-making animal, which propensity too often interferes with his benevolence": "\ud83d\udc68\ud83d\udcb0\u27a1\ufe0f\ud83d\udc12, \ud83e\udd14\u26a0\ufe0f\ud83c\udf00\ud83d\udeab\u2764\ufe0f\u2728", "all this to explain, would be to dive deeper than Ishmael can go": "\ud83d\udc0b\ud83d\udcd6\u27a1\ufe0f\ud83d\ude2e\u200d\ud83d\udca8\ud83d\udd0d\u2b07\ufe0f\ud83d\udc68\u200d\ud83c\udfeb\ud83c\udf0a\ud83d\udcda\u274c\u2693", "My sensations were strange.": "\ud83e\udde0\u2753 My sensations were strange.", "the profound calm which only apparently precedes and prophesies of the storm, is perhaps more awful than the storm itself": "\ud83c\udf0c\ud83d\ude0c\u2601\ufe0f\u26a1 (quiet before storm) \ud83d\udc49\ud83d\udd2e\ud83c\udf2a\ufe0f\ud83d\udcdc, \ud83d\ude28\ud83d\ude1f\ud83d\udd2e\u27a1\ufe0f\ud83c\udf2a\ufe0f", "what wonder remained soon waned away; for in a whaler wonders soon wane": "\ud83e\udd14\u2753\u27a1\ufe0f\ud83d\ude2e\ud83c\udf20\u27a1\ufe0f\ud83d\udcc9\ud83d\ude14; \ud83d\udc0b\u26f5\u2728\ud83d\udcc9\u27a1\ufe0f\ud83d\ude10", "\u201cSwim away from me, do ye?\u201d murmured Ahab, gazing over into the water. There seemed but little in the words, but the tone conveyed more of deep helpless sadness than the insane old man had ever before evinced.": "\u201c\ud83c\udfca\u200d\u2642\ufe0f\u27a1\ufe0f\ud83c\udd9ame, do ye?\u201d \ud83e\udd14 Ahab, \ud83d\udc40\ud83c\udf0a. There seemed but little in the words, but the tone conveyed more of deep \ud83d\ude1e\ud83d\ude22 than the \ud83e\udd2a\ud83d\udc74 had ever before shown.", "French soldiers in the Russian campaign turned their dead horses into tents, and crawled into them": "\ud83c\uddeb\ud83c\uddf7\ud83e\ude96\u27a1\ufe0f\ud83c\uddf7\ud83c\uddfa\ud83e\udd76\ud83d\udc34\ud83d\udc80\u27a1\ufe0f\u26fa\ufe0f\ud83d\udc64\ud83d\udd73\ufe0f\ud83d\udc34", "till you get to be Captain, the higher you rise the harder you toil": "\ud83e\uddd7\u200d\u2642\ufe0f \u27a1\ufe0f \u2693\ufe0f, \u2b06\ufe0f\u2b06\ufe0f\u2b06\ufe0f = \ud83d\udcaa\ud83d\udd28", "coffined, hearsed, and tombed in the secret inner chamber and sanctum sanctorum of the whale": "\u26b0\ufe0f\ud83d\udc33\ud83d\udce6\u2b1b\ufe0f\ud83d\udd12\ud83d\udc0b\ud83c\udf0c", "a strange fatality pervades the whole career of these events, as if verily mapped out before the world itself was charted": "\ud83c\udf00\u2728\ud83d\uddfa\ufe0f A strange destiny threads through these events, as if they were destined before the world was even mapped \ud83c\udf0d\ud83d\uddfa\ufe0f\u2728", "sharks do most socially congregate, and most hilariously feast": "\ud83e\udd88\ud83e\udd1d\ud83d\ude04\ud83c\udf7d\ufe0f", "The whale, like all things that are mighty, wears a false brow to the common world.": "\ud83d\udc0b \u27a1\ufe0f like all \ud83c\udf0d that are \ud83d\udcaa, wears a \ud83d\ude36\u2b06\ufe0f to the \ud83c\udf10.", "it should still remain a problem": "\ud83e\udd14\u27a1\ufe0f\ud83d\udccc\ud83d\ude15", "the sound of gay voices all over the house": "\ud83d\udd0a\ud83c\udff3\ufe0f\u200d\ud83c\udf08\ud83d\udde3\ufe0f\ud83c\udfe0\ud83c\udf08", "in this world, head winds are far more prevalent than winds from astern": "\ud83c\udf0e\ud83d\udca8\u2b06\ufe0f\ud83c\udfc3\u200d\u2642\ufe0f\ud83c\udf2c\ufe0f\u27a1\ufe0f\ud83d\udef3\ufe0f", "a righteous judgment descended upon him": "\u2696\ufe0f\u2728\u2b07\ufe0f\ud83d\udc68\u200d\u2696\ufe0f", "I felt a melting in me. No more my splintered heart and maddened hand were turned against the wolfish world.": "\ud83d\ude0a\ud83d\udc96\ud83e\udee0. \ud83d\udeab\ud83d\udc94\u270b\ud83d\udc3a\ud83c\udf0d.", "Nature absolutely paints like the harlot, whose allurements cover nothing but the charnel-house within": "\ud83c\udf3f\ud83c\udfa8\ud83d\udc83\u2728\u27a1\ufe0f\u26b0\ufe0f\ud83c\udfda\ufe0f", "Ahab\u2019s harpoon had shed older blood than the Pharaoh\u2019s.": "\u2693\ufe0f\ud83e\udd91\ud83d\udccf\ud83d\udc89\ud83e\ude78\ud83d\udcdc\ud83d\udd34\ud83d\udc51", "Hence, the spare boats, spare spars, and spare lines and harpoons, and spare everythings, almost, but a spare Captain and duplicate ship.": "\ud83d\udef6\ud83d\udef6, \ud83c\udfa3, \ud83d\udd17, \ud83c\udff9, and almost everything else, but \ud83d\udc68\u200d\u2708\ufe0f\u274c and \ud83d\udea2\u274c.", "immortality is but ubiquity in time": "\ud83e\uddec\u23f3 is but \ud83c\udf0d\u23f0 in time", "I felt dreadfully.": "\ud83d\ude1f\ud83d\udc94", "\u2019Twas rehearsed by thee and me a billion years before this ocean rolled.": "\ud83c\udf0a\ud83c\udfad\ud83d\udd04\ud83d\ude4c1\ufe0f\u20e30\ufe0f\u20e30\ufe0f\u20e30\ufe0f\u20e30\ufe0f\u20e30\ufe0f\u20e30\ufe0f\u20e30\ufe0f\u20e30\ufe0f\u20e30\ufe0f\u20e30\ufe0f\u20e3\ud83d\udd19\u231b\ufe0f", "in this zoned quest, does Ahab touch no land?": "\ud83c\udfde\ufe0f\u2753\ud83d\udd0d, \ud83c\udff4\u200d\u2620\ufe0f\ud83e\uddd4\ud83e\udd14\ud83d\udeab\ud83c\udf0d?", "much wriggling, and loud and incessant expostulations": "\ud83d\udc1b\ud83d\udd0a\ud83d\udd0a\ud83e\udd1a\ud83d\ude21\u26a0\ufe0f", "In the case of a small Sperm Whale the brains are accounted a fine dish.": "\ud83d\udc0b\ud83e\udde0\ud83c\udf7d\ufe0f\u2728", "any highly cultured, poetical nation shall lure back to their birth-right, the merry May-day gods of old": "\ud83c\udf1f\ud83c\udfdb\ufe0f\ud83d\udcdc\u2728\ud83c\udf38\ud83c\udf3f\ud83c\udf1e\u2728\ud83c\udf1f\ud83c\udfad\u23f3\u27a1\ufe0f\ud83c\udfe1\ud83d\udc63, \ud83d\ude02\ud83c\udf3c\ud83d\udcc5\ud83d\udc7c\u23f3\ud83d\udd19", "the archangel cared little or nothing for the captain and mates; and since the epidemic had broken out, he carried a higher hand than ever": "\ud83d\ude07\ud83d\udeab\u2764\ufe0f\ud83d\ude11\ud83d\udc68\u200d\u2708\ufe0f\ud83e\uddd1\u200d\u2708\ufe0f\ud83e\udd1d\ud83d\udeb7\ud83d\ude37\ud83c\udf0d\ud83d\ude24\u270b\u2b06\ufe0f\ud83d\udcc8", "the deep cistern will yield no more": "\ud83d\udca7\u26cf\ufe0f\ud83d\udd73\ufe0f\ud83d\udd19\ud83d\udeab\ud83d\udc50", "its most dreaded creatures glide under water, unapparent for the most part, and treacherously hidden beneath the loveliest tints of azure": "\ud83d\udc09\ud83c\udf0a\ud83d\udc7b\ud83e\udd91\ud83e\udd2b\ud83d\udd0d\ud83e\udd14\u26d4\ufe0f\ud83d\udeab\ud83c\udf0a\ud83d\udc40\ud83c\udfa8\ud83d\udc99", "I lay there broad awake, feeling a great deal worse than I have ever done since": "\ud83d\udecc\ud83d\ude33, \ud83e\udd15\ud83e\udd12\ud83d\ude29\ud83d\ude16\ud83d\ude14\ud83d\udcad", "account for those repeated whaling disasters": "\ud83d\udcca\u27a1\ufe0f\ud83d\udc0b\ud83c\udf0a\u2620\ufe0f\ud83d\udd04\ud83d\udcc9", "Bear thee grimly, demigod!": "\ud83d\udc3b \u2694\ufe0f \ud83c\udffa\ud83e\uddb8\u200d\u2642\ufe0f!", "bleeds with keenest anguish at the undraped spectacle of a valor-ruined man.": "\ud83e\ude78\ud83d\ude22\ud83d\udc41\ufe0f\u200d\ud83d\udde8\ufe0f\ud83e\ude78\ud83d\ude22\ud83d\udc41\ufe0f\u200d\ud83d\udde8\ufe0f(cry with pain) at the sight of a \u2694\ufe0f ruined \ud83e\udd26\u200d\u2642\ufe0f.", "it seemed hardly to budge at all": "\ud83e\udd14\u27a1\ufe0f\ud83d\udfe2 moved\u2b05\ufe0f\ud83d\ude10", "I try all things; I achieve what I can.": "\ud83e\udd14\ud83d\udd0d\u2728; \ud83c\udfc6\ud83d\udcaa\ud83c\udfaf", "instantly, a swift tremor was felt running like lightning along the keel": "\u26a1\ufe0f\ud83d\udca8\u26f5\ufe0f", "it is but reasonable to presume, that the longer the stricken whale stays under water, the more he is exhausted": "\ud83d\udc0b\ud83d\udca6\u23f3\u27a1\ufe0f\ud83d\ude34", "Let me only say that it fared with him as with the storm-tossed ship, that miserably drives along the leeward land.": "\u26f5\ufe0f\ud83d\udca8\u27a1\ufe0f\ud83d\ude1f\u26f4\ufe0f\ud83c\udf0a\u27a1\ufe0f\u26c5\ufe0f\ud83c\udf0a\ud83c\udfdd\ufe0f", "It is by reason of this cosy blanketing of his body, that the whale is enabled to keep himself comfortable in all weathers, in all seas, times,and tides": "\ud83d\udc0b\ud83e\uddfa\u27a1\ufe0f\ud83c\udfe0\ud83d\udd32\ud83c\udf21\ufe0f\ud83d\udc0b\u27a1\ufe0f\ud83d\ude0c\ud83c\udf0a\ud83c\udf26\ufe0f\ud83d\udd70\ufe0f\ud83c\udf0a\ud83d\udd04", "And so, through all the thick mists of the dim doubts in my mind, divine intuitions now and then shoot": "\ud83c\udf2b\ufe0f\ud83e\udd14\ud83d\udcad\u2728\ud83d\udca1\u27a1\ufe0f\ud83e\udde0\ud83d\udcad\ud83d\ude0a\ud83d\ude4f\ud83c\udf1f\u2728\ud83d\udc49\ud83c\udffc\ud83d\udca5", "Is heaven a murderer when its lightning strikes a would-be murderer in his bed, tindering sheets and skin together?": "\u2601\ufe0f\u26a1\ufe0f\u27a1\ufe0f\ud83d\udc7c\ud83d\udd2a? \ud83d\udecf\ufe0f\ud83d\udd25\ud83d\udc64\ud83d\udecc\ud83d\udecf\ufe0f\u2728", "Or is it, that as in essence whiteness is not so much a colour as the visible absence of colour": "\ud83e\udd14\u2753\ud83d\udd0d\ud83c\udf1f\u2755\ud83e\udd0d\u27a1\ufe0f\ud83d\udeab\ud83c\udf08\ud83d\udccf\ud83d\udc49\ud83d\udc40\ud83d\udeab\ud83c\udfa8", "Darkness came on": "\ud83c\udf11\ud83c\udf0c\u2728", "Talk not to me of blasphemy, man; I\u2019d strike the sun if it insulted me.": "\ud83d\udde3\ufe0f\ud83d\udeab\u27a1\ufe0f\ud83d\ude21\ud83c\udf1e\ud83d\ude24\u270b\u26a1", "But in pursuit of those far mysteries we dream of, or in tormented chase of the demon phantom": "\ud83d\udd0d\ud83c\udf0c\ud83d\udcad\u2728\ud83d\ude08\ud83d\udc7b\ud83c\udfc3\u200d\u2642\ufe0f\ud83d\udca8", "pondering all this, the palsied universe lies before us a leper": "\ud83e\udd14\ud83c\udf0c\ud83e\udd1d\ud83d\ude1f\ud83e\udda0", "the measureless crush and crash of the sperm whale's ponderous flukes": "\ud83d\udc0b\ud83d\udca5\ud83d\udd0a\ud83d\udd28\ud83d\udccf\u274c\ud83c\udf0a", "this interlude was over": "\u23f8\ufe0f\ud83d\udcad\u23f3\u27a1\ufe0f\ud83c\udfc1", "It was Moby Dick\u2019s open mouth and scrolled jaw; his vast, shadowed bulk still half blending with the blue of the sea.": "\ud83d\udc0b\ud83d\udcd6\ud83d\ude2e\ud83d\udc44\u2795\ud83d\udd04\ud83d\udc33; \ud83d\udc0b\u2b1b\ufe0f\ud83c\udf0a\ud83d\udd35", "Take heart, take heart, O Bulkington!": "\u2764\ufe0f\u200d\ud83d\udd25 \u2764\ufe0f\u200d\ud83d\udd25, O \ud83d\udea2\u2693\ufe0f!", "he knew that for all this the chief mate, in his soul, abhorred his captain\u2019s quest, and could he, would joyfully disintegrate himself from it, or even frustrate it": "\ud83e\uddd4\u200d\u2642\ufe0f\ud83d\udcad\u27a1\ufe0f\u2693\ufe0f\ud83d\udc68\u200d\u2708\ufe0f\ud83e\uddd1\u200d\u2708\ufe0f\ud83d\udc94\ud83d\udef3\ufe0f\ud83c\udff4\u200d\u2620\ufe0f\ud83d\uddfa\ufe0f\u274c\ud83d\ude4f\ud83d\udd1a\ud83c\udfaf\ud83d\udeab\ud83d\udca5\ud83d\ude04\ud83d\udeaa\ud83d\ude21", "I own thy speechless, placeless power": "Here's a translation of the text into emojis:\n\n\"I \ud83d\udc41\ufe0f own \ud83c\udfa4\ud83e\udd10, \ud83c\udf0d\ud83c\udfe0\u274c power \ud83d\udcaa\"", "like another Ixion I did revolve": "\ud83d\udc4d\ud83d\udd04\ud83c\udf00\ud83e\uddd4\u27a1\ufe0f\ud83d\udd04", "that harpoon\u2014so like a corkscrew now\u2014was flung in Javan seas, and run away with by a whale, years afterwards slain off the Cape of Blanco": "\ud83d\udc0b\ud83e\ude9d\ud83d\udd04\ud83c\udf0a\ud83d\udccd\ud83d\udc33\u27a1\ufe0f\u2b05\ufe0f\ud83c\udfdd\ufe0f\ud83d\udd2a\ud83d\udccd\u23f3\u27a1\ufe0f\ud83d\uddfa\ufe0f", "Don\u2019t I always say that to be good, a whale-steak must be tough? There are those sharks now over the side, don\u2019t you see they prefer it tough and rare?": "\ud83d\ude45\u200d\u2642\ufe0f\u27a1\ufe0f\ud83d\udde3\ufe0f\ud83d\udd04\ud83d\udc46\ud83e\udd14\ud83d\udc0b\ud83e\udd69\ud83d\udc4a\ud83d\udc4c\u2753\ud83e\udd88\u27a1\ufe0f\ud83d\udc40\ud83e\udd14\ud83d\udc40\u27a1\ufe0f\ud83d\udc4d\ud83c\udf36\ufe0f\ud83c\udf56\ud83c\udf74", "His life, as they significantly call it, was untouched.": "\ud83d\udc49\ud83d\ude42 'His life, as they significantly call it, was untouched.' \ud83c\udf31", "after all this silence, his unearthly voice was heard announcing that silvery, moon-lit jet": "\ud83e\udd2b\ud83c\udf15\ud83c\udf0c\ud83d\udd0a\ud83d\udc7d\ud83d\udde3\ufe0f\ud83d\ude80", "Ah! how they still strove through that infinite blueness to seek out the thing that might destroy them!": "\ud83d\ude32\ud83d\udcaa\ud83d\udd0d\ud83c\udf0a\ud83d\udd35\ud83d\udd0d\ud83d\udd0d\ud83d\udca5", "the fare was of the most substantial kind\u2014not only meat and potatoes, but dumplings; good heavens! dumplings for supper!": "\ud83c\udf7d\ufe0f\ud83e\udd69\ud83e\udd54\ud83e\udd5f\ud83c\udf19\ud83d\ude32\ud83e\udd5f\ud83c\udf7d\ufe0f", "Queequeg was George Washington cannibalistically developed.": "Queequeg \ud83d\uddff\u27a1\ufe0f\ud83c\uddfa\ud83c\uddf8\ud83c\udf74\ud83d\udc68\u200d\ud83c\udf3e", "There, then, he sat, holding up that imbecile candle in the heart of that almighty forlornness.": "\ud83e\ude91\ud83d\udd25\ud83e\udd26\u200d\u2642\ufe0f\ud83d\udd6f\ufe0f\ud83d\udc94\ud83c\udf0c", "this dignity is heightened by the pepper and salt colour of his head at the summit, giving token of advanced age and large experience": "\ud83d\udc74\u2728\ud83e\uddc2\ud83c\udf73\ud83d\udc68\u200d\ud83e\uddb3\u2b06\ufe0f\ud83d\udd1d\ud83d\udd70\ufe0f\ud83d\udcda", "these spiritual throes in him heaved his being up from its base, and a chasm seemed opening in him, from which forked flames and lightnings shot up, and accursed fiends beckoned him to leap down among them": "\ud83c\udf00\ud83d\udcab\ud83d\udd25\ud83d\ude16\ud83d\udcc8\ud83d\udd1d\ud83c\udf0c\ud83d\ude1f\ud83d\udd73\ufe0f\ud83c\udf0b\u26a1\ud83d\udc79\ud83d\udc46\ud83d\udc47", "Porpoises, indeed, are to this day considered fine eating. The meat is made into balls about the size of billiard balls, and being well seasoned and spiced might be taken for turtle-balls or veal balls.": "\ud83d\udc2c\u27a1\ufe0f\ud83e\udd24\ud83c\udf7d\ufe0f\ud83d\udd2a\ud83c\udf56\u27a1\ufe0f\u26aa\ufe0f\u2795\ud83c\udf36\ufe0f\ud83d\udc4c\u2795\ud83e\uddc4\ud83d\udcab\ud83d\udc49\ud83d\udc22\ud83c\udf56\ud83d\udd04\ud83d\udc04\ud83c\udf56", "I have ever found your plain things the knottiest of all.": "\ud83d\ude4b\u200d\u2642\ufe0f\u2753\ud83e\udd14\ud83d\udd0e\ud83d\udc49\ud83d\udcbc\u27a1\ufe0f\ud83d\udc54\ud83e\udde9\ud83d\udd17\ud83c\udf10\u2757\ufe0f", "my means are sane, my motive and my object mad": "\ud83e\udd14\ud83d\udc49\ud83e\udd2f, \ud83c\udfaf\ud83d\udcc8 \ud83e\udd2a", "a black night in an open boat, when almost despairing of reaching any hospitable shore": "\ud83c\udf11\u26f5\ud83c\udf0c\ud83d\ude1f\ud83c\udfdd\ufe0f\ud83d\ude14", "The drama\u2019s done.": "\ud83c\udfad\u2705", "Squall, whale, and harpoon had all blended together; and the whale, merely grazed by the iron, escaped.": "\ud83c\udf27\ufe0f\ud83d\udc0b\ud83d\udd31\u2795\u2728\u27a1\ufe0f\ud83d\udc0b, \ud83e\ude79\u2796\ud83d\udd31, \ud83c\udfc3\u200d\u2642\ufe0f", "One day the planks stream with freshets of blood and oil": "\u2600\ufe0f\ud83d\udcc5\ud83c\udf0a\ud83e\udeb5\u27a1\ufe0f\ud83c\udf0a\ud83e\ude78\ud83d\udee2\ufe0f", "Gnawed within and scorched without, with the infixed, unrelenting fangs of some incurable idea": "\ud83e\udde0\ud83d\udd25\ud83d\udc0d\ud83d\udca1\u274c", "I might proceed with several more examples, one way or another known to me, of the great power and malice at times of the sperm whale.": "\ud83d\udc0b \u27a1\ufe0f \ud83e\udd14 \u27a1\ufe0f \ud83d\udd1c \u2795 \ud83d\udd22 \ud83d\udcda, \ud83d\udd00 \u2194\ufe0f \u2753 \u27a1\ufe0f \ud83e\udd1d \ud83d\udcad, \ud83d\udd1d \ud83c\udf1f \ud83d\udcaa & \ud83d\ude20 \ud83c\udfad \ud83d\udd70\ufe0f \ud83d\udc33", "More and more she leans over to the whale": "\ud83d\udc69\u27a1\ufe0f\ud83d\udc0b\ud83d\udcc8", "With a terrific snap, every fastening went adrift; the ship righted, the carcase sank.": "\ud83d\udcf8\ud83d\udca5\u26d3\ufe0f\u27a1\ufe0f\ud83c\udf0a; \ud83d\udea2\u2693\ufe0f\ud83d\udd04, \ud83d\udc0b\u2b07\ufe0f\ud83c\udf0a.", "however they may thump and punch me about, I have the satisfaction of knowing that it is all right": "\ud83d\udc4a\ud83d\ude24\ud83d\udd04\ud83e\udd15\ud83d\ude0a\u270c\ufe0f\ud83e\udd14\ud83d\udcac\ud83d\udc4d", "Supplied by a late consumptive usher to a grammar school": "\ud83d\udce6\ud83d\udd1c\ud83d\udd70\ufe0f\ud83d\ude1e\ud83d\udcda\ud83d\udeb6\ud83c\udfeb\ud83d\udcda", "But what thinks Lazarus? Can he warm his blue hands by holding them up to the grand northern lights?": "\ud83e\udd14\ud83e\udd14\ud83c\udf1f\u2753\ud83e\udd14\u2600\ufe0f\u2753\ud83c\udf0c\ud83d\ude4c\ud83d\udd35\ud83d\udc50\u2753", "Fool! I am the Fates\u2019 lieutenant; I act under orders.": "\ud83e\udd21! I am the \ud83d\udd70\ufe0f\ud83c\udfad\ud83d\udcbc; I \ud83d\udc68\u200d\u2708\ufe0f\ud83d\udcdc.", "whether these spoutings are, after all, really water, or nothing but vapor\u2014this is surely a noteworthy thing": "\ud83d\udca7\ud83e\udd14\ud83d\udca8\u2753\ud83e\udd37\u200d\u2642\ufe0f\u2728\ud83d\udccc", "There are certain queer times in this strange mixed affair we call life when a man takes this whole universe for a vast practical joke": "\ud83c\udf0c\ud83e\udd14 There are certain \ud83e\udd28 times in this \ud83e\udd14 strange mixed \ud83c\udfad affair we call \ud83c\udf0d life when a \ud83e\udd37\u200d\u2642\ufe0f man takes this \ud83c\udf0c whole universe for a \ud83d\ude02 vast practical \ud83d\ude02 joke", "in the tail the confluent measureless force of the whole whale seems concentrated to a point": "\ud83d\udc0b\u27a1\ufe0f\ud83d\udd1a: \ud83c\udf0a\ud83d\udca5\ud83d\udd04\ud83d\udd01\u2728\ud83d\udc33\ud83c\udfaf", "the rushing Pequod, freighted with savages, and laden with fire, and burning a corpse, and plunging into that blackness": "\ud83d\udea2\ud83d\udca8\ud83d\udef6\ud83c\udf0d\ud83d\udd25\ud83d\udd25\u26b0\ufe0f\ud83d\udd25\u2b1b\ud83c\udf0a", "We thought the tissued, infiltrated head of the Sperm Whale, was the lightest and most corky part about him; and yet thou makest it sink in an element of a far greater specific gravity than itself.": "\ud83e\udde0\u27a1\ufe0f\ud83d\udca7\ud83d\udc0b\u2696\ufe0f\ud83d\udcc9\ud83d\udca1\ud83d\udce6\ud83d\udd0d\ud83e\udd14 \u2795 \ud83c\udf0a\u26aa\ufe0f\u2b07\ufe0f\ud83c\udf0c\ud83d\udcc9\u2696\ufe0f\ud83e\udd37\u200d\u2642\ufe0f", "But why say more?": "\ud83e\udd37\u200d\u2642\ufe0f\ud83e\udd10\u2753", "The truest of all men was the Man of Sorrows, and the truest of all books is Solomon\u2019s": "\ud83d\ude22\ud83d\udc68\u200d\ud83e\uddb1\u271d\ufe0f\ud83d\udcd6\ud83d\udcaf\ud83d\udcda\ud83d\udd1d\ud83d\udcd8\u270d\ufe0f\ud83d\udc51\u2721\ufe0f", "Ahab to-and-fro paced the deck; in his forward turn beholding the monsters he chased, and in the after one the bloodthirsty pirates chasing him": "\ud83e\uddd4\u200d\u2642\ufe0f\u27a1\ufe0f\u2b05\ufe0f\ud83d\udeb6\u200d\u2642\ufe0f\ud83d\udef3\ufe0f; \u27a1\ufe0f\ud83d\udd0d\ud83d\udc0b he \ud83d\udd19\ud83d\udc40\ud83e\udd9c\ud83c\udff4\u200d\u2620\ufe0f\ud83d\udd2a him", "And, to wind up, with Pisces, or the Fishes, we sleep.": "\ud83d\udc1f\ud83d\udca4", "Here now\u2019s the very dreaded symbol of grim death, by a mere hap, made the expressive sign of the help and hope of most endangered life.": "\u2620\ufe0f\u27a1\ufe0f\u2764\ufe0f\u270b\ud83d\udc80\u27a1\ufe0f\ud83d\udc4d\ud83d\ude4c\ud83e\udd1e\ud83c\udf1f\ud83d\udcaa", "he takes to wife in the wilderness of waters, and the best of wives she is, though she keeps so many moody secrets": "\ud83d\udc68\u200d\u2764\ufe0f\u200d\ud83d\udc69\ud83d\udc8d\ud83c\udf0a\ud83c\udfde\ufe0f, \ud83d\udc70\u2728\ud83d\udc4d, \ud83e\udd2b\ud83c\udf0a\ud83d\udcac", "It was a Saturday night, and such a Sabbath as followed!": "\ud83c\udf19\ud83d\udcc5\u2728 It was a Saturday night, and such a Sabbath as followed! \u2728\ud83d\ude4f", "What is best let alone, that accursed thing is not always what least allures.": "\ud83e\udd14\u2753\ud83d\udc49\ud83d\udeab\ud83d\udd1d\ud83d\udd52, \ud83d\udc7f\ud83d\udc94\ud83d\udeab\ud83d\udc40\ud83d\udd19\ud83d\udd52\ud83c\udf00\ud83d\udd52\u2728.", "a prodigious sensation in all directions": "\ud83c\udf1f\ud83d\ude32\ud83c\udf1f in all \ud83d\udd04", "my men, the thunder turned old Ahab\u2019s needles; but out of this bit of steel Ahab can make one of his own, that will point as true as any": "\ud83d\udc68\u200d\ud83e\uddb3\u26a1\ufe0f\ud83d\udd04\ud83d\udc74\ud83e\udded\ud83d\udccc; \ud83d\udee0\ufe0f\ud83e\ude9b\ud83e\uddd4\u200d\u2642\ufe0f\ud83d\udc49\u2699\ufe0f\ud83c\udd95\ud83e\udded, \ud83d\udc68\u200d\u2708\ufe0f\ud83d\udccc\u27a1\ufe0f\u2b06\ufe0f\ud83d\udccd\ud83d\udccd\ud83d\udd1d", "up from yonder cottage goes a sleepy smoke": "\ud83c\udf04\ud83c\udfe0\ud83d\udca4\ud83c\udf2b\ufe0f\u2b06\ufe0f", "Whelped somewhere by the sharkish sea": "\ud83d\udc36\ud83c\udf0a\ud83e\udd88\ud83c\udf0a", "throw out some hints touching the phrenological characteristics of other beings than man": "\ud83d\udd0d\ud83d\udcad\ud83d\udc49\ud83d\ude2f\ud83d\udd0d\ud83d\udc64+\ud83d\udd0d\ud83d\udc65\ud83d\udc7d", "the constituents of a chaos, nothing less is here": "\ud83c\udf0c\u2728\ud83d\udca5, \ud83d\udeab\u2b07\ufe0f\ud83d\udd3d\ud83d\udccd\ud83e\udd14", "mortal man should feed upon the creature that feeds his lamp": "\ud83e\uddcd\u200d\u2642\ufe0f\u27a1\ufe0f\ud83c\udf74\ud83d\udc04\u27a1\ufe0f\ud83d\udca1", "how it is that we still refuse to be comforted for those who we nevertheless maintain are dwelling in unspeakable bliss": "\ud83e\udd14\ud83d\ude22\ud83d\udcad\u274c\ud83d\ude0c\ud83d\udc65\ud83d\udc7c\ud83c\udf08", "I think his broad brow to be full of a prairie-like placidity, born of a speculative indifference as to death.": "\ud83e\udd14\ud83d\udc64\ud83e\udd15\ud83c\udf3e\ud83d\ude0a\ud83e\udde0\u27a1\ufe0f\ud83d\ude0c\ud83c\udf3e\ud83c\udf3b, \ud83c\udf7c\ud83d\udd0d\u2753\ud83d\ude36\ud83c\udff4\u200d\u2620\ufe0f\ud83d\udc80.", "to comprehend it aright, you must know something of the curious internal structure of the thing operated upon": "\ud83e\udd14\u27a1\ufe0f\ud83e\udde0\ud83d\udc4d, \ud83d\udc49\ud83d\udcd6\ud83e\uddd0\ud83d\udd0d\ud83c\udfd7\ufe0f\ud83c\udf00\ud83d\udca1\ud83e\udd14\ud83d\udd27", "admire and model thyself after the whale! Do thou, too, remain warm among ice. Do thou, too, live in this world without being of it.": "\ud83d\udc0b\u2728 Admire the whale! Be like the whale! Stay warm \u2744\ufe0f\ud83d\udd25 in the cold. Live in the world \ud83c\udf0d without being of it. \ud83c\udf0a", "of what a very light substance the entire interior of the sperm whale\u2019s enormous head consists": "\ud83d\udc0b\ud83e\udd14\ud83c\udf1f\ud83d\udcad\ud83d\udce6\ud83d\udeab\ud83d\udc18\ud83e\udde0\ud83d\udca1\ud83c\udfad", "Why tell the whole?": "\ud83e\udd14\u2753\ud83d\udde3\ufe0f\ud83d\ude2e\u200d\ud83d\udca8", "In the midst of the personified impersonal, a personality stands here.": "\ud83d\udc64\u2728 in the \ud83c\udf2a\ufe0f of \ud83c\udf10, a \ud83d\udc64 stands \u2b07\ufe0f", "the body showed symptoms of sinking with all its treasures unrifled": "\ud83c\udff4\u200d\u2620\ufe0f\u2693\ufe0f The body showed symptoms of sinking, with all its treasures unrifled \ud83c\udff4\u200d\u2620\ufe0f\ud83d\udc8e\ud83d\udd12", "Vacantly eyeing the heaving whale": "\ud83d\udc40\ud83d\ude36\ud83d\udc0b", "What are the Rights of Man and the Liberties of the World but Loose-Fish?": "\ud83d\udfe0\u2753\ud83e\udd37\u200d\u2642\ufe0f\u2696\ufe0f\ud83e\uddd1\u200d\u2696\ufe0f\ud83c\udf0e\ud83d\udd13\ud83d\udc1f", "The truth is, that living or dead, if but decently treated, whales as a species are by no means creatures of ill odor": "\ud83d\udd0d\u27a1\ufe0f\ud83d\udc33\u2728\ud83e\udd14\ud83d\udc80, \u261d\ufe0f\ud83d\ude42\ud83d\ude07, \ud83d\udc0b\ud83d\udc99\ud83e\udd91 \ud83d\udeab\ud83d\udc09\u26a0\ufe0f\ud83d\udca8", "in everything imposingly beautiful, strength has much to do with the magic": "\ud83d\udcaa\u2728 In everything imposingly beautiful, strength has much to do with the magic \u2728\ud83d\udcaa", "they swam out of the white curds of the whale\u2019s direful wrath into the serene, exasperating sunlight": "\ud83d\udc65\ud83c\udfca\u200d\u2642\ufe0f\ud83c\udfca\u200d\u2640\ufe0f\u27a1\ufe0f\ud83d\udc33\ud83c\udf0a\ud83c\udf29\ufe0f\u27a1\ufe0f\ud83c\udf1e\ud83d\ude0c\ud83d\ude20", "conscience is the wound, and there\u2019s naught to staunch it": "\ud83e\udde0\ud83e\udd15 = \ud83d\ude14, \u274c\ud83d\udeab\ud83e\ude79", "an ostrich of potent digestion gobbles down bullets and gun flints": "\ud83e\udda9\ud83c\udf7d\ufe0f\ud83d\udd2b\ud83d\udca5\ud83e\udd44", "They are the only whales regularly hunted by man.": "\ud83d\udc0b\u2757\ufe0f\ud83d\udd0d\ud83d\udd2b\ud83d\ude4b\u200d\u2642\ufe0f", "we have elsewhere seen": "\ud83d\udd0d\ud83c\udf0d\ud83d\udc40", "does the all-contributed and all-receptive ocean alluringly spread forth his whole plain of unimaginable, taking terrors": "\ud83c\udf0a\ud83e\udd1d\ud83c\udf0d\ud83c\udf0a\u2728\ud83d\udc50\ud83c\udf0c\ud83d\ude31", "As in general shape the noble Sperm Whale\u2019s head may be compared to a Roman war-chariot": "\ud83d\udc0b\u2694\ufe0f\ud83c\udfdb\ufe0f\ud83d\udde1\ufe0f In general shape, the noble Sperm Whale's head may be compared to a Roman war-chariot.", "my free will had received a mortal wound; and that another\u2019s mistake or misfortune might plunge innocent me into unmerited disaster": "\ud83d\ude47\u200d\u2642\ufe0f\ud83e\ude78\u27a1\ufe0f\ud83d\udc94\u2696\ufe0f\ud83e\udea6; \u2795\ud83d\udc94's \ud83d\udcad\ud83d\udcac\u26a0\ufe0f\u26a1\u27a1\ufe0f\ud83d\ude07\ud83d\ude14\ud83d\ude23\u26a1\u27a1\ufe0f\ud83d\udeab\ud83c\udfc6\ud83d\ude1e", "The whale fell directly over him, and probably killed him in a moment.": "\ud83d\udc0b\u2b07\ufe0f\ud83d\ude32\u2620\ufe0f\u26a1\ufe0f", "not one in fifty of the actual disasters and deaths by casualties in the fishery, ever finds a public record at home, however transient and immediately forgotten that record": "\ud83e\udd14 Not 1\ufe0f\u20e3 in 5\ufe0f\u20e30\ufe0f\u20e3 of the actual \u26a0\ufe0f\ud83c\udf0a and \u2620\ufe0f in the \ud83c\udfa3, ever finds a \ud83d\udcdc\ud83c\udfe0, however \ud83d\udd52 and \ud83d\udd1c forgotten that record", "a dim consciousness of knowing something about me seemed slowly dawning over him": "\ud83d\ude36\ud83d\udcad\ud83d\udd75\ufe0f\u200d\u2642\ufe0f\ud83d\udca1\ud83e\udd14\u27a1\ufe0f\ud83d\udd70\ufe0f\ud83d\udc65", "bury thyself in a life which, to your now equally abhorred and abhorring, landed world, is more oblivious than death": "\ud83e\udea6\ud83e\udd14\ud83c\udf31\u27a1\ufe0f\ud83c\udf0d\ud83d\udcda,\ud83d\udd04\ud83d\udc94\ud83d\ude45\u200d\u2642\ufe0f\u27a1\ufe0f\ud83c\udf00\ud83c\udf0c\ud83c\udf0d,\ud83d\udeab\ud83d\udd0d\u27a1\ufe0f\ud83d\udc80", "I trod the ship; I knew the crew; I have seen and talked with Steelkilt since the death of Radney.": "\ud83d\udc63\ud83d\udea2\ud83d\udc65\ud83e\udd1d\ud83d\udde3\ufe0f\ud83d\udc80", "in most creatures, nay in man himself, very often the brow is but a mere strip of alpine land lying along the snow line": "\ud83c\udf0d\u27a1\ufe0f\ud83d\ude3a, \ud83d\udeab\ud83d\udc68\u200d\ud83d\udd2c\ud83e\udd37\u200d\u2642\ufe0f, \ud83d\udd01\ud83d\udd70\ufe0f\ud83d\ude2f\ud83d\udeb6\u200d\u2642\ufe0f\ud83d\udd1d, \ud83d\udc41\ufe0f\u26a0\ufe0f\ud83d\udc41\ufe0f \ud83c\udf5e\ud83c\udf04\u23e9\u2744\ufe0f\ud83d\udcc9", "And here, shipmates, is true and faithful repentance; not clamorous for pardon, but grateful for punishment.": "\ud83d\udde3\ufe0f\ud83e\uddd1\u200d\u2708\ufe0f\u27a1\ufe0f\ud83d\udea2\ud83e\udd1d\ud83d\udc99\ud83d\ude14: \ud83d\ude4f\u2728\u2194\ufe0f\ud83d\udd04\ud83d\ude4f; \ud83e\udd10\ud83d\udd0a\u274c\ud83d\ude4f, \ud83e\udd32\ud83d\udc96\u2714\ufe0f\u2696\ufe0f.", "a miraculous lamp that burnt without any oil": "\ud83d\udd2e\ud83e\ude94\u2728\ud83d\udd25\u274c\ud83d\udee2\ufe0f", "In this world, shipmates, sin that pays its way can travel freely, and without a passport": "\ud83c\udf0d\u26f5\ufe0f\u2757\ufe0f\ud83d\ude08\ud83d\udcb5\ud83d\udee3\ufe0f\u2708\ufe0f\ud83c\udd93, \ud83d\udec2\ud83d\udeab", "malignant iron scorchingly devoured the baptismal blood": "\ud83e\udda0\ud83d\udd25 voraciously consumed \ud83d\udca7\ud83d\udc80", "thoughts like these troubled very few of the reckless crew": "\ud83e\udd14\ud83d\udcad like these \ud83e\udd2f worried very few of the \ud83e\udd2a\ud83d\udef3\ufe0f crew", "beneath all that silence and placidity, the utmost monster of the seas was writhing and wrenching in agony": "\ud83c\udf0a\ud83e\udd2b\ud83d\udc0b\ud83d\udca4 -> \ud83d\ude16\ud83d\udd04\ud83d\udc79\ud83d\udca5\ud83d\ude29", "a long, low, shelf-like table covered with cracked glass cases, filled with dusty rarities gathered from this wide world\u2019s remotest nooks": "\ud83e\ude91\ud83d\udccf\ud83e\uddca\u274c\ud83c\udf0d\ud83d\udcda\ud83d\udd78\ufe0f\ud83c\udffa\ud83d\uddfa\ufe0f\ud83d\udd0d", "the more whales the less fish": "\ud83d\udc0b\u2795\ud83d\udc0b\u27a1\ufe0f\ud83d\udc1f\u2796", "Methinks that what they call my shadow here on earth is my true substance.": "\ud83e\uddd0\ud83c\udf0d\ud83d\udcad\u27a1\ufe0f\ud83d\udd76\ufe0f\u2601\ufe0f=\ud83d\udcaf\ud83c\udf1f", "creatures, that warm themselves under the lee of an iceberg, as a traveller in winter would bask before an inn fire": "\ud83d\udc3e\u2744\ufe0f\ud83e\uddca\ud83c\udf2c\ufe0f\u2600\ufe0f\ud83e\uddf3\ud83c\udf28\ufe0f\u27a1\ufe0f\ud83d\udd25\ud83c\udfe8", "Hurrah! this is the way to sail now. Every keel a sunbeam!": "\ud83c\udf89\u26f5\ufe0f\u2600\ufe0f", "Though I cannot tell why it was exactly that those stage managers, the Fates, put me down for this shabby part of a whaling voyage": "\ud83e\udd14\u26f4\ufe0f\ud83c\udfad\ud83e\udd37\u200d\u2642\ufe0f\u27a1\ufe0f\ud83c\udfad\ud83c\udfad,\ud83e\udd14\ud83d\udd2e\ud83d\udd00\ud83d\udc49\ud83e\uddd1\u200d\u2708\ufe0f\ud83c\udf0a\ud83d\udc33\ud83d\udef3\ufe0f", "Almost forgetting for the moment all thoughts of Moby Dick, we now gazed at the most wondrous phenomenon which the secret seas have hitherto revealed to mankind.": "\ud83d\udc0b\ud83e\udd14\u274c\ud83d\udcad\u27a1\ufe0f\ud83d\udc33, \ud83d\udc40\ud83d\udd0d\u2728\ud83c\udf0a\ud83c\udf0c\ud83d\udd0d\ud83e\udd2b\ud83c\udf0a\ud83c\udf0f\u27a1\ufe0f\ud83d\udc40\ud83d\udc65.", "the sea dashes even the mightiest whales against the rocks, and leaves them there side by side with the split wrecks of ships": "\ud83c\udf0a\ud83d\udc33\ud83d\udca5\ud83e\udea8\u27a1\ufe0f\ud83c\udf0a\u26f5\ufe0f\ud83d\udc94", "In the long try watches of the night it is a common thing for the seamen to dip their ship-biscuit into the huge oil-pots and let them fry there awhile.": "\ud83c\udf19\u23f3\ud83e\udd14\ud83d\udd52\ud83c\udf0c\ud83c\udf0a\ud83d\udea2\ud83d\udc68\u200d\u2708\ufe0f\ud83d\udc49\ud83c\udf6a\u27a1\ufe0f\ud83d\udee2\ufe0f\u27a1\ufe0f\ud83c\udf73\ud83d\udd52", "But look! here come more crowds, pacing straight for the water, and seemingly bound for a dive. Strange!": "\ud83d\udc40\ud83c\udfc3\u200d\u2642\ufe0f\ud83c\udfc3\u200d\u2640\ufe0f\u27a1\ufe0f\ud83c\udf0a\ud83e\udd14\ud83d\udca6\ud83e\udd3f\ud83d\ude2e", "Go visit the Prairies in June, when for scores on scores of miles you wade knee-deep among Tiger-lilies": "\ud83d\udfe2\ud83c\udf3e\ud83c\udf1e\u27a1\ufe0f\ud83d\ude8c\u27a1\ufe0f\ud83c\udf3e\u27a1\ufe0f\ud83d\uddd3\ufe0f\ud83c\udf1e6\ufe0f\u20e3\ud83d\udcc5\u27a1\ufe0f\ud83d\udccf\u27a1\ufe0f\ud83c\udf3c\ud83c\udfc3\u200d\u2642\ufe0f\ud83c\udf3c\ud83c\udf3c\ud83c\udf3c", "Every one knows the fine story of Perseus and Andromeda": "\ud83d\udc68\u200d\ud83c\udfa4\ud83d\udd31\ud83d\udcd6\u2728\ud83d\udc0d\ud83d\udc69\u200d\ud83e\uddb1", "I squeezed that sperm till a strange sort of insanity came over me": "\ud83d\udc4b\ud83c\udf00\ud83e\uddd1\u200d\u2695\ufe0f\ud83e\udd2f", "accursed fiends beckoned him to leap down among them": "\ud83d\ude08\ud83e\udddb\u200d\u2642\ufe0f\ud83e\udddf\u200d\u2642\ufe0f\ud83d\udc49\ud83d\udc47\ud83e\udd14", "the tun of the whale contains by far the most precious of all his oily vintages; namely, the highly-prized spermaceti, in its absolutely pure, limpid, and odoriferous state": "\ud83d\udc0b\ud83c\udf76\u2728\ud83d\udd1d\ud83c\udf1f\ud83d\udca7\ud83d\udc8e\u27a1\ufe0f\ud83e\udd47\ud83d\udcc8\ud83c\udf0a\ud83c\udfc6\ud83d\udcb0\u2728\ud83d\udc33\ud83d\udc47\ud83d\udcc8\ud83e\udd70", "mortal disasters have immemorially and indiscriminately befallen tens and hundreds of thousands of those who have gone upon the waters": "\ud83d\udc80\ud83c\udf0a\u26f5\ufe0f\u2620\ufe0f\u23f3\ud83d\udc49\u2693\ufe0f\ud83d\udcaf\u2795\ud83d\udc65\ud83d\udeb6\u200d\u2642\ufe0f\ud83d\udd39", "Moby Dick moved on, still withholding from sight the full terrors of his submerged trunk, entirely hiding the wrenched hideousness of his jaw.": "\ud83d\udc0b\u27a1\ufe0f\ud83d\udeb6\u200d\u2642\ufe0f, \ud83e\udd2b\ud83d\udc40\ud83d\ude31\ud83c\udf0a\ud83e\udd2b\ud83d\udd30, \ud83d\ude48\ud83d\ude28\ud83d\udc44\ud83d\udd12.", "Thou saw\u2019st the murdered mate when tossed by pirates from the midnight deck; for hours he fell into the deeper midnight of the insatiate maw": "\u2693\ufe0f\ud83d\udc40\ud83d\udc80\ud83d\udea2\ud83c\udff4\u200d\u2620\ufe0f\ud83c\udf0c\u27a1\ufe0f\ud83d\udd52\u2b07\ufe0f\ud83c\udf0a\ud83d\udcc9\ud83d\udda4\ud83d\udd73\ud83d\ude08\ud83e\udd88", "even then, Ahab, in his hidden self, raved on": "\ud83c\udf1c\ud83e\udd14, \ud83c\udff4\u200d\u2620\ufe0f\ud83d\udc33, \ud83e\udd2b\ud83d\ude4d\u200d\u2642\ufe0f, \ud83d\udd25\ud83d\udcad\ud83c\udfad", "breathing is only a function indispensable to vitality": "\ud83c\udf2c\ufe0f\u27a1\ufe0f\ud83d\udd27\ud83d\udca8\ud83e\uddd8\u200d\u2642\ufe0f\ud83d\udeab\u27a1\ufe0f\ud83d\udcaf\ud83c\udfc6\ud83d\udd0c\ud83c\udf31", "For worm-like, then, oh! who would craven crawl to land!": "\ud83d\udc1b\u2753\ud83d\ude32\ud83e\udeb1\u27a1\ufe0f\ud83c\udf0d\ud83c\udf31", "\u201cI fear not thy epidemic, man,\u201d said Ahab": "\ud83d\udde3\ufe0f \"I fear not thy epidemic, man,\" \ud83d\udde3\ufe0f said Ahab", "I\u2019ll get a crucible, and into it, and dissolve myself down to one small, compendious vertebra.": "\ud83d\udd2e\u27a1\ufe0f\ud83d\udd25\ud83d\udd3d\ud83e\uddea\ud83d\udcc9\ud83d\udd04\u2796\ud83d\udccf\ud83e\uddb4", "there are instances where, after the lapse of many hours or several days, the sunken whale again rises, more buoyant than in life": "\ud83c\udf0a\ud83d\udd52\u27a1\ufe0f\u231b\ufe0f\ud83d\uddd3\ufe0f\u27a1\ufe0f\u2600\ufe0f\ud83d\udc0b\u2b06\ufe0f, \ud83d\udea2\ud83d\udc33\ud83d\udd1d, \ud83d\udcc8\ud83d\udca8\ud83d\udcc8\ud83c\udf1e", "through infancy\u2019s unconscious spell, boyhood\u2019s thoughtless faith, adolescence\u2019 doubt (the common doom), then scepticism, then disbelief, resting at last in manhood\u2019s pondering repose of If": "\ud83d\udc76\u2728 \u27a1\ufe0f \ud83e\uddd2\ud83d\ude4f \u27a1\ufe0f \ud83e\uddd1\u200d\ud83c\udf93\u2753 \u27a1\ufe0f \ud83e\udd14\u27a1\ufe0f \ud83e\udd28\u27a1\ufe0f \ud83d\ude4c \u27a1\ufe0f \ud83d\udc68\ud83e\udde0\ud83d\udcad 'If'", "Silence reigned over the before tumultuous but now deserted deck.": "\ud83e\udd2b\ud83d\udc51 \ud83c\udf0a\ud83d\udef3\ufe0f\u27a1\ufe0f\ud83e\udd2f\ud83d\udcc9\u27a1\ufe0f\ud83c\udfdd\ufe0f\ud83d\uddc3\ufe0f", "it would not do to be sellin\u2019 human heads about the streets when folks is goin\u2019 to churches": "\ud83e\udde0\ud83d\udeab\u27a1\ufe0f\ud83c\udfd9\ufe0f\ud83d\uded2\ud83d\udeb6\u200d\u2642\ufe0f\u27a1\ufe0f\u26ea", "high above the flying scud and dark-rolling clouds, there floated a little isle of sunlight": "\u2601\ufe0f\u2b06\ufe0f\ud83c\udf2c\ufe0f\ud83c\udf25\ufe0f\u2601\ufe0f\u2728\ud83c\udf24\ufe0f\ud83c\udfdd\ufe0f", "Moby Dick bodily burst into view!": "\ud83d\udc0b\ud83d\udca5\ud83d\udc40!", "Inferable from these statements, are many collateral subtile matters touching the chase of whales.": "\ud83d\udd0d\ud83d\uddef\ufe0f\ud83d\udcdc\u2712\ufe0f\ud83d\udc0b\u27a1\ufe0f\ud83e\udd14\ud83d\udcda\ud83c\udff9\ud83d\udc33", "Not so much thy skill, then, O hunter, as the great necessities that strike the victory to thee!": "\ud83c\udff9\u274c\ud83d\ude45\u200d\u2642\ufe0f\ud83e\udd14\ud83d\udcda\ud83d\udc3e\ud83d\udd0d\ud83e\udd14, \ud83c\udf1f\ud83d\uded1\ud83e\uddd1\u200d\ud83e\uddb3\ud83c\udff9, \ud83d\udd1b\ud83e\udd14\ud83c\udf1f\ud83d\udcc8\ud83d\udea8\ud83d\udd11\ud83d\udc3e\ud83c\udf1f\ud83d\udcaa\ud83c\udfc6\ud83d\udc49\ud83c\udfaf!", "There\u2019s orthodoxy!": "\ud83e\ude7b\ud83d\udc68\u200d\u2695\ufe0f\ud83d\udcda!", "For God\u2019s sake, be economical with your lamps and candles! not a gallon you burn, but at least one drop of man\u2019s blood was spilled for it.": "\ud83d\ude4f\ud83d\udca1\ud83d\udd6f\ufe0f\ud83d\udcb0\u2757\ufe0f\ud83d\udd25\u26fd\ufe0f\u27a1\ufe0f\ud83d\udca7\ud83e\ude78\ud83d\udc80", "I came here to hunt whales, not my commander\u2019s vengeance.": "\ud83d\udeec\ud83e\udd88\ud83d\udd0d\ud83d\udc0b\u274c\ud83e\udef5\u2694\ufe0f\ud83d\udc57", "the proper skin of the tremendous whale is thinner and more tender than the skin of a new-born child": "\ud83d\udc0b\u27a1\ufe0f\ud83d\udc76\ud83d\udc76\u2728\ud83c\udd95\ud83d\udc76\ud83d\udc76\ud83d\udc76\ud83d\udc93", "But once gone through, we trace the round again; and are infants, boys, and men, and Ifs eternally.": "\ud83d\udd04\ud83d\udc76\ud83d\udc66\ud83d\udc68\u23f3\u267e\ufe0f", "length of foundation is nothing without corresponding breadth": "\ud83d\udccf\u2795\ud83c\udfd7\ufe0f\u2796\ud83d\udcac\ud83d\udccf\ud83d\udca4\u26d4\ufe0f\ud83d\udcda\u2696\ufe0f\ud83d\udccf\ud83d\udc4d\ud83c\udd9a\ud83d\udccf\ud83c\udf10", "Ginger!\u2014what the devil is ginger? Sea-coal? firewood?\u2014lucifer matches?\u2014tinder?\u2014gunpowder?\u2014what the devil is ginger, I say": "\ud83e\udeda\u2757\u2014\ud83d\ude08\u2753\ud83e\udeda\u2753\ud83c\udf0a\ud83e\udeb5\u2753\ud83d\udd25\ud83e\udeb5\u2753\u2014\u2728\ud83e\udde8\u2753\u2014\ud83d\udd25\ud83c\udf3f\u2753\u2014\ud83d\udca3\u2753\u2014\ud83d\ude08\u2753\ud83e\udeda\u2753", "Light though thou be, thou leapest out of darkness; but I am darkness leaping out of light, leaping out of thee!": "\ud83d\udca1\u27a1\ufe0f\ud83c\udf11; \ud83c\udf11\u27a1\ufe0f\ud83d\udca1, \u27a1\ufe0f\ud83d\udca1!", "Avast! heave to! I mean when you die, cook. It\u2019s an awful question. Now what\u2019s your answer?": "\ud83c\udff4\u200d\u2620\ufe0f\ud83d\uded1\u2693\ufe0f I mean \ud83e\udea6\ud83d\udc68\u200d\ud83c\udf73\u2753 It's \ud83d\ude31\ud83e\udd14\ud83e\udd28 Now \ud83e\udd37\u200d\u2642\ufe0f?", "be but an idle whim": "\ud83d\udd52\u274c\ud83e\udd14\ud83d\udcad", "a sort of brief interlude and solo between more extensive performances": "\ud83c\udfad\u23f8\ufe0f\ud83c\udfb6\u2728\ud83c\udfa4\u23f8\ufe0f\ud83c\udfb6\ud83c\udfad\ud83d\udcdc\ud83c\udf1f", "this round gold is but the image of the rounder globe": "\ud83d\udd04\ud83c\udfc5\u27a1\ufe0f\ud83d\uddbc\ufe0f\ud83c\udf0d\ud83d\udd35", "Didn\u2019t ye hear a word about them matters and something more, eh?": "\ud83d\udc42\u2753\ud83d\udde3\ufe0f\ud83d\ude49\ud83e\udd14\ud83d\udcdc\u2139\ufe0f\u2795\ud83d\udd0d\ud83e\udd28", "spiritually feasting upon some unearthly reminiscence": "\ud83e\uddd8\u200d\u2640\ufe0f\u2728\ud83c\udf7d\ufe0f\ud83d\udc7b\ud83d\udd70\ufe0f\ud83d\udd2e", "Then there you lie like the one warm spark in the heart of an arctic crystal.": "\ud83d\udecc\u2728\u2764\ufe0f\u2744\ufe0f\ud83d\udc8e", "even the high lifted and chivalric Crusaders of old times were not content to traverse two thousand miles of land to fight for their holy sepulchre, without committing burglaries, picking pockets, and gaining other pious perquisites": "\ud83d\udc51\ud83d\udc82\u200d\u2642\ufe0f\ud83d\udee1\ufe0f\u2694\ufe0f\ud83d\uddfa\ufe0f\u271d\ufe0f\ud83c\udff0\ud83c\udff4\u200d\u2620\ufe0f\ud83d\udcb0\ud83d\udc5c\u270b\ud83d\ude4f", "Nothing but two dismal tallow candles, each in a winding sheet.": "\ud83d\udeab\ud83c\udf87\ud83d\udd6f\ufe0f\ud83d\udd6f\ufe0f\u2620\ufe0f\ud83e\ude78", "I always go to sea as a sailor, because of the wholesome exercise and pure air of the fore-castle deck.": "\ud83d\udc68\u200d\u2708\ufe0f\ud83c\udf0a\ud83d\udea2\ud83d\udc68\u200d\u2708\ufe0f\ud83d\udca8\ud83c\udfcb\ufe0f\u200d\u2642\ufe0f\ud83c\udf1e\ud83c\udf43\u2693\ufe0f", "great bodies are at times encountered": "\ud83d\udcaa\ud83d\ude03\ud83c\udfcb\ufe0f\u200d\u2640\ufe0f\ud83d\udc40\ud83e\udd1d", "not the smallest atom stirs or lives on matter, but has its cunning duplicate in mind.": "\ud83d\udd2c\u274c\u2b07\ufe0f\ud83c\udf0c\ud83d\udd04\ud83c\udf31\u2795\ud83e\udde0\ud83c\udf00\ud83d\udc6f\u200d\u2642\ufe0f\ud83d\udca1", "less celestial, I celebrate a tail": "\ud83c\udf0c\u2b07\ufe0f, \ud83c\udf89\ud83d\udc3e", "the boat looks as if it were pulling off with a prodigious great wedding-cake to present to the whales.": "\ud83d\udea4\u27a1\ufe0f\ud83c\udf82\ud83d\udc0b\ud83c\udf81?", "With the landless gull, that at sunset folds her wings and is rocked to sleep between billows": "\ud83d\udd4a\ufe0f\ud83c\udf05\ud83d\udecc\ud83c\udf0a\ud83d\udca4", "Captain Ahab remained invisibly enshrined within his cabin.": "\ud83e\uddd4\u200d\u2642\ufe0f\ud83d\udea2\ud83d\udecb\ufe0f\ud83e\udd2b", "his brain seems that geometrical circle which it is impossible to square": "\ud83e\udde0 \u27a1\ufe0f \ud83d\udd04 \ud83d\udccf\u274c \ud83d\udd32", "The huge corpulence of that Hogarthian monster undulates on the surface, scarcely drawing one inch of water.": "\ud83d\udc37\ud83c\udf0a The huge bulk of that artistic monster ripples on the surface, barely dipping into the water.", "no way of reaching that place would offer": "\ud83d\udeab\u27a1\ufe0f\ud83c\udfde\ufe0f\ud83d\udd1c\ud83e\udd1d\ud83c\udfde\ufe0f\u274c", "In old Norse times, the thrones of the sea-loving Danish kings were fabricated, saith tradition, of the tusks of the narwhale.": "\ud83d\udc0b\ud83d\udc51\ud83c\udf0a\ud83e\uddb7\ud83e\udd84\ud83d\udd28\ud83d\udd70\ufe0f\ud83d\udcdc\ud83c\udde9\ud83c\uddf0dados", "the doom of boats, and ships, and men": "\u26f4\ufe0f\u2693\ud83d\udca5\ud83e\uddcd\u200d\u2642\ufe0f\u26b0\ufe0f", "What a fine frosty night; how Orion glitters; what northern lights!": "\ud83c\udf0c\u2728 What a fine frosty night \u2744\ufe0f; how Orion glitters \u2728; what northern lights! \ud83c\udf0c\ud83c\udf87", "If this be so, fancy the irresistibleness of that might, to which the most impalpable and destructive of all elements contributes.": "\ud83d\udd0d\ud83e\udd14\u2728\u27a1\ufe0f\ud83d\udcaa\u26a1\ufe0f\ud83c\udf2a\ufe0f\ud83d\udd25\ud83d\udca7\u27a1\ufe0f\ud83d\udc50\ud83c\udf2c\ufe0f\u2728", "But the reason of this is obvious.": "\ud83e\udd14\u27a1\ufe0f\ud83d\udd0d\ud83c\udf1f", "For hardly have we mortals by long toilings extracted from this world\u2019s vast bulk its small but valuable sperm": "\ud83d\udc49\ud83d\ude13\ud83d\ude05\ud83c\udf0d\ud83c\udf0d\ud83d\udcaa\ud83d\udd75\ufe0f\u200d\u2642\ufe0f\u27a1\ufe0f\ud83d\udca7\ud83e\udd11\ud83c\udf1f\ud83e\udde0\u26cf\ufe0f\ud83d\udc65", "and here, going from Virtue, Leo, a roaring Lion, lies in the path\u2014he gives a few fierce bites and surly dabs with his paw": "\ud83e\udd81\u27a1\ufe0f\ud83e\udd81\u27a1\ufe0f\ud83d\udd0a\ud83e\udd81\u27a1\ufe0f\ud83d\udee3\ufe0f\u27a1\ufe0f\ud83e\udd81\u27a1\ufe0f\ud83d\ude21\ud83e\udd81\u27a1\ufe0f\ud83e\udd1a", "Touching that monstrous bulk of the whale or ork we have received nothing certain.": "\ud83d\udc49\ud83d\udc0b\ud83e\udd14\u2753", "many strange things were hinted in reference to this wild affair": "\ud83c\udf00\ud83e\udd14\ud83d\udcdc\ud83d\udcac\u27a1\ufe0f\ud83c\udf32\ud83e\udd2f", "Genius in the Sperm Whale? Has the Sperm Whale ever written a book, spoken a speech?": "\ud83e\udde0 in the \ud83d\udc33? Has the \ud83d\udc33 ever \u270d\ufe0f a \ud83d\udcda, \ud83d\udde3\ufe0f a \ud83d\udde8\ufe0f?", "were the whale then to run the line out to the end almost in a single, smoking minute as he sometimes does, he would not stop there": "\ud83d\udc0b\u27a1\ufe0f\ud83c\udfc3\u200d\u2642\ufe0f\ud83e\udea2\u27a1\ufe0f\ud83d\udd1a\u23f1\ufe0f\ud83d\udca8\ud83d\udd04\ud83d\udc0b\u2b55\ud83d\udeab\ud83d\uded1", "It was a terrific, most pitiable, and maddening sight.": "\ud83c\udf1f\ud83d\ude22\ud83d\ude21", "There is nothing surprising in this.": "\ud83e\udd37\u200d\u2642\ufe0f\ud83d\udd0d Nothing surprising in this. ", "hear the thunder": "\ud83d\udc42\ud83c\udf29\ufe0f", "Go to the meat-market of a Saturday night and see the crowds of live bipeds staring up at the long rows of dead quadrupeds.": "\ud83d\udc65\u27a1\ufe0f\ud83e\udd69\ud83d\uded2\ud83c\udf03\ud83d\udcc5\ud83d\udc40\ud83d\udc65\ud83d\udd0d\u2b06\ufe0f\ud83c\udd9a\ud83d\udccf\ud83d\udc65\u2620\ufe0f\ud83e\udd8c", "let us squeeze ourselves universally into the very milk and sperm of kindness": "\ud83e\udec2\ud83c\udf0e\ud83c\udf7c\ud83e\uddec\ud83d\udc95", "from the ashes of the burned scraps of the whale, a potent lye is readily made": "\ud83d\udd25\ud83d\udc0b\u27a1\ufe0f\ud83c\udd7f\ufe0f\ud83d\udcaa\ud83e\uddfc\u2728", "Nor have I been at all sparing of historical whale research, when it has seemed needed.": "\ud83d\udc33\ud83d\udcda\u270b\ud83d\ude36\ud83d\udc49\ud83d\udcdc\ud83d\udcdc\ud83d\udd0d, \ud83d\udcc5\ud83d\udcc5\ud83d\udcc5\ud83e\udd14\ud83d\udcdc\ud83d\udcdc\u2b55\ufe0f\ud83d\udcda\ud83d\ude0c", "sail round his vast head in your jolly-boat": "\ud83d\udef6\u26f5\ufe0f\ud83c\udf00\ud83d\udde3\ufe0f\ud83c\udf0a\ud83d\udc64\ud83d\udcab", "Are you not the precious image of each and all of us men in this whaling world?": "\ud83e\udd14\ud83d\udc64\u2753\ud83c\udf1f\ud83d\uddbc\ufe0f\ud83d\udc68\u200d\ud83d\udc69\u200d\ud83d\udc66\u200d\ud83d\udc66\ud83d\udc0b\ud83c\udf0e\u2753", "Up from the spray of thy ocean-perishing\u2014straight up, leaps thy apotheosis!": "\ud83c\udf0a\u2b06\ufe0f\ud83d\udd1d\ud83c\udf0a\u2014\u2b06\ufe0f\u27a1\ufe0f\u2728, \ud83d\udd1d, \ud83d\ude80\ud83c\udf1f!", "But how?": "\ud83e\udd14\u2753", "I saw the opening maw of hell, With endless pains and sorrows there; Which none but they that feel can tell\u2014 Oh, I was plunging to despair.": "\ud83d\udc41\ud83d\udc44\ud83d\udd25\ud83d\ude31, \ud83d\udca2\ud83d\udc94\ud83d\ude2d\ud83d\udeaa; \ud83d\udc64\u274c\ud83e\udd15\ud83d\udde3\ud83c\udf0a\u2014 \ud83d\ude29, \ud83d\udc64\u2b07\ufe0f\ud83c\udf00\u26ab", "striving to get a still better seaward peep": "\ud83d\udeb6\u200d\u2642\ufe0f\u27a1\ufe0f\ud83c\udf0a\ud83d\udc40\ud83d\udd0d\ud83d\udcc8", "this sort of thing is unpleasant enough": "\ud83e\udd14\ud83d\ude15\ud83d\ude2c", "She was a thing of trophies. A cannibal of a craft, tricking herself forth in the chased bones of her enemies.": "\ud83d\udc69\u200d\ud83c\udfa8\ud83c\udfc6\u2728\ud83c\udf56\ud83d\udee0\ufe0f\ud83c\udfad\ud83d\udcda\ud83d\udc80", "Narcissus, who because he could not grasp the tormenting, mild image he saw in the fountain, plunged into it and was drowned.": "\ud83d\udca7\ud83c\udf3f Narcissus, who because he couldn't reach the tormenting, gentle image he saw in the fountain, \ud83d\udeb6\u200d\u2642\ufe0f\u27a1\ufe0f\ud83d\udca6 and was \ud83c\udf0a\ud83d\udc80.", "the joke is at nobody\u2019s expense but his own": "\ud83d\ude02\u27a1\ufe0f\ud83d\udd75\ufe0f\u200d\u2642\ufe0f\ud83d\udcb8\u27a1\ufe0f\ud83d\udc64\u274c\ud83d\udcb8\u27a1\ufe0f\ud83d\ude04", "not a single groan or cry of any sort, nay, not so much as a ripple or a bubble came up from its depths": "\ud83d\ude36\ud83c\udf0a\u274c\ud83d\ude29\u274c\ud83d\ude22\u274c\ud83d\udd0a, \ud83d\udeab, \u274c\ud83c\udf0a\ud83d\udd04\u274c\ud83d\udca7\ud83d\udcc8\u2b06\ufe0f\ud83d\udd19\ud83c\udf0a\ud83d\udd1d", "this one small brain think thoughts": "\ud83e\udde0\ud83e\udd0f\ud83d\udcad\ud83e\udd14", "abating in his flurry, the whale once more rolled out into view": "\ud83d\udc0b\u2b07\ufe0f\ud83c\udf0a, \ud83d\udc0b\ud83d\udd04\ud83d\udc40", "The few sleepers below in their bunks were often startled by the sharp slapping of their tails against the hull, within a few inches of the sleepers\u2019 hearts.": "\ud83d\udecc\ud83d\ude34\ud83d\udc47\ud83d\udea2\ud83d\udc1f\ud83d\udca5\ud83d\ude32\ud83d\udea2\ud83d\udd0a\u2665\ufe0f", "For ere they drown, drowning things will twice rise to the surface; then rise again, to sink for evermore.": "\ud83c\udf0a Before they sink, \ud83c\udf0a sinking things will \u2b06\ufe0f rise twice to the \ud83d\udd1d surface; then rise again, \u2b07\ufe0f to sink forever. \ud83c\udf0a", "both he and the sharks were at times half hidden by the blood-muddled water": "\ud83e\udd37\u200d\u2642\ufe0f\ud83e\udd88\ud83c\udf0a\ud83d\udd34\u2753\ud83d\udd0d", "There\u2019s your law of precedents; there\u2019s your utility of traditions; there\u2019s the story of your obstinate survival of old beliefs": "\ud83d\udcdc\u2696\ufe0f\u27a1\ufe0f \ud83d\udcda\u23f3; \ud83d\udcda\u27a1\ufe0f\ud83d\udd17\ud83d\udc74; \ud83d\udcd6\u27a1\ufe0f\ud83d\ude45\u200d\u2642\ufe0f\u23f3\ud83d\udd17\ud83d\udcad", "There is more character in the Sperm Whale\u2019s head.": "\ud83d\udc0b\ud83d\udca1\u27a1\ufe0f SperM Whale's \ud83e\udde0\ud83d\udcc8", "He saw God\u2019s foot upon the treadle of the loom": "\ud83d\udc68\u200d\ud83e\uddb0\ud83d\udc40\ud83d\udc63\u2699\ufe0f\ud83e\uddf6", "an unfurnished parlor called the blubber-room": "\ud83d\udecb\ufe0f\ud83d\udeaa\ud83d\udce6 \u27a1\ufe0f \ud83d\udc0b\u27a1\ufe0f\ud83d\udeaa", "my dear Ishmael, be sure to inquire the price, and don\u2019t be too particular": "\ud83d\udc64\u2764\ufe0f\ud83d\udc0b, \ud83d\udccb\ud83d\udd0d\ud83d\udcb2, \u274c\ud83e\uddd0\u2696\ufe0f", "I was now as much afraid of him as if it was the devil himself": "\ud83d\ude28\ud83d\udc64\u27a1\ufe0f\ud83d\ude08", "the triumphant tackle rises into sight": "\ud83c\udfc6\ud83e\udd3e\u200d\u2642\ufe0f\u2b06\ufe0f\ud83d\udc40", "How it is I know not; but there is no place like a bed for confidential disclosures between friends.": "\ud83d\udecc\ud83e\udd14\u2728\u2753; \ud83d\udecf\ufe0f\ud83c\udfe0\ud83d\udcac\ud83e\udd1d\ud83c\udf1f\ud83d\udc65", "A steak, a steak, ere I sleep!": "\ud83e\udd69\ud83e\udd69\ud83d\ude34", "they were nigh enough to risk a harpoon from the bowsprit": "\ud83e\uddd1\u200d\u2708\ufe0f\u27a1\ufe0f\ud83c\udff9\ud83c\udf0a\ud83d\udccf\u2693\ufe0f", "I never hurt when I hit, except when I hit a whale or something of that sort": "\ud83e\udd1c\ud83d\ude0c\u27a1\ufe0f\ud83d\udca5\u274c\ud83d\udc0b\ud83d\ude16\ud83e\udda3\ud83d\udca5", "Let the most absent-minded of men be plunged in his deepest reveries\u2014stand that man on his legs, set his feet a-going, and he will infallibly lead you to water": "\ud83e\udde0\u27a1\ufe0f\ud83d\udcad\ud83d\udc68\u200d\ud83e\uddaf\ud83d\udd04\ud83d\udeb6\u200d\u2642\ufe0f\u27a1\ufe0f\ud83d\udca6", "of all tools used in the shadow of the moon, men are most apt to get out of order": "\ud83c\udf11\ud83d\udd27\ud83d\udc68\u200d\ud83d\udd27\ud83d\udeb6\u200d\u2642\ufe0f\ud83d\udcc9", "Of erections, how few are domed like St. Peter\u2019s! of creatures, how few vast as the whale!": "\ud83c\udfd7\ufe0f\u26ea\ufe0f\u2757\ufe0f\ud83d\udc0b\u2757\ufe0f", "\u201cThat\u2019s he! that\u2019s he!\u2014the long-togged scaramouch the Town-Ho\u2019s company told us of!\u201d": "\ud83d\udde3\ufe0f \"\ud83d\udc40 That's him! That's him!\u2014the \ud83c\udfad long-coated scaramouch the \ud83d\udea2 Town-Ho's crew told us about!\"", "But let us hold on here by this tooth, and look about us where we are.": "\ud83e\uddb7\ud83d\udd0d\ud83d\udc40\ud83d\uded1\ud83e\udd14\ud83d\udccd\ud83d\uddfa\ufe0f", "we heard about Moby Dick\u2014as some call him\u2014and then I knew it was he.": "\ud83d\udc42\ud83d\udc0b\ud83d\udcd6\u2014\ud83d\udc65\ud83d\udcde\ud83d\udc68\u200d\ud83d\udc68\u200d\ud83d\udc66\ud83d\udc68\u200d\ud83d\udd27\u2014\ud83d\udc49\ud83d\udc68\ud83d\udc48\ud83e\udde0\ud83d\udcd6\ud83d\udc4d\ud83d\udd08\ud83d\udd0d", "The crotch alluded to on a previous page deserves independent mention.": "\ud83d\udd0d\ud83d\udc56\u27a1\ufe0f\ud83d\udcc4\ud83e\udd14\ud83d\udc4d\ud83d\udcdd", "I deny their credentials as whales; and have presented them with their passports to quit the Kingdom of Cetology.": "\ud83d\ude45\u200d\u2642\ufe0f\ud83d\udc0b\u274c\ud83c\udf93\u2709\ufe0f\ud83d\udd0d\u27a1\ufe0f\ud83d\udec2\ud83d\udcbc\ud83c\udff4\u200d\u2620\ufe0f\ud83d\udc0b\ud83c\uddec\ud83c\udde7", "He looked like a man who had never cringed and never had had a creditor.": "\ud83d\udc68\ud83d\ude0e\u274c\ud83e\udd26\u200d\u2642\ufe0f\u274c\ud83d\udcb8", "For small erections may be finished by their first architects; grand ones, true ones, ever leave the copestone to posterity.": "\ud83c\udfd7\ufe0f\ud83d\udd28\ud83c\udfe0\u27a1\ufe0f\ud83e\uddd1\u200d\ud83d\udd27\ud83d\udc77\u200d\u2642\ufe0f\ud83d\udccf; \ud83c\udfe2\ud83c\udfdb\ud83c\udd9a\ud83e\udd47, \u23e9\u23f3\ud83d\udc63\ud83e\uddf1\u27a1\ufe0f\ud83d\udc76\ud83c\udf0d.", "it rings most vast, but hollow": "\ud83d\udd14\ud83c\udf0c most vast, but \ud83d\udd73\ufe0f", "All that most maddens and torments": "\ud83d\ude21\ud83d\ude24\ud83e\udd2f\ud83d\udd2a", "what he ate did not so much relieve his hunger, as keep it immortal in him": "\ud83e\udd14\ud83c\udf7d\ufe0f\u274c\ud83d\ude0c\ud83e\udd24\ud83c\udf74\ud83c\udf7d\ufe0f\ud83d\udd01\u23f3", "It\u2019s an all-fired outrage to tell any human creature that he\u2019s bound to hell. Flukes and flames!": "\ud83d\ude21\ud83d\udd25\ud83d\udeab\ud83d\udc7c\u27a1\ufe0f\ud83d\udd25\ud83c\udf0b. \ud83d\udc20\ud83d\udd25!", "the three boats lay there on that gently rolling sea, gazing down into its eternal blue noon": "\ud83d\udea4\ud83d\udea3\u26f5\ufe0f ~ \ud83c\udf0a, \ud83d\udc40\u2b07\ufe0f\ud83c\udf0a\ud83d\udd35\ud83c\udf1e\u2728", "Paddles were dropped, and oars came loudly into play.": "\ud83d\udea3\u200d\u2642\ufe0f\ud83e\ude82\u2b07\ufe0f, \ud83c\udf0a\ud83d\udd0a\u2194\ufe0f\ud83d\udef6", "my face shall not be seen": "\ud83d\ude48\ud83d\udeab\ud83d\udc40", "that tempestuous wind Euroclydon kept up a worse howling than ever it did about poor Paul's tossed craft": "\ud83d\udca8\ud83c\udf2a\ufe0f\u26c8\ufe0f\ud83d\ude23\ud83d\udd0a\u2b06\ufe0f\ud83c\udf0a\u26f5\ufe0f\ud83d\udeab\ud83d\ude1f\ud83d\ude4f\ud83d\udc94", "almost all men in their degree, some time or other, cherish very nearly the same feelings towards the ocean": "\ud83d\udc68\ud83c\udf0a\u2764\ufe0f\ud83c\udf0a", "God help thee, old man, thy thoughts have created a creature in thee": "\ud83d\ude4f\ud83e\uddd3\ud83e\udde0\u27a1\ufe0f\ud83d\udc79", "In old times, there seem to have prevailed the most curious fancies": "\u23f3\ud83c\udff0\ud83d\udc74\ud83d\udd70\ufe0f\ud83e\udd14\ud83c\udf00\ud83d\udd0d\u2728", "if any strange suspicious sights are seen, my lord whale keeps a wary eye on his interesting family": "\ud83d\udc40\ud83e\uddd0\ud83c\udf0a\ud83d\udc51\ud83d\udc0b\ud83d\udc40\ud83d\udc40\ud83d\udc68\u200d\ud83d\udc69\u200d\ud83d\udc67\u200d\ud83d\udc66", "the weeping and wailing and teeth-gnashing there": "\ud83d\ude22\ud83d\ude2d\ud83d\udde3\ufe0f\ud83d\ude2b\ud83d\ude2c\ud83e\uddb7", "he ain\u2019t sick; but no, he isn\u2019t well either": "\ud83d\udc68\u274c\ud83d\ude37 \u27a1\ufe0f \ud83d\ude10\u274c\ud83d\ude0c ", "they were going all abreast with great speed": "\ud83d\udc65\u27a1\ufe0f\ud83c\udfc3\ud83d\udca8", "remain an infidel as to one of the most appalling, but not the less true events, perhaps anywhere to be found in all recorded history": "\ud83d\udd75\ufe0f\u200d\u2642\ufe0f\ud83e\udd14\ud83d\udcdc\u274c\ud83d\ude31, \ud83e\udd37\u200d\u2642\ufe0f\ud83d\ude33\u2705\ud83d\udcdc, \u2708\ufe0f\ud83d\udcda\ud83d\udd70\ufe0f", "I grin at thee, thou grinning whale!": "\ud83d\ude0a\ud83d\ude04\ud83d\udc0b", "English and American whale draughtsmen seem entirely content with presenting the mechanical outline of things, such as the vacant profile of the whale": "\ud83c\uddec\ud83c\udde7\ud83d\udd8c\ufe0f\ud83d\udc0b\ud83d\udc68\u200d\ud83c\udfa8\u27a1\ufe0f\ud83d\ude0a\ud83d\udc49\ud83d\udcd0\ud83d\udd8d\ufe0f\ud83d\udd04, \ud83d\ude36\ud83d\uddbc\ufe0f\ud83d\udc0b", "The red tide now poured from all sides of the monster like brooks down a hill.": "\ud83d\udfe5\ud83c\udf0a\ud83d\udd1c\ud83d\udc09\ud83d\udccd\u2194\ufe0f\ud83c\udf0a\ud83d\udd3d\ud83c\udfde\ufe0f", "are these ashes from that destroyed city, Gomorrah?": "\ud83e\udd14\ud83c\udf2b\ufe0f\ud83c\udfd9\ufe0f\ud83d\udd25\ud83d\uddfa\ufe0f\u2753", "and by that humming, we, too, who look on the loom are deafened": "\ud83d\udc1d\ud83d\udd0a, \ud83d\udc65\ud83d\udc40\ud83d\udc57\ud83c\udfb6\ud83d\udc42\u274c", "But will any whaleman believe these stories?": "\ud83d\udc0b\ud83e\udd14\u2753", "Still New Bedford is a queer place.": "\ud83d\uded1\u2728 New Bedford is a \ud83c\udf00\ud83d\udd75\ufe0f\u200d\u2640\ufe0f place.", "see how elastic our stiff prejudices grow when love once comes to bend them": "\ud83d\udc40\u27a1\ufe0f\ud83d\udcc8\u2764\ufe0f\u2194\ufe0f\ud83d\udc49\ud83d\udcaa\ud83d\udccf\ud83d\udcad\ud83c\udf31\ud83c\udf3f\ud83d\udd25", "the glorious, golden, glad sun, the only true lamp\u2014all others but liars!": "\ud83c\udf05\u2728, \ud83c\udf1f, \ud83d\ude0a\u2600\ufe0f, \ud83c\udf1e, \u27a1\ufe0f \ud83d\udd6f\ufe0f\u2014all \ud83d\udd26\ud83d\udeab\ud83e\udd25!", "Nor white whale, nor man, nor fiend, can so much as graze old Ahab in his own proper and inaccessible being.": "\ud83d\udc0b\ud83d\udeab\ud83d\udc68\ud83d\udeab\ud83d\udc7f\ud83d\udeab\u27a1\ufe0f\u2712\ufe0f\ud83d\udcdb\ud83e\uddd3\ud83c\udff4\u200d\u2620\ufe0f\ud83d\udee1\ufe0f\ud83d\udcad\ud83c\udf0c", "the skeleton of a sperm whale": "\ud83d\udc0b\ud83d\udc80", "But Faith, like a jackal, feeds among the tombs, and even from these dead doubts she gathers her most vital hope.": "\ud83e\udd8a\ud83e\udea6\ud83d\udd4a\ufe0f, like a \ud83d\udc36, \ud83c\udf7d\ufe0f among the \u26b0\ufe0f, and even from these \u2620\ufe0f\u2753 she gathers her most \ud83c\udf1f\ud83d\udd4a\ufe0f.", "Think not, is my eleventh commandment; and sleep when you can, is my twelfth": "\ud83e\udd14\ud83d\udeab, is my 1\ufe0f\u20e31\ufe0f\u20e3th \ud83d\udcdc; and \ud83d\ude34\ud83d\udecc when you can, is my 1\ufe0f\u20e32\ufe0f\u20e3th \ud83d\udcdc", "is it for these reasons that there is such a dumb blankness, full of meaning, in a wide landscape of snows": "\u2753\u2744\ufe0f\ud83e\uddd0\ud83e\udd14\ud83d\uddfb\u2744\ufe0f\ud83d\udc40\ud83e\udd2f\ud83c\udf28\ufe0f", "I\u2019ll eat this whale in one mouthful.": "\ud83d\udc45\ud83d\udc0b\u27a1\ufe0f\ud83e\udd44", "For we are all killers, on land and on sea; Bonapartes and Sharks included.": "\ud83d\udc65\ud83d\udd2a\ud83c\udf0d\u26f4\ufe0f; \ud83c\udfc7\ud83e\udd88 \u2795\ud83e\udd88\u2705.", "Any man may kill a snake, but only a Perseus, a St. George, a Coffin, have the heart in them to march boldly up to a whale.": "\ud83d\udc68\ud83d\udc0d\u274c, \ud83e\udd14\ud83d\udc68\u200d\ud83c\udfa4\ud83d\udcaa\ud83d\udc09, \ud83e\uddd4\u2764\ufe0f\ud83d\udc33\ud83d\udeb6\u200d\u2642\ufe0f\ud83d\udd25", "leave us, if you please, and I will see to this strange affair myself": "\ud83d\udc4b\ud83d\udeb6\u200d\u2642\ufe0f, \ud83d\ude4f, \ud83e\udd14\u27a1\ufe0f\ud83d\udc40\ud83d\udc64\ud83d\udc49\ud83e\udd28\ud83d\udcdc\ud83d\udcaa", "it\u2019s worth a fellow\u2019s while to be born into the world, if only to fall right asleep": "\ud83d\udc76\ud83d\udcab\ud83c\udf0d\u27a1\ufe0f\ud83d\ude34\ud83d\udc4d", "this difficulty is ingeniously overcome": "\ud83e\udde0\ud83d\udd27\u27a1\ufe0f\ud83d\ude0a", "in New Bedford, actual cannibals stand chatting at street corners; savages outright; many of whom yet carry on their bones unholy flesh": "\ud83c\udf06\ud83d\udd2a\ud83d\ude33 In New Bedford, actual cannibals stand chatting at street corners; savages outright; many of whom yet carry on their bones unholy flesh \ud83c\udf56\u274c", "Born of earth, yet suckled by the sea; though hill and valley mothered me, ye billows are my foster-brothers!": "\ud83c\udf0d\u27a1\ufe0f\ud83d\udc76\u2693\ufe0f\ud83c\udf0a; \ud83c\udf04\ud83c\udf3f\ud83c\udf3e\ud83d\udc69\u200d\ud83d\udc66, \ud83c\udf0a\ud83c\udf0a\ud83d\udc68\u200d\ud83d\udc66", "marks in my whale-books": "\ud83d\udcd1\ud83d\udcd6\ud83d\udc0b", "whatever other business he has to attend to, waking or sleeping, breathe he must, or die he will": "\ud83c\udf10\ud83e\uddd1\u200d\ud83d\udcbc\u27a1\ufe0f\ud83d\ude34\ud83d\ude34, \ud83c\udf2c\ufe0f\ud83d\udca8=\ud83d\udddd\ufe0f, \ud83d\udca8\ud83d\udcad\ud83c\udff4, \u2620\ufe0f", "this occasional inevitable sinking of the recently killed Sperm Whale is a very curious thing": "\ud83d\udc0b\ud83d\udc80\ud83c\udf0a\u27a1\ufe0f\ud83e\udd14\u2753", "sin that pays its way can travel freely, and without a passport; whereas Virtue, if a pauper, is stopped at all frontiers": "\ud83d\udcb8\ud83d\ude08\u2708\ufe0f\ud83c\udf0d\ud83c\udd93\ud83d\udec2\u274c, \ud83e\udd14\ud83c\udf1f\ud83d\udeb6\u200d\u2642\ufe0f\ud83d\udea7\ud83d\udcb0\u274c\u21aa\ufe0f\u26d4\ufe0f\ud83c\udf0d\ud83d\udeb7", "I would rather feel your spine than your skull, whoever you are.": "\ud83d\ude42\u2795\ud83d\udcda>\ud83d\udc80\ud83d\udd0d\ud83d\udc64", "we saw an arm thrust upright from the blue waves; a sight strange to see, as an arm thrust forth from the grass over a grave": "\ud83c\udf0a\ud83d\udc40\ud83d\udd90\ufe0f\u2b06\ufe0f\ud83d\udc99\ud83c\udf0a; \ud83d\udc40\ud83e\udd14\ud83d\udeb6\ud83d\udd90\ufe0f\u2b06\ufe0f\ud83c\udf3f\u26b0\ufe0f", "I found Queequeg\u2019s arm thrown over me in the most loving and affectionate manner. You had almost thought I had been his wife.": "\ud83d\udc6b\u2764\ufe0f\ud83d\udecc I found Queequeg\u2019s arm thrown over me in the most loving and affectionate manner. You'd almost think I was his wife! \ud83d\udc8d", "they went to the captain and told him if Gabriel was sent from the ship, not a man of them would remain": "\ud83d\udc65\u27a1\ufe0f\ud83e\uddd1\u200d\u2708\ufe0f\ud83d\udea2\ud83d\udc49\ud83d\udc68\u200d\u2708\ufe0f\ud83d\udce2\ud83d\udeab\ud83d\udde3\ufe0f\ud83d\udc68\u200d\ud83e\uddb1\ud83c\udf0a\ud83d\udea2,\ud83d\udeab\ud83e\uddd1\u200d\ud83e\udd1d\u200d\ud83e\uddd1\u2194\ufe0f\u26f4\ufe0f", "there are a rabble of uncertain, fugitive, half-fabulous whales, which, as an American whaleman, I know by reputation, but not personally": "\ud83d\udc0b\u2753\ud83e\udd14\ud83d\ude4c\ud83e\udd37\u200d\u2642\ufe0f\ud83c\udfa9\ud83c\udff4\u200d\u2620\ufe0f\ud83c\udf0d\ud83d\udc65\ud83c\uddfa\ud83c\uddf8\ud83e\uddd1\u200d\u2708\ufe0f\ud83d\udcda\ud83e\udd1d\u274c\ud83d\udc64", "If you attentively regard almost any quadruped\u2019s spine, you will be struck with the resemblance of its vertebr\u00e6 to a strung necklace of dwarfed skulls": "\ud83d\udc40\u27a1\ufe0f\ud83d\udc3e\ud83d\udd0d\ud83d\udc15\ud83d\udc08\ud83e\uddb4 \u27a1\ufe0f \ud83e\udd2f\u27a1\ufe0f\ud83d\udcff\ud83d\udc80\ud83d\udc80\ud83d\udc80", "their spirits penetrate through the thick haze of the future, and descry what shoals and what rocks must be shunned": "\ud83d\udd2e\ud83d\udd4a\ufe0f\u2728\ud83c\udf2b\ufe0f\ud83d\udd2e\ud83d\udd0d\u26f5\u26d4\ufe0f\ud83d\udca5", "the hoisted sperm whale\u2019s head jogged about very violently, and Gabriel was seen eyeing it with rather more apprehensiveness than his archangel nature seemed to warrant": "\ud83d\udc0b\ud83d\udd1d\ud83d\udc33's \ud83d\udc64\ud83c\udfc3\u200d\u2642\ufe0f\ud83d\udca5, \ud83d\udc41\ufe0f\ud83d\ude28\ud83d\ude1f \u27a1\ufe0f\ud83d\ude07 \u2795\ud83d\udc41\ufe0f\u203c\ufe0f", "there was no time for shuddering": "\u23f0\u274c\u23f1\ufe0f\ud83d\ude28", "the Lord Warden is busily employed at times in fobbing his perquisites; which are his chiefly by virtue of that same fobbing of them": "\ud83d\udc51\ud83d\udd0d\ud83d\udd70\ufe0f\ud83d\udcbc\ud83d\udcb0\u27a1\ufe0f\u23f0\ud83e\udd39\u200d\u2642\ufe0f\ud83d\udcdc\ud83d\udcbc\ud83d\udcb0\ud83d\udc48\u2728\u27a1\ufe0f\ud83d\udd04", "his vindictiveness towards the White Whale might have possibly extended itself in some degree to all sperm whales": "\ud83d\udc68\u200d\u2708\ufe0f\ud83d\udca2\u27a1\ufe0f\ud83d\udc0b\u26aa\ufe0f\ud83d\udd04\u2795\ud83d\udcc8\ud83d\udd1c\ud83d\udd04\u26aa\ufe0f\ud83d\udc33", "simply irresistible": "\ud83d\ude0a\ud83c\udf00\u2764\ufe0f", "the spermaceti whale obtains his whole food in unknown zones below the surface": "\ud83d\udc0b\ud83c\udf0a\ud83c\udf7d\ufe0f\u2753\u2b07\ufe0f\ud83c\udf10", "if this whale be a king, he is a very sulky looking fellow": "\ud83d\udc0b\ud83d\udc51\ud83d\ude20\ud83e\udd14\ud83d\udc64", "Seldom have I known any profound being that had anything to say to this world": "\ud83d\ude36\u200d\ud83c\udf2b\ufe0f\ud83e\udd14 \ud83d\ude36\u200d\ud83c\udf2b\ufe0f\ud83c\udf0d", "so that all deified Nature absolutely paints like the harlot, whose allurements cover nothing but the charnel-house within": "\ud83c\udfa8\ud83c\udf3f paints like \ud83d\udc8b but hides \u2620\ufe0f\ud83c\udfe0 within.", "In this enchanted mood, thy spirit ebbs away to whence it came": "\u2728\ud83c\udf19\ud83e\uddd9\u200d\u2642\ufe0f\ud83c\udf00, \ud83d\udcab\u2728\ud83d\udca8\ud83d\udd19\u27a1\ufe0f\ud83c\udf0c", "It is well to parenthesize here": "\ud83d\udd0d\ud83d\ude0a ( )", "go down with him, and get what thou wantest thyself": "\ud83d\udc65\u2b07\ufe0f\u2b07\ufe0f\ud83d\udd04\ud83d\udc66, \ud83d\udecd\ufe0f\u27a1\ufe0f\ud83d\udd0d\ud83d\ude0c\ud83e\udef5", "This terrible event clothed the archangel with added influence": "\ud83d\ude14\u26a0\ufe0f\ud83d\udc7c\ud83d\udd4a\ufe0f \u2795\u2728", "And if you be a philosopher, though seated in the whale-boat, you would not at heart feel one whit more of terror": "\ud83e\udde0\ud83e\udd14\ud83d\udc0b\u26f5\ufe0f\u2764\ufe0f\ud83d\ude0c\ud83d\ude31\u274c", "a cobbler\u2019s job, that\u2019s at an end in the middle, and at the beginning at the end": "\ud83d\udc5e\ud83d\udd27, \ud83d\udd1a\u2796\ud83d\udd1c, \ud83c\udfc1\u27a1\ufe0f \ud83d\udd1a", "the last one must be grown in America": "\ud83c\udf31\u27a1\ufe0f\ud83d\uddfd\ud83c\uddfa\ud83c\uddf8", "the chambers of my soul are all in crookedness!": "\ud83c\udf00\ud83d\udc94 The chambers of my soul are all in crookedness! \ud83d\ude23\ud83c\udf00", "And in this same last or shoe, that old woman of the nursery tale, with the swarming brood, might very comfortably be lodged, she and all her progeny.": "\ud83d\udc75\ud83d\udc5f In this large shoe, the old woman from the nursery tale, along with her many children, could be comfortably housed. \ud83c\udfe0\ud83d\udc76\ud83d\udc76\ud83d\udc76", "a lesson by no means to be forgotten": "\ud83d\udcda\u274c\ud83e\udde0\ud83d\udcad\ud83d\udd04", "But even so, amid the tornadoed Atlantic of my being, do I myself still for ever centrally disport in mute calm": "\ud83c\udf00\ud83c\udf0a\ud83e\udd2f, \ud83c\udf00\ud83c\udf2a\ufe0f\ud83d\ude36\ud83d\udd15\ud83d\udcad.", "as for the narwhale, one glimpse at it is enough to amaze one, that in this nineteenth century such a hippogriff could be palmed for genuine": "\ud83e\udd84\u27a1\ufe0f\ud83d\udc0b\ud83d\udc40\u2728\ud83d\ude32\ud83d\udcc5\ud83d\udd1f\u2795\ud83c\udf10\ud83e\udd84\u27a1\ufe0f\ud83e\udd14\ud83d\udcaf", "And so saying the lighted tomahawk began flourishing about me in the dark.": "\ud83c\udf15\ud83d\udde3\ufe0f\ud83d\udd25\ud83e\ude93\ud83d\udca8\ud83d\udd7a\ud83c\udf0c", "screw-drivers, cork-screws, tweezers, awls, pens, rulers, nail-filers, countersinkers": "\ud83d\udd29\ud83e\ude9b, \ud83c\udf7e\ud83d\udd11, \u2702\ufe0f\ud83d\udc5d, \ud83e\udea1, \ud83d\udd8a\ufe0f, \ud83d\udccf, \ud83d\udc85\ud83d\uddc3\ufe0f, \ud83d\udd29\u2b55\ufe0f", "furrowed heads, broken teeth, scolloped fins": "\ud83e\udd14\ud83d\udc64\ud83e\uddb7\ud83d\udc94\ud83d\udc1f\u2702\ufe0f", "I stood in the middle of a dreary street shouldering my bag, and comparing the gloom towards the north with the darkness towards the south": "\ud83d\udc64\ud83d\udeb6\u200d\u2642\ufe0f\ud83d\udee3\ufe0f\ud83c\udf27\ufe0f\ud83d\udc5c\ud83e\udd14\ud83c\udf2b\ufe0f\u2b06\ufe0f\u2b1b\ud83c\udd9a\ud83c\udf0c\u2b07\ufe0f", "you are experienced in these things, and I am not": "\ud83d\udd0d\ud83d\ude0f\u2728\ud83d\udcda, \ud83e\udd14\u274c", "Sing out for every spout, though he spout ten times a second!": "\ud83c\udfa4\ud83e\udd29\ud83d\udde3\ufe0f\ud83c\udf1f\ud83d\udd1fx\u23f8\ufe0f\u79d2", "That is to say, he would then live without breathing.": "\ud83e\udd14\u27a1\ufe0f\ud83d\udcac\ud83d\ude36\u27a1\ufe0f\ud83c\udfe0\ud83d\ude36\u27a1\ufe0f\ud83d\udeab\ud83d\udca8", "the malignant iron scorchingly devoured the baptismal blood": "\ud83e\udda0\ud83d\udd25\ud83c\udf74\ud83e\ude78", "\u201cEgo non baptizo te in nomine patris, sed in nomine diaboli!\u201d deliriously howled Ahab": "\ud83d\udc64\ud83d\udcac \"I don't baptize you in the name of the Father, but in the name of the Devil!\" \ud83d\udc0b\ud83d\ude31 Ahab", "I s'pose you are goin' a-whalin', so you'd better get used to that sort of thing.": "\ud83e\uddd4\u200d\u2642\ufe0f\ud83c\udf0a\ud83d\udc33\u27a1\ufe0f\ud83d\udee5\ufe0f\ud83e\udd14\ud83e\udd76\ud83e\udef4\ud83d\udd04\ud83d\udc81", "we harpooneers of Nantucket should be enrolled in the most noble order of St. George": "\ud83e\uddcd\u200d\u2642\ufe0f\ud83d\udde1\ufe0f\ud83e\udd88\ud83d\udef6\ud83c\udfdd\ufe0f\u27a1\ufe0f\ud83c\udfc5\ud83d\udc51\ud83d\udde1\ufe0f\u2694\ufe0f\ud83c\udff0", "certainly knowest not thy beginning, hence callest thyself unbegun": "\ud83e\udd14\u2753\ud83d\udcc5\ud83d\udc49\ud83d\udccd, \ud83d\udeab\ud83d\udcde\ud83d\ude4b\u200d\u2642\ufe0f\ud83d\udeab\u23ea", "Oh, Death, why canst thou not sometimes be timely?": "\ud83d\ude2e\ud83d\udc80, \ud83e\udd14\ud83d\udd70\ufe0f\u2753", "I never go as a passenger": "\ud83d\udef3\ufe0f\ud83d\udeab\ud83d\udc64\ud83d\udc68\u200d\u2708\ufe0f", "they are full of fight, fun, and wickedness, tumbling round the world at such a reckless, rollicking rate, that no prudent underwriter would insure them": "\ud83e\udd3a\ud83c\udf89\ud83d\ude08, \ud83c\udf0d\ud83c\udfc3\u200d\u2640\ufe0f\ud83d\udca8\ud83d\udca5, \u26a0\ufe0f\ud83d\udcc8, \ud83d\udee1\ufe0f\u274c", "As strange misgrown masses gather in the knot-holes of the noblest oaks when prostrate, so from the points which the whale\u2019s eyes had once occupied, now protruded blind bulbs, horribly pitiable to see.": "\ud83d\udc0b\ud83d\ude27\ud83c\udf33\ud83c\udf3f\ud83c\udf00\u27a1\ufe0f\ud83d\udc40\ud83d\udd00\ud83d\udc41\ufe0f\ud83d\udd0d\ud83c\udf11\u27a1\ufe0f\ud83d\udd34\ud83d\udd34\ud83d\ude22", "Whaling is imperial! By old English statutory law, the whale is declared \u201ca royal fish.\u201d": "\ud83d\udc0b\ud83d\udc51\u2696\ufe0f! \ud83c\uddec\ud83c\udde7\ud83d\udcdc, \ud83d\udc0b=\ud83e\udd34\ud83d\udc1f", "the hidden ways of the Sperm Whale when beneath the surface remain, in great part, unaccountable to his pursuers": "\ud83d\udc0b\u2753\ud83c\udf0a\ud83d\udd0d\u274c\ud83d\udc40\ud83d\udd0d\ud83d\udc40", "And God had prepared a great fish to swallow up Jonah.": "\ud83d\udc1f\ud83d\ude4f\ud83d\uded0 \u27a1\ufe0f \ud83d\udcd6\u27a1\ufe0f\ud83d\udcd6 \ud83d\udc20 to \ud83d\udd04\ud83d\ude0a\u27a1\ufe0f\ud83d\udc64 \ud83c\udf0a\ud83d\udc40", "The next day was exceedingly still and sultry": "\ud83c\udf1e\u27a1\ufe0f\ud83d\udcc5\u27a1\ufe0f\ud83d\ude0c\ud83c\udf2c\ufe0f\ud83d\ude13\ud83d\udd25", "there no conceivable time or occasion when you will find them in such countless numbers, and in gayer or more jovial spirits, than around a dead sperm whale": "\ud83d\udc0b\ud83d\udeab\ud83d\udd70\ufe0f\ud83e\udd14\ud83d\udcc5\ud83d\udd0d\ud83d\udc65\ud83d\udd22\ud83d\ude02\ud83e\udd23\ud83c\udf08\ud83c\udf89\u2728\ud83d\udc0b\u2620\ufe0f", "do you mean what you say, and have been saying all along": "\ud83e\udd14\ud83d\udcac \"do you mean what you say, and have been saying all along\"", "a circle of profound darkness": "\u26ab\ufe0f\ud83c\udf11\ud83d\udd04", "But if the great sun move not of himself; but is as an errand-boy in heaven": "\u2600\ufe0f\u2753\u27a1\ufe0f \ud83d\udeb6\u200d\u2642\ufe0f\u274c\ud83d\udd04 \u2b06\ufe0f; \u27a1\ufe0f \ud83d\udce7\ud83d\udc66\ud83d\udccd\ud83c\udf0c", "a creature in the transition stage\u2014neither caterpillar nor butterfly": "\ud83e\udd8b\u27a1\ufe0f\ud83d\udc1b\ud83d\udcf6\ud83d\udd04\ud83d\udc1b\ud83d\udeab\ud83e\udd8b", "So rarely is it beheld, that though one and all of them declare it to be the largest animated thing in the ocean, yet very few of them have any but the most vague ideas concerning its true nature and form": "\ud83d\udc0b\u2728\ud83e\uddd0\ud83e\udd14\ud83c\udf0a\ud83c\udf1f\ud83e\udd2f\ud83d\udccf, \ud83e\udd37\u200d\u2642\ufe0f\ud83c\udf0d\ud83d\udde3\ufe0f\ud83d\udce3\ud83d\udd1d\ud83d\udccf\ud83d\udcca\ud83d\udd0d\ud83c\udf0a, \ud83e\udd14\ud83d\ude48\ud83d\udc65\ud83e\udd0f\ud83d\udca1\ud83d\udcad\u27a1\ufe0f\ud83e\udd91\ud83d\udcd0\u2753\ud83c\udfde\ufe0f\ud83d\udd0e", "in what is called a long dart, the heavy implement has to be flung to the distance of twenty or thirty feet": "\ud83c\udff9\u27a1\ufe0f\ud83c\udfcb\ufe0f\u200d\u2642\ufe0f\ud83d\udccf\ud83d\udcaa\ud83c\udf0c20\u20e3-3\u20e30\u20e3\ud83d\udc63", "what trances of torments does that man endure who is consumed with one unachieved revengeful desire": "\ud83e\udd14\ud83d\ude23\ud83e\udd2f\ud83d\udcad\ud83d\udd25\ud83d\udc94\ud83d\ude21\ud83d\udd01\ud83d\udd1a", "this is a thing which carries more of true terror than any other aspect of this dangerous affair": "\ud83d\ude28\u27a1\ufe0f\u26a0\ufe0f\ud83d\udce6\ud83e\udd14\ud83c\udd99\ud83d\ude31\ud83d\udcc8\u2620\ufe0f\ud83d\udcbc", "Should you ever be athirst in the great American desert, try this experiment": "\ud83e\udd14\ud83c\udf35 If you're ever thirsty in the great American desert, try this \ud83d\udca1\ud83c\udf35", "with a dexterous, off-handed daring, unknown in any other vocation, the sailors, goat-like, leaped down the rolling ship\u2019s side into the tossed boats below": "\ud83d\udc50\ud83d\udc10\u26f5\ufe0f\ud83c\udf0a\ud83d\udea3\u200d\u2642\ufe0f\u2b07\ufe0f", "this fellow has broken loose from somewhere; he\u2019s talking about something and somebody we don\u2019t know": "\ud83d\udc64\ud83d\udd13\ud83c\udfc3\u200d\u2642\ufe0f\ud83c\udd93\u2753; \ud83d\udde3\ufe0f\ud83d\udcac\ud83e\udd14\ud83d\udcdc\u2753\u2754", "the customary cheering cry was heard from aloft, and ere long a spectacle of singular magnificence saluted us": "\ud83d\udce3\u2728 As the traditional cheer echoed from above, a scene of extraordinary splendor greeted us. \ud83d\udc40\ud83c\udff0\ud83c\udf1f", "violently flailing with his flexible tail, and tossing the keen spade about him, wounding and murdering his own comrades": "\ud83d\udc09\ud83d\udca5\ud83d\ude24 with his \ud83d\udd04 tail, and \ud83d\udd04\u2692\ufe0f\ud83e\udd3a around him, \ud83d\udde1\ufe0f\ud83d\udc94\ud83d\ude4d\u200d\u2642\ufe0f and \u2620\ufe0f his own \ud83d\udc65", "perhaps we may become jolly good bedfellows after all\u2014there\u2019s no telling": "\ud83e\udd14\u27a1\ufe0f\ud83d\ude0a\ud83d\udc4d\ud83d\udecf\ufe0f\ud83d\udc6b\ud83d\udd2e", "How can the prisoner reach outside except by thrusting through the wall?": "\ud83d\udd12\ud83e\udd14\u27a1\ufe0f\ud83d\udeb6\u200d\u2642\ufe0f\ud83d\udce4\u2753\u27a1\ufe0f\ud83e\uddf1\ud83d\udcaa\ud83d\udce4", "a little withered old man, who, for their money, dearly sells the sailors deliriums and death": "\ud83d\udc74\ud83d\udcb0\u27a1\ufe0f\u2693\ud83d\ude35\ud83d\udc80", "At first sight, you would not think it so strong as it really is.": "\ud83d\udc40\u27a1\ufe0f\ud83d\udcad\ud83e\udde0:\u3030\ufe0f\ud83d\udd0d\ud83d\udcaa\ud83d\udd0b\u2694\ufe0f\ud83c\udfcb\ufe0f\u200d\u2642\ufe0f\u270a\ud83d\udc4a\ud83d\udca5\ud83c\udf1f", "this mere painstaking burrower and grub-worm of a poor devil of a Sub-Sub appears to have gone through the long Vaticans and street-stalls of the earth": "\ud83e\udea4\ud83d\udc1b\ud83d\udc64\ud83d\udd0d\u2728\ud83d\udcdc\ud83c\udf0d\u2728\ud83d\uded2", "It is a little significant, that while one sperm whale only fights another sperm whale with his head and jaw, nevertheless, in his conflicts with man, he chiefly and contemptuously uses his tail.": "\ud83d\udc0b\u27a1\ufe0f\ud83d\udc0b\ud83c\udd9a\ud83e\uddb7, \ud83e\udd14\ud83d\udcad\ud83d\udca5, \ud83d\udc68\u200d\ud83d\udc67\u200d\ud83d\udc66\u274c, \ud83d\udc40\ud83d\udccf\ud83d\udc63.", "Our souls are like those orphans whose unwedded mothers die in bearing them": "Here\u2019s a translation of your text into emojis: \n\n\ud83d\udc65\u2764\ufe0f\u27a1\ufe0f \ud83e\uddd1\u200d\ud83e\udd1d\u200d\ud83e\uddd1\ud83d\udc76\ud83d\ude22\ud83d\udd4a\ufe0f\u27a1\ufe0f\ud83d\udc94\ud83d\udecf\ufe0f\ud83c\udf39 \n\nLet me know if you need any adjustments!", "moody Ahab was now all quiescence, at least so far as could be known": "\ud83d\ude12\ud83e\udd14\ud83c\udf0a\ud83d\udd07\u2728\ud83d\udd0d\ud83d\udca4", "the ancestry and posterity of Grief go further than the ancestry and posterity of Joy": "\ud83d\udc75\ud83c\udffd\ud83d\udd19\ud83d\udc68\u200d\ud83d\udc69\u200d\ud83d\udc66\u200d\ud83d\udc66\ud83d\ude22\u27a1\ufe0f\ud83d\udd1c\ud83d\udc6a\ud83d\ude04\ud83d\udd1c\ud83d\udd19", "It was a negro church; and the preacher\u2019s text was about the blackness of darkness": "\u26ea\ufe0f\ud83d\udc64\ud83d\udda4\ud83c\udf11\ud83c\udf0c\u2728", "he will have no one near him but Nature herself; and her he takes to wife in the wilderness of waters, and the best of wives she is, though she keeps so many moody secrets": "\ud83d\udc64\ud83d\udeab\ud83d\udc65\ud83c\udf33\ud83c\udf0a\ud83d\udc70\ud83d\udc8d\ud83c\udf3f\ud83d\udc96\ud83e\udd2b\ud83c\udf0c", "Look not too long in the face of the fire, O man! Never dream with thy hand on the helm!": "\ud83d\udc40\u23f3\ud83d\udd25\ud83d\udc68\u200d\u2708\ufe0f\ud83d\udeab\ud83d\udcad\ud83e\udd1a\u2693\ufe0f", "But there is another thing to rebut. They hint that all whales always smell bad. Now how did this odious stigma originate?": "\ud83e\udd14\ud83d\udc0b\u27a1\ufe0f\ud83d\udeab\ud83d\udc43\ud83d\udca8\u2757\ud83e\uddd0\u2753\ud83d\udcad\ud83d\udca9\u2753", "the world-wandering whale-ship carries no cargo but herself and crew, their weapons and their wants": "\ud83c\udf0d\ud83d\udc0b\u2693\ufe0f\ud83d\udea2\u274c\ud83d\udce6\ud83d\udc69\u200d\u2708\ufe0f\ud83d\udc68\u200d\u2708\ufe0f\ud83d\udcbc\u2694\ufe0f\ud83d\udcad", "come along that way, and to my breezelessness bring his breeze": "\ud83d\udc49\ud83d\udeb6\u200d\u2642\ufe0f\u27a1\ufe0f\ud83c\udf2c\ufe0f\u274c\u27a1\ufe0f\ud83d\ude0c\u27a1\ufe0f\u2728\ud83c\udf2c\ufe0f", "If I had been downright honest with myself, I would have seen very plainly in my heart": "\ud83e\udd14\ud83d\udcad\ud83d\udc94\ud83d\udd0d\u2728\u2764\ufe0f", "memory shot her crystals as the clear ice most forms of noiseless twilights": "\ud83e\udde0\ud83d\udca5\ud83d\udc8e\u2744\ufe0f\ud83d\udd07\ud83c\udf06", "the tissued, infiltrated head of the Sperm Whale, was the lightest and most corky part about him; and yet thou makest it sink": "\ud83d\udc0b\ud83d\udca6\ud83e\uddfb\ud83e\udde0\ud83d\udca1\ud83c\udf0a\u2696\ufe0f\ud83e\ude82\ud83e\udd37\u200d\u2642\ufe0f", "it is but the first salutation to the possibilities of the immense Remote, the Wild, the Watery, the Unshored": "\ud83d\udc4b\u2728\ud83c\udf0d\ud83c\udf0a\ud83c\udf3f\ud83c\udfde\ufe0f\ud83c\udf00\ud83c\udfd4\ufe0f", "Leap! leap up, and lick the sky!": "\ud83e\udd98\u2728\u2b06\ufe0f\ud83c\udf0c\ud83d\udcab", "straining forwards and backwards on his seat, like a pacing tiger in his cage": "\ud83d\ude24\u27a1\ufe0f\u2b05\ufe0f\ud83e\ude91\ud83d\udc05\ud83d\udd04\ud83e\udd81\ud83c\udfe0", "the bottom of the whale-boat is like critical ice, which will bear up a considerable distributed weight, but not very much of a concentrated one": "\ud83d\udc0b\ud83d\udea4\u27a1\ufe0f\u2744\ufe0f\u26a0\ufe0f\u2696\ufe0f\ud83d\udd04\ud83d\udcaa\ud83d\udd33\ud83d\udd3d\ud83d\udd04\ud83d\udeab\ud83d\udd1d", "goaded by it into more than sufferable anguish, the whale now spouting thick blood, with swift fury blindly darted at the craft": "\ud83d\udc33\ud83d\udc94\ud83d\ude20\ud83d\udca8\ud83e\ude78\u2693\ufe0f\ud83d\udca8\ud83d\udca5", "If the gods think to speak outright to man, they will honorably speak outright; not shake their heads, and give an old wives\u2019 darkling hint": "\ud83d\udc7c\u26a1\ud83d\udde3\ufe0f\ud83d\udc68\u200d\ud83d\udc69\u200d\ud83d\udc66\u2728\ud83d\udde8\ufe0f\ud83d\ude45\u200d\u2642\ufe0f\ud83d\udd2e\ud83d\udc75\ud83c\udf11\ud83d\udca1", "he, shivering and half shipwrecked, instead of rainbows speaking hope and solace to his misery, views what seems a boundless churchyard grinning upon him with its lean ice monuments and splintered crosses": "\ud83d\udc68\u200d\ud83e\uddb0\u2744\ufe0f\ud83d\udef6\ud83c\udf08\ud83d\ude1e\ud83d\udd4a\ufe0f\ud83d\udc40\ud83c\udf0c\u26ea\ud83e\udea6\ud83d\ude2c\u27a1\ufe0f\ud83d\udc80\ud83c\udff0\u2744\ufe0f\ud83e\udea8\u271d\ufe0f", "Leviathan is of so mighty a magnitude, all his proportions are so stately, that the same deficiency which in the sculptured Jove were hideous, in him is no blemish at all.": "\ud83d\udc09\ud83d\udcaa\u2728\ud83d\udccf\ud83d\udd4a\ufe0f\ud83e\udd34\ud83c\udffd\u2696\ufe0f\u26a1\ufe0f\ud83d\udee0\ufe0f\ud83d\udd0d\u274c\ud83d\ude31\u2795\ud83d\ude0a", "an Ohio honey-hunter, who seeking honey in the crotch of a hollow tree, found such exceeding store of it, that leaning too far over, it sucked him in, so that he died embalmed": "\ud83c\udfde\ufe0f\ud83c\udf6f\ud83d\udc1d\ud83c\udf33\ud83e\udd0f\ud83d\ude2f\ud83d\ude31\ud83e\uddd1\u200d\ud83c\udf3e\u27a1\ufe0f\ud83d\udca8\ud83d\ude35\u200d\ud83d\udcab\u26b0\ufe0f\ud83d\udd4a\ufe0f", "For, d\u2019ye see, rainbows do not visit the clear air; they only irradiate vapor.": "\ud83c\udf08\u274c\ud83c\udf25\ufe0f\u27a1\ufe0f\ud83c\udf24\ufe0f; \ud83c\udf08\u2795\ud83d\udcab\ud83d\udca8.", "And what are you, reader, but a Loose-Fish and a Fast-Fish, too?": "\ud83d\udc1f\ud83d\udca8\ud83e\udd14\ud83d\udcd6\u2728\ud83d\udd04\ud83d\udc0b\ud83d\udca8", "ye shall soon be initiated into certain facts hitherto pretty generally unknown": "\ud83d\udc65\ud83d\udd1c\u2728\ud83d\udcdc\ud83e\udd14\u2753\u2757\ufe0f", "the whale beyond also rose": "\ud83d\udc0b\u27a1\ufe0f\ud83c\udf0a\u2b06\ufe0f", "what is it that makes the front of a man\u2014what, indeed, but his eyes?": "\ud83e\udd14\u2753\ud83d\udc64\u27a1\ufe0f\ud83d\udc40\u2753", "we are all somehow dreadfully cracked about the head, and sadly need mending.": "\ud83d\udc6b\ud83d\udc94\ud83d\ude1f\ud83e\udde0\ud83d\udee0\ufe0f\u2728", "that man was swallowed up in the deep": "\ud83d\udc68\ud83c\udf0a\ud83c\udf00\u27a1\ufe0f\ud83c\udf0a\ud83c\udf0c", "does the ocean furnish any fish that in disposition answers to the sagacious kindness of the dog? The accursed shark alone can in any generic respect be said to bear comparative analogy to him.": "\ud83c\udf0a\ud83d\udc1f\ud83e\udd14\ud83d\udc96\ud83d\udc15\u2753\ud83d\udc20\ud83d\ude08\ud83e\udd88\ud83c\udd9a\ud83d\udc15", "Great pains, small gains for those who ask the world to solve them; it cannot solve itself.": "\ud83d\ude29\ud83d\udc94\ud83d\udd04\ud83c\udf0d\ud83e\udd32\u274c\ud83c\udd98\ud83d\udca1\ud83d\udc94", "Bethink yourself also of another thing.": "\ud83d\udcad\ud83e\udd14\u27a1\ufe0f\ud83e\udde0\ud83d\udd04\u2728", "and if he had a chance he will pull down and pulverize that subaltern\u2019s tower, and make a little heap of dust of it": "\ud83d\udd3d\ud83d\udca5\ud83c\udff0\ud83e\udea8\u27a1\ufe0f\ud83d\udca8\u2728", "you can hardly regard any creatures of the deep with the same feelings that you do those of the shore": "\ud83e\udddc\u200d\u2642\ufe0f\ud83d\ude15\ud83c\udf0a\ud83e\udd88\ud83d\udc20\ud83d\udd0d\ud83d\udc94\ud83c\udfd6\ufe0f\ud83e\udd14", "all this indirectly proceeds from the helpless perplexity of volition": "\ud83c\udf0d\u27a1\ufe0f\ud83e\udd37\u200d\u2642\ufe0f\ud83d\ude35\u200d\ud83d\udcab\ud83c\udf00\ud83d\udcad", "enlightened gourmand, who nailest geese to the ground and feastest on their bloated livers in thy pate de fois gras": "\ud83e\uddd8\u200d\u2642\ufe0f\ud83c\udf7d\ufe0f\ud83e\udda2\ud83d\udd28\ud83c\udf0d\ud83c\udf42\ud83e\udd69\ud83c\udf7d\ufe0f\ud83d\udc45\ud83c\udf77\ud83d\udcab", "dusty rarities gathered from this wide world\u2019s remotest nooks": "\ud83c\udf0d\ud83d\udd75\ufe0f\u200d\u2642\ufe0f\u2728\ud83d\udc8e\ud83c\udf2a\ufe0f\ud83c\udfde\ufe0f\ud83c\udf0c\ud83d\udd0d", "for ever and for ever, to the crack of doom, the sea will insult and murder him": "\ud83d\udd04\u267e\ufe0f\ud83c\udf0a\ud83d\ude20\ud83d\udd2a\ud83d\udc80", "We must watch for a breach in the living wall that hemmed us in; the wall that had only admitted us in order to shut us up.": "\ud83d\udc40\ud83d\udee1\ufe0f\ud83d\udeaa\ud83e\uddf1\ud83e\udea8\ud83d\udea7\ud83d\udd12\ud83d\udd12", "his smoke is horrible to inhale, and inhale it you must, and not only that, but you must live in it for the time": "\ud83d\udeac\ud83d\ude37\ud83d\udca8\ud83d\ude29\u27a1\ufe0f\ud83d\ude24\ud83c\udfe0\u23f3", "in his ordinary attitude, the Sperm Whale's mouth is buried at least eight feet beneath the surface": "\ud83d\udc0b\ud83d\udcad\ud83c\udf0a\u2b07\ufe0f\ud83e\uddb68\ufe0f\u20e3\ud83d\udd3d", "A very white, and famous, and most deadly immortal monster, Don;\u2014but that would be too long a story.": "\u26aa\ud83c\udf1f\ud83d\udc80\ud83e\udddb\u200d\u2642\ufe0f\ud83d\udc79 Don;\u2014\ud83d\udcd6\u274c\ud83d\udd70\ufe0f", "Warmest climes but nurse the cruellest fangs: the tiger of Bengal crouches in spiced groves of ceaseless verdure.": "\ud83c\udf1e\ud83c\udf34\ud83d\udc05\ud83c\udf36\ufe0f\ud83c\udf3f\ud83c\udf43\ud83c\udf33", "as though they deemed our ship some drifting, uninhabited craft; a thing appointed to desolation": "\ud83d\udea2\ud83c\udf0a\ud83e\udd14\u27a1\ufe0f\ud83d\udea2\u274c\ud83c\udfe0\ud83d\udca8\u2693\ufe0f\u27a1\ufe0f\ud83d\udc94\ud83c\udfdd\ufe0f", "he is always of the largest leviathanic proportions": "\ud83d\udc68\u200d\ud83e\uddb0\u27a1\ufe0f\ud83d\udd5b\ud83d\udd1d\u2693\ud83d\udc09\ud83d\udccf", "How wondrous familiar is a fool!": "\ud83e\udd14\u2728\ud83c\udf0d\ud83d\udc40\ud83d\ude05\ud83d\udc68\u200d\ud83c\udfeb", "it was not so much the fear of striking hidden rocks, as the fear of that hideous whiteness that so stirred me": "\ud83e\udd14\ud83d\udcad\ud83d\udeab\ud83e\udea8\ud83d\ude28\ud83d\udc94\ud83d\udc7b\u26aa\ufe0f\ud83d\ude31\u2728", "how it was exactly, there is no telling now": "\ud83e\udd14\ud83d\udd0d\u27a1\ufe0f\ud83d\udd70\ufe0f\u2753\ud83d\udcc9", "Oh, busy weaver! unseen weaver!\u2014pause!\u2014one word!\u2014whither flows the fabric? what palace may it deck?": "\ud83d\ude40\ud83d\udc69\u200d\ud83c\udfa4\ud83e\uddf5\u2728\u23f8\ufe0f\ud83d\udde3\ufe0f\u27a1\ufe0f\ud83c\udff0\ud83e\uddf6\ud83d\udd1c\ud83c\udfdb\ufe0f\ud83c\udf1f\ud83d\udc50", "we eighteen men with our thirty-six arms, and one hundred and eighty thumbs and fingers, slowly toiled hour after hour upon that inert, sluggish corpse in the sea; and it seemed hardly to budge at all": "\ud83d\udc6518\ud83d\udc68\u200d\ud83d\udd27\ud83d\udcaa36\ud83d\udd90\ufe0f\ud83d\udc40180\ud83d\udc4d\u270b\ud83d\udca6\ud83d\udecf\ufe0f\ud83d\udca4\ud83d\udcc5\u23f3\ud83d\ude29\ud83c\udf0a\ud83d\udc80\u2693\ufe0f\ud83d\ude35\u200d\ud83d\udcab\ud83c\udf00\ud83e\udddf\u200d\u2642\ufe0f\ud83d\udca8\ud83d\udca6\ud83d\udca7", "they think that, at best, our vocation amounts to a butchering sort of business": "\ud83e\udd14\ud83e\udd37\u200d\u2642\ufe0f\ud83d\udcad\ud83d\udd1d\ud83d\udeab\ud83d\udd2a\ud83d\udc16\ud83d\udcbc", "these mystic gestures": "\u2728\ud83e\udd32\ud83d\udd2e", "as if his chest had been a mortar, he burst his hot heart\u2019s shell upon it": "\ud83d\udc94\ud83d\udd25\ud83d\udca5\ud83d\udca3\ud83d\udca8\ud83d\udc94\u2764\ufe0f", "cook, you cook!\u2014sail this way, cook!": "\ud83d\udc68\u200d\ud83c\udf73\ud83c\udf7d\ufe0f\ud83d\udc49\u26f5\ufe0f\ud83d\udeb6\u200d\u2642\ufe0f\ud83d\udc68\u200d\ud83c\udf73", "you were kicked by a great man, and with a beautiful ivory leg": "\ud83d\udc5f\u27a1\ufe0f\ud83d\udcaa\ud83c\udf1f\ud83d\udc68\u200d\ud83e\uddb1\u2728\ud83e\uddb5\ud83e\udd0d", "Gayer sallies, more merry mirth, better jokes, and brighter repartees, you never heard": "\ud83c\udf89\ud83d\ude04\ud83d\ude02\u2728\ud83d\udd0a\ud83d\udcac\ud83c\udf08", "tales of terror told in words of mirth": "\ud83d\udcd6\ud83d\ude31\ud83d\udde3\ufe0f\ud83d\ude02\u2728", "With this once long lance, now wildly elbowed, fifty years ago did Nathan Swain kill fifteen whales between a sunrise and a sunset.": "\ud83c\udff9\u23f3\ud83d\udef6\ud83d\udc0b\ud83d\udc0b\ud83d\udc0b\ud83d\udc0b\ud83d\udc0b\ud83d\udc0b\ud83d\udc0b\ud83d\udc0b\ud83d\udc0b\ud83d\udc0b\ud83d\udc0b\ud83d\udc0b\ud83d\udc0b\ud83d\udc0b\ud83c\udf05\ud83c\udf07\u2728", "when, accordingly, Queequeg and a forecastle seaman came on deck, no small excitement was created among the sharks": "\ud83d\udd52\u27a1\ufe0f\u2693\ud83d\udc6b\ud83e\uddd1\u200d\u2708\ufe0f\ud83c\udd99\ud83c\udf89\ud83d\udc0b\ud83e\udd88", "All passed in a flash.": "\ud83c\udf1f\u26a1\ufe0f\u23f3", "Look ye, sun, moon, and stars! I call ye assassins of as good a fellow as ever spouted up his ghost.": "\ud83d\udc40\u2600\ufe0f\ud83c\udf19\u2b50\ufe0f\u2694\ufe0f\ud83d\udc64\ud83d\ude07\ud83d\udca8", "all the world": "\ud83c\udf0d\ud83c\udf0e\ud83c\udf0f", "instantaneous, violent, convulsive": "\u26a1\ufe0f\ud83d\udca5\ud83d\ude31", "All men tragically great are made so through a certain morbidness. Be sure of this, O young ambition, all mortal greatness is but disease.": "\ud83d\udc68\u200d\ud83d\udcbc\u26b0\ufe0f\ud83c\udf1f\ud83d\ude14\ud83d\udd0d\ud83d\udcaa\ud83d\udc80\ud83e\udde0\ud83d\udc94\u2728\ud83d\udd4a\ufe0f", "for what is man that he should live out the lifetime of his God?": "\ud83e\udd14\ud83d\udc68\u200d\ud83d\udcbc\u2753\u2696\ufe0f\u23f3\ud83d\ude4f\ud83c\udffd\u2728", "He sleeps with clenched hands; and wakes with his own bloody nails in his palms.": "\ud83d\ude34\u270b\ud83d\udcaa\ud83d\udd2a\ud83e\ude78\ud83d\udc50\u2728", "the thinnest shreds of isinglass": "\ud83e\uddca\u2702\ufe0f\ud83e\ude84\u2728", "this mighty monster is actually a diademed king of the sea": "\ud83d\udc09\ud83d\udc51\ud83c\udf0a\ud83d\udc1f", "A curious and most puzzling question might be started concerning this visual matter as touching the Leviathan.": "\ud83e\udd14\u2753\ud83d\udd0d\ud83e\udde9\ud83d\uddbc\ufe0f\ud83d\udc09", "look-outs were repeatedly hailed, and admonished to keep wide awake": "\ud83d\udc40\ud83d\udea8\ud83d\udd0a\u26a0\ufe0f\ud83d\ude34\ud83d\uded1\ud83d\udca4\ud83d\udc40\ud83c\udf19\ud83c\udf04", "start her like grim death and grinning devils, and raise the buried dead perpendicular out of their graves, boys": "\ud83d\udd2a\ud83d\udc69\u200d\ud83c\udfa4\ud83d\udc80\ud83d\ude08\ud83d\udc79\u2b06\ufe0f\u26b0\ufe0f\ud83e\uddd1\u200d\ud83e\uddb0", "its grand fact and feature is the wonderful distance to which the long lance is accurately darted from a violently rocking, jerking boat, under extreme headway": "\ud83c\udf0a\ud83d\udea4\u26a1\ufe0f\ud83c\udfaf\ud83d\udde1\ufe0f\u2728\ud83c\udf0c\ud83e\udd2f\ud83d\udca8", "In what census of living creatures, the dead of mankind are included": "\ud83d\udcca\ud83d\udc64\ud83d\udd0d\ud83c\udf0d\u26b0\ufe0f\u200d\ud83e\uddd1\u200d\ud83e\udd1d\u200d\ud83e\uddd1", "not to speak of the peril of the thing, it is to be doubted whether this course is always the best": "\ud83d\udeab\ud83d\udde3\ufe0f\u26a0\ufe0f\ud83e\udd14\u2753\ud83d\udcad\ud83e\udd37\u200d\u2642\ufe0f\ud83d\udcad\u27a1\ufe0f\ud83d\udc4d\u2753", "Naught\u2019s an obstacle, naught\u2019s an angle to the iron way!": "\ud83d\udeab\ud83d\uded1\u274c\ud83d\udd04\u27a1\ufe0f\ud83d\udee4\ufe0f", "take mankind in mass, and for the most part, they seem a mob of unnecessary duplicates, both contemporary and hereditary": "\ud83d\udc65\ud83c\udf0d\u27a1\ufe0f\ud83d\udc65\ud83d\udca5\ud83d\udd04\ud83e\uddec\ud83d\udc6c\ud83e\uddd1\u200d\ud83e\udd1d\u200d\ud83e\uddd1\ud83d\udd70\ufe0f\ud83d\udeab", "this pine-tree shakes down its sighs like leaves upon this shepherd's head": "\ud83c\udf32\ud83d\udca8\ud83c\udf42\ud83d\udcad\ud83d\ude0c\ud83d\udc64\ud83c\udf33", "once again leviathan returns to his native profundities, sliding along beneath the surface as before; but, alas! never more to rise": "\ud83d\udc09\ud83d\udd19\ud83c\udf0a\u2b07\ufe0f\ud83c\udf0c\ud83d\ude14\u2693\ufe0f\u274c\u2b06\ufe0f", "the old man is hard bent after that White Whale, and the devil there is trying to come round him, and get him to swap away his silver watch, or his soul, or something of that sort, and then he\u2019ll surrender Moby Dick": "\ud83d\udc74\ud83c\udffd\ud83d\udcaa\ud83d\udc0b\ud83d\ude08\ud83d\udd04\ud83d\udd70\ufe0f\ud83d\udcb0\ud83d\ude07\ud83d\udcad\u27a1\ufe0f\ud83e\udd1d\ud83d\udc33", "the grave-digger in the play sings, spade in hand. Dost thou never?": "\ud83e\udea6\ud83d\udc77\u200d\u2642\ufe0f\ud83c\udfad\ud83c\udfb6\ud83e\ude9a\ud83e\udd14\u2753", "What befell the weakling youth lifting the dread goddess\u2019s veil at Lais?": "\ud83e\udd14\ud83d\udc66\ud83d\udcaa\ud83d\ude1f\ud83d\udd4a\ufe0f\ud83c\udffa\ud83d\udc78\ud83d\udd2e\ud83d\ude2f\ud83c\udf2b\ufe0f", "this brought about new revelations of the incredible ferocity of the foe": "\ud83d\udcc8\ud83d\udd0d\u2728\ud83e\udd2f\ud83e\udd81\ud83d\udca5\ud83d\udc79", "here sleeps his meadow, and there sleep his cattle": "\ud83c\udfde\ufe0f\ud83d\ude34\ud83d\udc04\ud83d\udca4\ud83c\udfde\ufe0f\ud83d\udc04", "an utterly fearless man is a far more dangerous comrade than a coward.": "\ud83d\udc68\u200d\ud83e\uddb0\ud83d\udcaa\ud83d\ude28\ud83d\udd2b\ud83e\udd1d\ud83d\udca3\ud83d\udc80", "It is customary to have two harpoons reposing in the crotch": "\ud83e\ude9d\ud83e\ude9d\ud83d\udecc\u27a1\ufe0f\ud83d\udc56", "art thou not an arrant, all-grasping, intermeddling, monopolising, heathenish old scamp, to be one day making legs, and the next day coffins": "\ud83c\udfa8\ud83e\udd14\ud83d\udeab\ud83d\ude08\ud83d\udcb0\ud83e\udd1d\ud83d\udc74\ud83c\udfa9\ud83d\udd8c\ufe0f\ud83d\udeb6\u200d\u2642\ufe0f\ud83d\udc80\ud83d\udce6\ud83d\udcc5\ud83d\udc49\ud83d\udee0\ufe0f\ud83d\udce6", "At this hour of the night, of the last day of the week, that quarter of the town proved all but deserted.": "\ud83c\udf19\ud83d\udd5b\ud83d\udd70\ufe0f\ud83d\udd1a\ud83d\udcc5\ud83c\udfd9\ufe0f\ud83d\udeb6\u200d\u2642\ufe0f\ud83d\udca8\ud83d\udeb6\u200d\u2640\ufe0f\ud83d\udd73\ufe0f", "The lower subdivided part, called the junk, is one immense honeycomb of oil": "\ud83d\udee0\ufe0f\ud83d\udce6\u27a1\ufe0f\ud83d\uddd1\ufe0f\ud83c\udf6f\ud83c\udf6f\ud83c\udf6f\u27a1\ufe0f\ud83d\udee2\ufe0f", "mark what robustness is there": "\ud83d\udcdd\ud83d\udd0d\ud83d\udcaa\u2753", "they present the two extremes of all the known varieties of the whale": "\ud83d\udc0b\u27a1\ufe0f\u2696\ufe0f\u27a1\ufe0f\ud83d\udc33\ud83d\udd0d\ud83c\udf0a\ud83c\udf10", "whatever random allusions to whales he could anyways find in any book whatsoever, sacred or profane": "\ud83c\udf00\ud83d\udcda\ud83d\udc0b\ud83d\udd0d\u2728\ud83d\udd4a\ufe0f\ud83d\udcd6\ud83d\udc80", "they will not fail to elucidate several most important, however intricate passages, in scenes hereafter to be painted": "\ud83d\udc65\u274c\u274c\ud83d\udd1c\ud83d\udd0d\ud83d\udcd6\u2728\ud83d\udccc\ud83d\udd06\ud83c\udfa8", "a most delectable mess": "\ud83c\udf7d\ufe0f\ud83d\ude0b\ud83e\udd2a\ud83d\udca5", "this is a thing": "\ud83d\udc48\ud83d\udc40\u2728", "I wonder, Flask, whether the world is anchored anywhere; if she is, she swings with an uncommon long cable, though.": "\ud83e\udd14\ud83e\uddea\ud83c\udf0d\u2693\ufe0f\u2753\ud83c\udf00\ud83e\uddd7\u200d\u2642\ufe0f\ud83e\uddf5\ud83d\udcab", "For all his old age, and his one arm, and his blind eyes, he must die the death and be murdered": "\ud83d\udc74\ud83c\udffb\ud83e\uddbe\ud83d\udc40\u274c\ud83d\udc80\ud83d\udd2a", "He bolts down all events, all creeds, and beliefs, and persuasions, all hard things visible and invisible": "\u26a1\ufe0f\ud83d\udcc5\ud83c\udf0d\ud83d\ude4f\ud83d\udcad\ud83d\udcaa\ud83d\udc40\ud83d\udc7b", "Moby Dick was ubiquitous; that he had actually been encountered in opposite latitudes at one and the same instant of time.": "\ud83d\udc33\ud83c\udf0a\ud83c\udf0d\ud83d\udd04\u23f3\u2728", "If they but knew it": "\ud83e\udd14\ud83d\udcad\ud83e\udd2b\ud83d\udca1\u2728", "those same things that would have repelled most others, they were the very magnets that thus drew me": "\ud83d\udd04\ud83d\udc94\u27a1\ufe0f\ud83d\udeb6\u200d\u2642\ufe0f\u274c\ud83c\udf0d, \ud83c\udf1f\ud83d\udccc\u27a1\ufe0f\ud83d\udc96\ud83d\udd17\ud83d\ude0c\u2728", "this wild cannibal, tomahawk between his teeth, sprang into bed with me.": "\ud83c\udf2a\ufe0f\ud83e\ude93\ud83e\uddb7\ud83d\udecf\ufe0f\ud83d\udc64", "A sweet and unctuous duty!": "\ud83c\udf6d\ud83c\udf6f\u2728\ud83d\udc50\ud83d\udc96", "The great God absolute! The centre and circumference of all democracy!": "\ud83d\ude4f\ud83d\udc51\u2728\ud83c\udf0d\ud83d\udd35\ud83d\uddf3\ufe0f", "the doomed boat would infallibly be dragged down after him into the profundity of the sea; and in that case no town-crier would ever find her again": "\ud83d\udea4\ud83d\udc94\u2b07\ufe0f\ud83c\udf0a\ud83c\udf0c\u274c\ud83c\udfd9\ufe0f\ud83d\udd14\ud83d\udd0d\ud83d\ude45\u200d\u2642\ufe0f", "all truth is profound": "\ud83d\udd0d\u2728\ud83d\udcd6\ud83d\udcad", "mere sounds, full of Leviathanism, but signifying nothing": "\ud83c\udfb6\ud83d\udd0a\ud83d\udc0b\u274c\ud83d\udde3\ufe0f\u2728", "The classification of the constituents of a chaos, nothing less is here essayed.": "\ud83d\udcca\ud83e\udd14\ud83d\udd0d\ud83c\udf2a\ufe0f\u2728\ud83d\udcdd", "He piled upon the whale\u2019s white hump the sum of all the general rage and hate felt by his whole race from Adam down": "\ud83d\udc68\u200d\ud83e\uddb3\ud83d\udc0b\u26aa\ud83d\udca2\ud83d\udca2\ud83d\udca2\ud83d\udca2\ud83d\udca2\ud83d\udcad\ud83d\udca2\ud83d\udc63\ud83c\udf0d\ud83d\udc94", "the outermost enveloping layer of any animal, if reasonably dense, what can that be but the skin?": "\ud83d\udc3e\ud83c\udf0d\ud83e\udde5\ud83e\udd93\ud83d\ude48\ud83d\udcad\ud83d\udcaa\u2728\ud83d\udee1\ufe0f\ud83d\udc64\u270b\ud83d\udc56\uff1f", "few men\u2019s courage is proof against protracted meditation unrelieved by action": "\ud83d\udc68\u200d\ud83e\uddb0\ud83d\udc68\u200d\ud83e\uddb1\ud83d\udcaa\ud83d\ude0c\ud83d\udd0d\ud83d\udd70\ufe0f\ud83d\udcad\ud83d\udeab\u2694\ufe0f\ud83d\udca5", "It was in Queen Anne\u2019s time that the bone was in its glory, the farthingale being then all the fashion.": "\ud83d\udc51\ud83d\udc78\ud83d\udc83\u2728\ud83e\uddb4\ud83c\udf1f\ud83d\udd70\ufe0f\ud83d\udc57\ud83c\udf89\ud83d\udc96", "Yes, the world\u2019s a ship on its passage out, and not a voyage complete; and the pulpit is its prow.": "\ud83d\udc4d\ud83c\udf0d\ud83d\udea2\ud83c\udf0a\ud83c\udf05\ud83d\ude80\ud83d\udef3\ufe0f\u2693\ufe0f\u26f5\ufe0f\ud83d\udcab\u2728\ud83d\udc68\u200d\ud83c\udfeb\ud83d\udcd6\ud83d\udde3\ufe0f", "Yet habit\u2014strange thing! what cannot habit accomplish?": "\ud83e\udd14\ud83c\udf00\ud83e\udd37\u200d\u2642\ufe0f\ud83d\udcaa\u2728\u2753\ud83d\udd1d\ud83d\udd27", "We cannibals must help these Christians.": "\ud83c\udf7d\ufe0f\ud83d\udc65\ud83e\udd1d\u271d\ufe0f", "Shall we be dragged by him to the bottom of the sea? Shall we be towed by him to the infernal world?": "\ud83d\ude1f\ud83c\udf0a\u27a1\ufe0f\ud83e\uddd1\u200d\u2708\ufe0f\ud83d\udd3d\ud83e\udddc\u200d\u2642\ufe0f\u2753\ud83d\ude31\ud83c\udf0a\u27a1\ufe0f\ud83d\udc79\ud83c\udf0d\u2753", "Far inland, nameless wails came from him, as desolate sounds from out ravines": "\ud83c\udf32\u27a1\ufe0f\ud83c\udf04\ud83d\ude22\ud83d\udd0a\ud83c\udf0c\ud83c\udf0a\ud83c\udf2a\ufe0f\ud83c\udf04\ud83d\udd73\ufe0f", "Oh, hard! that to fire others, the match itself must needs be wasting!": "\ud83d\udd25\ud83d\ude29\ud83d\udc94\ud83d\udd25\ud83e\uddd1\u200d\ud83e\udd1d\u200d\ud83e\uddd1\ud83d\udca5\ud83d\udd6f\ufe0f\ud83d\udc94\ud83c\udf2a\ufe0f", "Nothing was said for some moments, while a succession of riotous waves rolled by, which by one of those occasional caprices of the seas were tumbling, not heaving it.": "\ud83e\udd2b\u23f3\ud83c\udf0a\ud83c\udf0a\ud83c\udf89\ud83c\udf0a\ud83d\udc49\ud83d\ude2e\u200d\ud83d\udca8\ud83c\udf0a\u26c5\ufe0f\ud83c\udf0a\ud83d\udca5\ud83c\udf0a\ud83d\udc40\ud83d\udcc9", "Ego non baptizo te in nomine patris, sed in nomine diaboli!": "\ud83d\udc64\u274c\ud83d\udca7\u27a1\ufe0f\ud83d\ude4f\ud83d\udc74,\u274c\u27a1\ufe0f\ud83d\ude4f\ud83d\udc7f!", "all the grave-yards, cemeteries, and family vaults of creation": "\ud83c\udff4\u200d\u2620\ufe0f\u26b0\ufe0f\ud83c\udf0c\ud83c\udff0\ud83e\udea6\ud83d\udc6a\ud83d\udc80", "the whale\u2019s horrible wallow": "\ud83d\udc0b\ud83d\udc94\ud83d\udec0", "Nothing exists in itself.": "\ud83c\udf00\u274c\u2728\ud83d\udd04", "For like certain other omnivorous roving lovers that might be named, my Lord Whale has no taste for the nursery, however much for the bower": "\ud83d\udc0b\u274c\ud83d\udc76\ud83c\udffb\ud83c\udf31\ud83d\udc96\ud83c\udf33", "I am impatient of all misery in others that is not mad.": "\ud83d\ude24\ud83e\udd37\u200d\u2642\ufe0f\ud83d\ude14\ud83d\udc94\ud83e\udd2a", "no suicides permitted here, and no smoking in the parlor": "\ud83d\udeab\ud83d\udc80\ud83d\udeab\ud83d\udeac\ud83c\udfe0\ud83d\udecb\ufe0f", "each silent sailor seemed resolved into his own invisible self": "\ud83c\udf0a\ud83e\uddd1\u200d\u2708\ufe0f\ud83e\udd2b\ud83d\udc65\u2728", "I\u2019ve no idea of sleeping with a madman": "\ud83d\ude34\ud83e\udd37\u200d\u2640\ufe0f\ud83d\udcad\ud83e\udd2a\ud83e\uddd1\u200d\ud83e\udd1d\u200d\ud83e\uddd1", "But here is an artist.": "\ud83c\udfa8\ud83d\udc69\u200d\ud83c\udfa8\u2728", "we marry and think to be happy for aye, when pop comes Libra, or the Scales\u2014happiness weighed and found wanting": "\ud83d\udc8d\u2764\ufe0f\ud83d\ude0a\u2728\u2696\ufe0f\ud83d\ude15\u2696\ufe0f\ud83d\udd0d\ud83d\udd04\ud83d\ude1e", "Serious fault might be found with the anatomical details of this whale, but let that pass; since, for the life of me, I could not draw so good a one.": "\u26a0\ufe0f\ud83d\udc0b\ud83e\uddd0\u274c\u270f\ufe0f\ud83e\udd37\u200d\u2642\ufe0f\ud83c\udfa8\u2728\ud83d\udc4c", "I quaked to think of it.": "\ud83d\ude31\ud83d\udcad\ud83c\udf2a\ufe0f", "we escape, and hail Virgo, the Virgin! that\u2019s our first love": "\ud83c\udfc3\u200d\u2642\ufe0f\u2728\ud83c\udf0c\ud83d\ude4c\u264d\ufe0f\ud83d\udc69\u200d\ud83c\udfa4\u2764\ufe0f\ud83c\udf1f", "He was intent on an audacious, immitigable, and supernatural revenge.": "\ud83d\udcaa\ud83d\udd25\ud83d\ude08\ud83e\uddb8\u200d\u2642\ufe0f\ud83d\udca5\u26a1\ufe0f\ud83d\udca3", "all this is both foolish and unnecessary": "\ud83e\udd26\u200d\u2642\ufe0f\ud83e\udd37\u200d\u2640\ufe0f\ud83d\udcad\u274c\u2728", "Ahab gave orders that not an oar should be used, and no man must speak but in whispers.": "\ud83e\uddd4\ud83d\udcdc\u27a1\ufe0f\ud83d\udeab\ud83d\udef6\ud83d\udeab\ud83d\udde3\ufe0f\ud83d\udc42\ud83d\udcac", "it is in vain to attempt a clear classification of the Leviathan, founded upon either his baleen, or hump, or fin, or teeth": "\ud83e\udd37\u200d\u2642\ufe0f\ud83d\udeab\ud83d\udd0d\ud83d\udccb\ud83e\udd88\ud83d\udc0b\ud83d\udc94\ud83e\uddb7\ud83e\udd88\u2728", "I have swam through libraries and sailed through oceans": "\ud83c\udfca\u200d\u2642\ufe0f\ud83d\udcda\ud83c\udf0a\u26f5\ufe0f", "His heart had burst!": "\ud83d\udc94\ud83d\udca5", "churning and churning": "\ud83c\udf2a\ufe0f\ud83d\udca8\ud83d\udd04\ud83d\udd01", "the robust and man-like sea heaved with long, strong, lingering swells, as Samson\u2019s chest in his sleep": "\ud83c\udf0a\ud83d\udcaa\ud83d\udca4\ud83d\udca8\ud83c\udf0a\ud83d\udcaa\ud83d\udca8\ud83c\udf0a\ud83d\udecc\ud83d\udcaa\ud83d\udca4", "at last he loses his identity": "\ud83c\udfc1\ud83d\ude14\ud83d\udc64\u274c", "It signifies\u2014\u201cGod: done this day by my hand.\u201d": "\ud83d\ude4f\u2728\ud83d\udcc5\u270b\ud83d\udd8a\ufe0f", "all that we call lives and souls, lie dreaming, dreaming, still": "\ud83c\udf0d\ud83d\udcab\ud83d\ude34\ud83d\udcad\ud83d\udcad\ud83d\udca4", "the pressure of the water is immense": "\ud83c\udf0a\ud83d\udca7\ud83d\udca6\ud83d\udd1d", "Consider also the devilish brilliance and beauty of many of its most remorseless tribes": "\ud83d\ude08\ud83d\udca1\u2728\ud83c\udf1f\ud83d\udc96\u2694\ufe0f\ud83c\udf0d\ud83c\uddf9\ud83c\uddf7\ud83d\udd2a", "their three Nantucket irons entered the whale": "\ud83d\udd043\ud83c\udffa\ud83d\udccd\ud83d\udc0b", "The continual sight of the fiend shapes before me, capering half in smoke and half in fire": "\ud83d\udc40\ud83d\udd25\ud83d\udc79\ud83d\udca8\ud83d\udc83\ud83c\udffb\ud83d\udca8\ud83d\udd25", "what nameless, inscrutable, unearthly thing is it; what cozening, hidden lord and master, and cruel, remorseless emperor commands me": "\ud83e\udd14\u2753\ud83d\udc7b\ud83e\udd37\u200d\u2642\ufe0f\u2728\ud83d\udd0d\ud83d\udd75\ufe0f\u200d\u2642\ufe0f\ud83d\udc51\ud83e\udd2b\ud83e\uddd9\u200d\u2642\ufe0f\ud83d\udc94\ud83d\ude20\ud83d\udc68\u200d\u2696\ufe0f\u2694\ufe0f\ud83d\udcdc", "no nose, eyes, ears, or mouth; no face; he has none": "\ud83e\udd1a\ud83d\udc43\u274c\ud83d\udc40\u274c\ud83d\udc42\u274c\ud83d\udc44\u274c\ud83d\ude36\u200d\ud83c\udf2b\ufe0f\u274c\ud83d\udc49\ud83d\udc68\u200d\u2696\ufe0f\ud83d\udeab", "a shocking sharkish business enough for all parties": "\ud83e\udd88\ud83d\udcbc\u26a1\ufe0f\ud83e\udd2f\ud83d\udcb0\ud83d\udc65\ud83d\udd04", "an exasperated whale, purposing to spring clean over the craft, is in the enormous act of impaling himself upon the three mast-heads": "\ud83d\udc0b\ud83d\ude24\ud83e\uddfc\ud83d\udef6\ud83d\udd2a\ud83c\udf0a\u2693\u2693\u2693", "If you should write a fable for little fishes, you would make them speak like great whales.": "\ud83d\udcdd\ud83d\udc1f\ud83d\udcac\ud83d\udc0b", "chance, though restrained in its play within the right lines of necessity, and sideways in its motions directed by free will, though thus prescribed to by both, chance by turns rules either, and has the last featuring blow at events": "\ud83c\udfb2\ud83d\udd12\u27a1\ufe0f\u2696\ufe0f\u270d\ufe0f\ud83c\udd93\ud83d\udd04\u2694\ufe0f\ud83c\udf00\ud83d\udd1a\ud83d\udca5\ud83c\udfad", "Could annihilation occur to matter, this were the thing to do it.": "\ud83d\udca5\u2753\ud83e\udd14\ud83d\udca8\ud83d\udd04\u269b\ufe0f\ud83d\udc7e\ud83d\udd1c\u26a0\ufe0f\u2728", "his special lunacy stormed his general sanity, and carried it, and turned all its concentred cannon upon its own mad mark": "\ud83d\ude1c\u26a1\ufe0f\ud83c\udf2a\ufe0f\ud83e\udd2a\ud83e\udde0\ud83d\udca5\u27a1\ufe0f\ud83d\udca3\ud83d\udd04\ud83c\udfaf\ud83c\udf00", "people were reliably apprised of the existence of Moby Dick, and the havoc he had made": "\ud83d\udc65\ud83d\udce2\ud83d\udcd6\ud83d\udc33\u26a1\ufe0f\ud83d\udca5", "There seems some ground to imagine that the great Kraken of Bishop Pontoppodan may ultimately resolve itself into Squid.": "\ud83c\udf0a\ud83e\udd91\ud83d\udcdc\ud83d\udd0d\u2728\ud83d\udc19\ud83e\udd91", "And the man that has anything bountifully laughable about him, be sure there is more in that man than you perhaps think for.": "\ud83e\uddd4\ud83d\ude04\ud83d\udcb0\ud83e\udd14\u2728", "unusual yellowish incrustations": "\ud83c\udf1f\ud83d\udfe1\ud83e\udea8\u2728", "I do not think I shall err": "\ud83e\udd14\u274c\ud83e\udd37\u200d\u2642\ufe0f\ud83d\uded1", "A peddler of heads too\u2014perhaps the heads of his own brothers. He might take a fancy to mine\u2014heavens! look at that tomahawk!": "\ud83e\uddd1\u200d\ud83c\udfa4\ud83e\ude96\ud83d\udc80\ud83e\udd14\ud83d\udc40\ud83d\udd2a\ud83d\udca5", "That immaculate manliness we feel within ourselves, so far within us, that it remains intact though all the outer character seem gone": "\ud83d\udcaa\u2728\ud83e\uddd4\ud83c\udffc\u200d\u2642\ufe0f\ud83d\udc96\ud83e\udd0d\ud83c\udf0c\ud83d\udc41\ufe0f\ud83d\udee1\ufe0f\ud83c\udf3f\ud83c\udf1f\ud83c\udf00", "Methinks that in looking at things spiritual, we are too much like oysters observing the sun through the water": "\ud83e\udd14\ud83d\udc40\ud83c\udf0a\ud83c\udf1e\ud83d\udc1a", "Moby Dick swam swiftly round and round the wrecked crew; sideways churning the water in his vengeful wake": "\ud83d\udc33\ud83c\udf0a\ud83d\udd04\ud83d\udc65\ud83d\udc94\ud83d\udca8", "It became imperative to lance the flying whale, or be content to lose him": "\ud83c\udff4\u200d\u2620\ufe0f\ud83c\udfaf\ud83d\udc0b\u2708\ufe0f\u2694\ufe0f\u2753\ud83d\ude14\u274c\ud83c\udfc6", "we nowadays fly under the same jaws for protection": "\ud83d\udd4a\ufe0f\u2708\ufe0f\ud83e\udd1d\ud83e\udd88\ud83d\udee1\ufe0f", "moment followed moment, and no sign of either the sinker or the diver could be seen": "\u23f3\u27a1\ufe0f\u23f3\ud83d\udeab\ud83d\udd0d\ud83e\udea3\ud83e\udd3f", "all for love": "\u2764\ufe0f\ud83d\udc96\ud83d\udc98\ud83d\udc9e\u2728", "the only whales that thus sank were old, meagre, and broken-hearted creatures": "\ud83d\udc0b\u274c\ud83d\udef3\ufe0f\ud83d\udc75\ud83d\ude14\ud83d\udc94\ud83d\udc94\ud83e\udd88", "blind and deaf, the whale plunged forward, as if by sheer power of speed to rid himself of the iron leech that had fastened to him": "\ud83d\udc0b\ud83d\udca8\ud83d\udc40\ud83d\udeab\ud83d\udc42\ud83d\udeab\ud83d\udd17\u2693\ufe0f\ud83d\udcaa\u2728", "I have another idea for you.": "\ud83d\udca1\u27a1\ufe0f\ud83e\udd14\u2728", "Listen, and thou wilt often hear my ivory foot upon the deck, and still know that I am there.": "\ud83d\udc42, \ud83d\udc18\ud83d\udc63\ud83d\udccf\ud83d\udef3\ufe0f, \ud83d\udd0a\ud83d\udc42\ud83d\udcac\ud83d\udccd\ud83d\udcad\ud83d\udc64.", "the head of this Leviathan, in the creature\u2019s living intact state, is an entire delusion": "\ud83d\udc09\ud83e\udde0\u2728\ud83e\ude84\ud83d\udd2e\ud83c\udf0a\ud83d\ude35\u200d\ud83d\udcab", "His motions plainly denoted his extreme exhaustion.": "\ud83d\udc68\u200d\ud83c\udfeb\ud83d\udd7a\u27a1\ufe0f\ud83d\ude29\ud83d\udca4\ud83d\udc94", "this nameless phantom feeling": "\ud83d\udc7b\ud83e\udd37\u200d\u2642\ufe0f\ud83d\udcad\u2728", "you cannot get at it": "\ud83d\udc64\u274c\u27a1\ufe0f\ud83d\uded1", "Oh, my Captain! my Captain! noble soul! grand old heart, after all!": "\ud83d\ude22\ud83d\udc68\u200d\u2708\ufe0f\ud83d\udc96\u2728\ud83d\udc94\ud83d\udd70\ufe0f", "smothered in the very whitest and daintiest of fragrant spermaceti": "\ud83d\ude2e\u200d\ud83d\udca8\u2744\ufe0f\ud83c\udf1f\ud83d\udc96\ud83c\udf38\ud83c\udf0a\ud83d\udc0b\u2728", "The intense concentration of self in the middle of such a heartless immensity, my God! who can tell it?": "\ud83d\ude24\ud83d\udcad\u2764\ufe0f\ud83c\udf0c\ud83d\ude31\ud83d\ude4f\u2753", "Do the heavens yet hate thee, that thou can\u2019st not go mad?": "\ud83c\udf0c\ud83d\udc94\ud83d\ude20\ud83e\udd14\ud83d\udd12\ud83d\ude35\u200d\ud83d\udcab", "indeed out of bed-clothes too, seeing that there was no fire in the room.": "\ud83d\udecf\ufe0f\u27a1\ufe0f\u274c\ud83d\udc57\ud83d\udd25\ud83c\udfe0", "the hunted whale cannot now escape speedy extinction": "\ud83d\udc0b\ud83c\udfc3\u200d\u2642\ufe0f\u274c\u26a1\ud83e\udea6", "nowadays, the whale-fishery furnishes an asylum for many romantic, melancholy, and absent-minded young men": "\ud83d\udc0b\ud83c\udfa3\ud83c\udfe0\ud83d\udc96\ud83d\ude14\ud83e\udde0\ud83d\udc66\ud83d\udc66\ud83d\udc66", "I could see no compass before me to steer by": "\ud83d\udc40\u274c\ud83e\udded\ud83d\udc64\u27a1\ufe0f\ud83d\udea2", "surrounded by circle upon circle of consternations and affrights": "\ud83d\udd34\ud83d\udd34\ud83d\udd34\ud83d\ude1f\ud83d\ude31\ud83d\udd34\ud83d\udd34\ud83d\udd34", "in the port is safety, comfort, hearthstone, supper, warm blankets, friends, all that\u2019s kind to our mortalities": "\u2693\ufe0f\ud83c\udfdd\ufe0f\ud83d\udee1\ufe0f\ud83d\udecb\ufe0f\ud83d\udd25\ud83c\udf7d\ufe0f\ud83d\udecf\ufe0f\ud83e\udde3\ud83d\udc6b\u2764\ufe0f\ud83c\udf0d\ud83d\ude0a", "one most perilous and long voyage ended, only begins a second; and a second ended, only begins a third, and so on, for ever and for aye": "1\ufe0f\u20e3\ud83c\udf0a\ud83d\udea2\u26f5\ufe0f\u2693\ufe0f\ud83d\uddfa\ufe0f\ud83d\udd1a, \ud83d\udd01\ud83d\udef3\ufe0f\ud83d\udd1c2\ufe0f\u20e3; 2\ufe0f\u20e3\ud83d\udd1a, \ud83d\udd01\ud83d\udd1c3\ufe0f\u20e3, \ud83d\udd01\ud83d\udd1c\ud83d\udd04, \u267e\ufe0f\u2728", "Let us scrape the ice from our frosted feet, and see what sort of a place this \u201cSpouter\u201d may be.": "\ud83e\uddca\ud83d\udc63\u2744\ufe0f\ud83e\uddfc\ud83d\udc40\ud83c\udfde\ufe0f\ud83d\udde3\ufe0f\u2753", "Two days chased; twice stove to splinters; thy very leg once more snatched from under thee": "2\ufe0f\u20e3\ud83c\udf05\ud83c\udfc3\u200d\u2642\ufe0f\ud83d\udca8; 2\ufe0f\u20e3\ud83d\udd25\ud83d\udd25\ud83d\udca5\ud83d\udca3; \ud83e\uddb5\ud83d\udd2a\ud83d\udc4b\ud83c\udfad\ud83e\uddd9\u200d\u2642\ufe0f", "The more so, I say, because truly to enjoy bodily warmth, some small part of you must be cold": "\ud83d\udcad\ud83d\udc96\ud83d\udd25\u27a1\ufe0f\u2744\ufe0f\u2728\ud83e\udec2\ud83c\udf21\ufe0f\ud83e\uddca", "I, for one, had no idea of so doing.": "\ud83d\ude4b\u200d\u2642\ufe0f\ud83e\udd37\u200d\u2642\ufe0f\u2753\ud83e\udd14\u27a1\ufe0f\ud83d\ude45\u200d\u2642\ufe0f\ud83d\udd0d\ud83e\ude84", "a whale must be near": "\ud83d\udc0b\u27a1\ufe0f\ud83c\udf0a\ud83d\udd0d", "through that gate lay the route to his vengeance": "\ud83d\udeaa\u27a1\ufe0f\ud83d\udee4\ufe0f\ud83d\ude08\u2694\ufe0f", "most letters never reach their mark; and many are only received after attaining an age of two or three years or more": "\u2709\ufe0f\u274c\ud83c\udfaf; \ud83d\udcec\ud83d\udd52\ud83d\udc76\ud83d\udc76\ud83d\udc67\ud83d\udd53\u2728", "if you narrowly search, you will at last see a lashless eye": "\ud83d\udd0d\ud83d\udc40\ud83d\udeab\ud83d\udc41\ufe0f", "But courage! there is good cheer in store for you": "\ud83d\udcaa\ud83d\ude0a\ud83c\udf89\u2728", "So have I seen a bird with clipped wing making affrighted broken circles in the air, vainly striving to escape the piratical hawks.": "\ud83d\udc26\u2702\ufe0f\ud83d\udd4a\ufe0f\ud83d\ude28\ud83d\udd04\ud83c\udf0c\ud83d\udca8\ud83d\ude45\u200d\u2642\ufe0f\ud83e\udd85\u2693\ufe0f", "I tell you, the sperm whale will stand no nonsense.": "\ud83d\udc64\u27a1\ufe0f\ud83d\udde3\ufe0f\ud83d\udc0b\u274c\ud83d\ude48\ud83c\udf00\ud83d\udd0a", "That sashless window, where the frost is on both sides, and of which the wight Death is the only glazier.": "\ud83e\ude9f\u274c\ud83e\udde3\u2744\ufe0f\u2b05\ufe0f\u27a1\ufe0f\ud83d\udc80\ud83d\udd28", "This fundamental thing settled, the next point is, in what internal respect does the whale differ from other fish.": "\ud83d\udd0d\ud83d\udc0b\u27a1\ufe0f\u2753\ud83c\udd9a\ud83d\udc1f", "unfolding its noiseless measureless leaves upon the sea": "\ud83d\udcdc\u27a1\ufe0f\ud83e\udd2b\ud83d\udccf\ud83c\udf43\ud83c\udf0a", "from the unmarred dead body of the whale, you may scrape off with your hand an infinitely thin, transparent substance": "\ud83d\udc0b\u2728\ud83d\udc4b\ud83d\udca7\ud83d\udd2c", "I\u2019ll try a pagan friend, thought I, since Christian kindness has proved but hollow courtesy.": "\ud83e\udd14\ud83d\udc65\ud83e\ude84\u2728\ud83d\ude4f\ud83d\ude07\ud83d\udc94\ud83d\udc81\u200d\u2642\ufe0f", "Some men die at ebb tide; some at low water; some at the full of the flood": "\ud83e\uddd1\u26b0\ufe0f\ud83c\udf0a\u23f3; \ud83e\uddd1\u26b0\ufe0f\ud83c\udf0a\u2b07\ufe0f; \ud83e\uddd1\u26b0\ufe0f\ud83c\udf0a\ud83c\udf15\u2728", "his mother tells him of me, of cannibal old me; how I am abroad upon the deep, but will yet come back to dance him again": "\ud83d\udc69\u200d\ud83d\udc66\ud83d\udde3\ufe0f\ud83d\udc75\ud83c\udf74\ud83d\udc64\ud83c\udf0a\u2708\ufe0f\ud83d\udc83\ud83d\udd04", "I never saw such a sight in my life.": "\ud83d\udc40\ud83e\udd2f\ud83e\udd29\ud83d\udcab", "an incorruptible sea": "\ud83c\udf0a\u2728\ud83d\udee1\ufe0f", "did ever whale yaw so before? it must be, he\u2019s lost his tiller": "\ud83d\udc0b\ud83d\ude34\u2753\ud83d\ude2e\u200d\ud83d\udca8\ud83c\udf0a\ud83e\ude9d\ud83d\udc49\ud83e\udd14\ud83d\udd1a\ud83d\udef6\ud83c\udfad", "A curious sight; these bashful bears, these timid warrior whalemen!": "\ud83d\udc3b\ud83d\udc40\ud83d\ude33\ud83d\udc0b\u2694\ufe0f\ud83e\uddd4", "Hurrah! this is the way a fellow feels when he\u2019s going to Davy Jones\u2014all a rush down an endless inclined plane!": "\ud83c\udf89\ud83d\ude04\u27a1\ufe0f\ud83d\udc68\u200d\u2708\ufe0f\ud83d\udc80\ud83c\udf0a\ud83c\udff4\u200d\u2620\ufe0f\u23ec\ud83c\udfd4\ufe0f\ud83d\udca8\ud83d\udca8", "Wretched entertainment": "\ud83d\ude12\ud83c\udfad\ud83d\udcfa", "I said nothing, and tried to think nothing.": "\ud83e\udd10\ud83d\ude45\u200d\u2642\ufe0f\ud83d\udcad\ud83d\udeab", "gripe your oars, and clutch your souls, now!": "\ud83d\udef6\ud83d\ude4c\u2693\ufe0f\ud83d\udc7b\ud83d\udcaa\u2728", "He\u2019s the devil, I say. The reason why you don\u2019t see his tail, is because he tucks it up out of sight; he carries it coiled away in his pocket, I guess.": "\ud83d\udc79\ud83e\udd14\ud83d\udc49\ud83d\udc7f\u2753\ud83d\udc40\ud83d\udc4e\ud83d\udc48\ud83d\udc0d\ud83d\udd12\ud83e\udd10\ud83c\udf92\ud83d\udcad", "He swam the seas before the continents broke water; he once swam over the site of the Tuileries, and Windsor Castle, and the Kremlin.": "\ud83c\udfca\u200d\u2642\ufe0f\ud83c\udf0a\ud83c\udf0d\ud83c\udfdd\ufe0f\ud83d\udca7\ud83c\udff0\ud83c\uddeb\ud83c\uddf7\ud83c\udff0\ud83c\uddec\ud83c\udde7\ud83c\udff0\ud83c\uddf7\ud83c\uddfa", "But sperm whales are not every day encountered; while you may, then, you must kill all you can.": "\ud83d\udc0b\u274c\ud83d\udcc5\ud83d\udc40\ud83d\udd0d\ud83d\udcaa\ud83d\udd2b\ud83d\udc0b\ud83d\udc94", "how had the mystic thing been caught? Whisper it not, and I will tell; with a treacherous hook and line": "\ud83e\udd14\u2728\ud83d\udd2e\ud83d\udc1f\u2753\ud83e\udd2b\ud83d\udde3\ufe0f\ud83d\udd0d\ud83c\udfa3\ud83d\udc94\ud83d\udc20", "they saw a falling phantom in the air; and looking down, a little tossed heap of white bubbles in the blue of the sea": "\ud83d\udc40\ud83d\udc7b\u2b07\ufe0f\ud83c\udf00\ud83d\udca8\u26aa\ufe0f\ud83c\udf0a\ud83d\udc99", "doubting those traditions did not make those traditions one whit the less facts": "\ud83e\udd14\u2753\ud83d\udcdc\ud83d\udd0d\ud83d\udeab\u27a1\ufe0f\ud83d\udc53\ud83d\udd0d\ud83d\udc65\u27a1\ufe0f\ud83d\udcca\u2728", "an accident which not seldom happens": "\ud83d\ude97\ud83d\udca5\ud83e\udd15\ud83d\udd04", "neither knows where lie the nameless things of which the mystic sign gives forth such hints": "\ud83e\udd37\u200d\u2642\ufe0f\u2753\ud83c\udf0c\ud83d\udd0d\u2728\ud83d\udcab\ud83e\udd14\ud83d\udd11\ud83c\udf00\ud83d\udd12\ud83d\udcdc\ud83c\udf13\ud83c\udf12\ud83d\udd2e", "in the midst of the manifold whizzings of a steam-engine in full play, when every flying beam, and shaft, and wheel, is grazing you": "\ud83c\udf2a\ufe0f\ud83d\ude82\ud83d\udca8\u2699\ufe0f\ud83d\udd29\ud83d\udd27\u2728\ud83d\udca8\ud83c\udf00", "The head looks a sort of reproachfully at him, with an \u201cEt tu Brute!\u201d expression.": "\ud83d\udc64\ud83d\udc49\ud83d\ude12\ud83d\udde3\ufe0f\u27a1\ufe0f\ud83d\udc68\u200d\u2696\ufe0f\ud83d\udc94\u2728", "But the mingled, mingling threads of life are woven by warp and woof: calms crossed by storms, a storm for every calm.": "\ud83e\uddf6\u2728\ud83c\udf2a\ufe0f\ud83c\udf0a\ud83c\udf08\u26a1\ufe0f\ud83c\udf2a\ufe0f\ud83c\udf0a", "utterly lost was he to all sense of reverence for the many marvels of their majestic bulk and mystic ways": "\ud83e\udd37\u200d\u2642\ufe0f\ud83d\udcab\ud83d\ude33\u2728\ud83c\udf0c\ud83e\udd84\ud83c\udf20\ud83c\udfd4\ufe0f\ud83d\udc96\ud83d\udd2e", "a purse is but a rag unless you have something in it": "\ud83d\udc5c \u27a1\ufe0f \ud83e\uddfb \u274c \ud83e\udd37\u200d\u2642\ufe0f \ud83d\udcb0 \ud83d\udd12", "Better sleep with a sober cannibal than a drunken Christian.": "\ud83d\ude34\ud83d\udca4\ud83d\udc49\ud83c\udf7d\ufe0f\ud83d\udc64\ud83d\ude45\u200d\u2642\ufe0f\ud83c\udf77\u271d\ufe0f", "mark of genius": "\ud83e\udde0\u2728", "whereto does all that circumnavigation conduct?": "\ud83d\udd04\u27a1\ufe0f\ud83c\udf0d\u2753", "you would have thought the craft had two keels\u2014one cleaving the water, the other the air\u2014as the boat churned on through both opposing elements at once": "\ud83d\udee5\ufe0f\ud83c\udf0a\u2708\ufe0f\u2693\ufe0f\ud83d\udca8\ud83d\udef6\ud83c\udf2a\ufe0f\ud83c\udf43\u2728", "as the ship sailed down to them, they turned and fled with swift precipitancy": "\ud83d\udea2\u2b07\ufe0f\ud83d\udc65\ud83c\udfc3\u200d\u2642\ufe0f\ud83d\udca8\ud83d\udca8", "And this, good friends, is ambergris, worth a gold guinea an ounce to any druggist.": "\ud83e\uddd1\u200d\ud83e\udd1d\u200d\ud83e\uddd1\u2728\ud83d\udc0b\ud83d\udc9b\ud83c\udfc5\u2696\ufe0f\ud83d\udc8a", "somehow, I never fancied broiling fowls": "\ud83e\udd37\u200d\u2642\ufe0f\u2753\ud83c\udf57\ud83d\udd25\ud83d\udc14", "I conclude that, like the dyspeptic old woman, he must have \u201cbroken his digester.\u201d": "\ud83e\uddd1\u200d\ud83e\uddb3\ud83d\udcad\u27a1\ufe0f\ud83e\udd14\ud83d\udd1a\ud83e\uddd3\ud83d\udc94\ud83e\udde0\ud83c\udf7d\ufe0f\ud83d\udd27", "This is what I mean.": "\ud83e\udd14\ud83d\udc49\ud83d\udcdd\u2728", "This whale is not dead; he is only dispirited; out of sorts, perhaps": "\ud83d\udc0b\u274c\ud83e\udea6\ud83d\ude14\ud83d\udc94\ud83e\udd37\u200d\u2642\ufe0f", "Queequeq, my fine friend, does this sort of thing often happen?": "\ud83e\udd1d\ud83e\udeb8\u2753\ud83e\udd14\ud83e\udd73\u2728", "carried down alive to wondrous depths, where strange shapes of the unwarped primal world glided to and fro before his passive eyes": "\ud83d\udeb6\u200d\u2642\ufe0f\u2b07\ufe0f\ud83c\udf89\ud83c\udf0a\ud83d\udd0d\ud83d\udc40\u2728\ud83d\udd2e\ud83c\udf0d\ud83d\udc7b\ud83c\udf2a\ufe0f\ud83c\udf0c\ud83d\udc41\ufe0f", "These are hieroglyphical; that is, if you call those mysterious cyphers on the walls of pyramids hieroglyphics": "\ud83d\udcdd\ud83d\udd24\ud83d\udd0d\ud83e\udd14\u2728\ud83c\udffa\ud83c\udfdb\ufe0f\ud83c\udf04\ud83d\udd12\ud83d\udcdc", "magical": "\ud83e\ude84\u2728\ud83c\udf1f\ud83d\udd2e\ud83c\udf08", "Invisible winged creatures that frolic all round us! Sweet childhood of air and sky! how oblivious were ye of old Ahab\u2019s close-coiled woe!": "\ud83e\udd8b\ud83d\udc7b\ud83e\udd84\ud83d\udd4a\ufe0f\ud83c\udf08\ud83c\udf2c\ufe0f\u2601\ufe0f\ud83c\udf1f\ud83d\udc76\ud83c\udf88\u2728\u26c5\ud83c\udf0d\ud83d\udc94\ud83e\udd85\ud83d\udd0d", "sharks also are the invariable outriders of all slave ships crossing the Atlantic, systematically trotting alongside, to be handy in case a parcel is to be carried anywhere, or a dead slave to be decently buried": "\ud83e\udd88\u27a1\ufe0f\ud83d\udea2\ud83c\udf0a\ud83c\udf0d\ud83d\udcbc\u2693\ufe0f\ud83d\udce6\ud83e\udea6\ud83e\udea6\ud83e\udea6", "Strike nothing, and stir nothing, but lash everything.": "\u2694\ufe0f\u274c\u2728\ud83d\udeab\ud83d\udd04\u274c, \u274c\ud83d\udd04\u274c\u261d\ufe0f, \ud83d\udd25\u26a1\ufe0f\ud83c\udf00\ud83d\udd17\ud83d\udc4ceverything.", "with blue lips and blood-shot eyes the exhausted savage at last climbs up the chains and stands all dripping and involuntarily trembling over the side": "\ud83d\udc44\ud83d\udc99\ud83d\udc41\ufe0f\u200d\ud83d\udde8\ufe0f\ud83e\ude78\ud83d\ude29\ud83d\udde1\ufe0f\ud83d\udd17\ud83e\uddd7\u200d\u2642\ufe0f\ud83d\udca7\ud83d\udca6\ud83d\ude30\ud83d\udd17\ud83d\udcaa", "he had been a great prophet; in their cracked, secret meetings having several times descended from heaven by the way of a trap-door, announcing the speedy opening of the seventh vial": "\ud83d\udc68\u200d\ud83c\udfeb\u2728\ud83d\udcdc\ud83e\udd2b\ud83e\udd1d\ud83d\udeaa\u2601\ufe0f\ud83d\udd14\u23f3\ud83c\udf767", "place this reversed skull (scaled down to the human magnitude) among a plate of men\u2019s skulls, and you would involuntarily confound it with them": "\ud83d\udd04\ud83d\udc80\ud83d\udd0d\ud83d\udc68\u200d\ud83e\uddb0\ud83d\udc80\ud83c\udf7d\ufe0f\ud83d\udc80\ud83e\udd14", "Once more the sermon proceeded.": "\ud83d\udd4a\ufe0f\ud83d\udcd6\u27a1\ufe0f\ud83d\udd0a\ud83d\ude0a", "as the short northern day merged into night, we found ourselves almost broad upon the wintry ocean, whose freezing spray cased us in ice": "\ud83c\udf05\u27a1\ufe0f\ud83c\udf03\ud83c\udf0a\ud83d\udc49\u2744\ufe0f\ud83c\udf0a\ud83c\udf28\ufe0f\ud83d\udd1c\ud83e\uddca", "On life and death this old man walked.": "\ud83d\udc74\u26b0\ufe0f\ud83d\udeb6\u200d\u2642\ufe0f", "a young buck with an intelligent looking calf\u2019s head before him, is somehow one of the saddest sights you can see": "\ud83e\udd8c\ud83d\udc76\ud83e\udd14\ud83d\udc2e\ud83d\ude22", "And, doubtless, my going on this whaling voyage, formed part of the grand programme of Providence that was drawn up a long time ago": "\ud83d\udc64\u27a1\ufe0f\ud83d\udef3\ufe0f\ud83d\udc0b\ud83c\udf0a\u2728\ud83d\udcdc\ud83d\uddd3\ufe0f\ud83d\udd70\ufe0f", "Speak, thou vast and venerable head": "\ud83d\udde3\ufe0f\ud83d\udc64\ud83c\udf0c\ud83d\udcab\ud83d\udc74", "something went hot and hissing along every one of their wrists": "\ud83d\udd25\ud83d\udca8\ud83e\udd1a\ud83d\udca8\ud83e\udd1a\ud83d\udca8\ud83e\udd1a\ud83d\udca8\ud83e\udd1a\ud83d\udca8", "the signal was set to see what response would be made": "\ud83d\udcf6\ud83d\udd27\ud83d\udc40\ud83e\udd14\ud83d\udcac", "there is no one who will speak more respectfully, not to say reverentially, of a broiled fowl than I will": "\ud83d\udc64\u274c\ud83d\ude4a\ud83d\udde3\ufe0f\u27a1\ufe0f\ud83d\udde3\ufe0f\ud83d\ude47\u200d\u2642\ufe0f\ud83d\udc50\ud83c\udf57\ud83d\udcac\ud83d\udc4c\ud83d\ude4b\u200d\u2642\ufe0f", "relinquish this turbulence": "\u270b\ud83c\udf2a\ufe0f\ud83d\udd1a", "until the whale is fairly captured and a corpse": "\ud83d\udd70\ufe0f\ud83d\udc0b\u27a1\ufe0f\ud83d\udd12\ud83c\udff4\u200d\u2620\ufe0f\u26b0\ufe0f", "Towards thee I roll, thou all-destroying but unconquering whale": "\u27a1\ufe0f\ud83e\udd88\ud83d\udca5\ud83c\udf0a\ud83c\udf00\ud83e\udd88\ud83d\uded1\ud83d\udcaa\ud83c\udf0a", "I begged him as well as I could, to accelerate his toilet somewhat, and particularly to get into his pantaloons as soon as possible.In an instant\u2019s compass, great hearts sometimes condense to one deep pang, the sum total of those shallow pains kindly diffused through feebler men\u2019s whole lives.": "\ud83d\ude4f\ud83d\udc68\u200d\ud83d\udd27\u23e9\ud83d\udebd\ud83e\ude73\ud83d\udca8\ud83d\udc94\ud83d\ude22\ud83d\udc94\ud83d\udc65\ud83d\udcaa\ud83d\udcad\ud83d\udca1\ud83d\udc96", "Whale-balls for breakfast\u2014don\u2019t forget.": "\ud83d\udc0b\u26bd\ufe0f\ud83c\udf73\u2014\ud83d\udc49\u274c\ud83d\udd19", "for in many old chronicles whales and dragons are strangely jumbled together, and often stand for each other": "\ud83d\udcd6\ud83d\udd70\ufe0f\ud83d\udc0b\ud83d\udc09\ud83d\udd04\ud83e\udd14\ud83d\udcad\ud83d\udc65", "he helplessly rolled away from the wreck he had made; lay panting on his side, impotently flapped with his stumped fin, then over and over slowly revolved like a waning world; turned up the white secrets of his belly": "\ud83d\udc68\u200d\u2708\ufe0f\ud83d\ude29\u27a1\ufe0f\ud83d\udea7\ud83d\udee0\ufe0f\ud83d\udca8\ud83d\ude2e\u200d\ud83d\udca8\ud83c\udf0d\ud83d\udd04\ud83d\udd04\ud83d\udd04\ud83d\udd06\ud83e\udd0d\ud83d\udd0d\ud83e\udd88", "As if struck by some enchanter\u2019s wand, the sleepy ship and every sleeper in it all at once started into wakefulness": "\u2728\ud83e\ude84\ud83d\ude34\ud83d\udea2\ud83d\udca4\ud83d\ude32\ud83c\udf0a\ud83c\udf05", "I am horror-struck at this antemosaic, unsourced existence of the unspeakable terrors of the whale": "\ud83d\ude31\ud83e\udd88\ud83d\udc80\ud83d\uddbc\ufe0f\u274c\ud83d\udcd6\ud83d\ude28\ud83c\udf0a\ud83d\udc0b\u2728", "A word concerning an incident in the last chapter.": "\ud83d\udde3\ufe0f\ud83d\udcac\u26a0\ufe0f\ud83d\udcdd\ud83d\udcd6\u2728", "against all natural lovings and longings, I so keep pushing, and crowding": "\ud83d\udeab\ud83c\udf3f\u2764\ufe0f\ud83d\udc94\u27a1\ufe0f\ud83d\udcaa\u27a1\ufe0f\ud83d\udc65", "as the monomaniac incarnation of all those malicious agencies which some deep men feel eating in them": "\ud83d\udc64\ud83d\udd04\ud83c\udf00\ud83d\ude08\ud83d\udd0d\ud83d\udcad\ud83c\udf7d\ufe0f\ud83e\udde0\u2728", "So man\u2019s seconds tick! Oh! how immaterial are all materials!": "\ud83d\udd52\ud83d\udc68\u200d\ud83e\uddb0\u23f3! \ud83d\ude2e\ud83c\udf0c\ud83d\udd04\ud83d\udcab\ud83d\udce6\ud83d\udca8!", "Drat the file, and drat the bone!": "\ud83d\udc4e\ud83d\udcc2\ud83d\udc94\ud83e\uddb4", "I jerked him now and then from between the whale and ship": "\ud83d\udc50\ud83d\udc0b\ud83d\udea2", "Ahab had purposely sailed upon the present voyage with the one only and all-engrossing object of hunting the White Whale.": "\ud83d\udee5\ufe0f\ud83c\udf0a\ud83c\udfaf\ud83d\udc0b\u26aa\ufe0f\ud83d\udd0d", "Damn me, but all things are queer, come to think of \u2019em.": "\ud83d\ude33\ud83e\udd37\u200d\u2642\ufe0f\ud83e\udd14\ud83c\udf08\ud83d\udcad\ud83c\udf00", "What despair in those immovable inscriptions!": "\ud83d\ude1f\ud83d\udcdc\ud83d\uded1\u2728", "There were eight whales, an average pod.": "\ud83d\udc0b\ud83d\udc0b\ud83d\udc0b\ud83d\udc0b\ud83d\udc0b\ud83d\udc0b\ud83d\udc0b\ud83d\udc0b \u2795 \ud83d\udcca", "sage ejaculation": "\ud83c\udf3f\ud83d\udca7\u2728", "It\u2019s a mutual, joint-stock world, in all meridians.": "\ud83c\udf0d\ud83e\udd1d\ud83d\udcbc\ud83e\udd11\ud83d\uddfa\ufe0f\u2728", "It fell at Ahab\u2019s feet.": "\ud83e\udea8\ud83d\udc63\ud83d\udc51", "Old man of oceans! of all this fiery life of thine, what will at length remain but one little heap of ashes!": "\ud83c\udf0a\ud83d\udc74\ud83d\udd25\ud83c\udf0d\u2753\ud83d\uddd1\ufe0f\ud83d\udd6f\ufe0f\ud83d\udc94\ud83d\udd25\ud83d\udd70\ufe0f\u26b0\ufe0f", "tossing like slumberers in their beds; the ever-rolling waves but made so by their restlessness": "\ud83d\udca4\ud83c\udf0a\ud83d\ude34\ud83d\udecf\ufe0f\ud83c\udf0a\ud83d\udd04\ud83d\udca4\u26aa\ufe0f\ud83c\udf0a\ud83d\udca8\u2728", "Pushing heavy cannon up mountain defiles, the elephant\u2019s brow is majestic.": "\ud83d\udc18\ud83d\udcaa\ud83c\udf86\ud83d\uddfb\u27a1\ufe0f\ud83d\udca5\ud83d\udd2b\ud83c\udf04\ud83d\udc51", "he will infallibly lead you to water, if water there be": "\ud83d\udc68\u200d\ud83e\uddb0\u27a1\ufe0f\ud83d\udca7\ud83c\udf0a, \u2753\ud83c\udf0a\u2728", "an accident which not seldom happens, and with much less reason": "\ud83d\ude97\ud83d\udca5\ud83d\ude48\ud83d\udd04\ud83e\udd37\u200d\u2642\ufe0f\ud83d\udcad\u274c\ud83d\udd0d", "the mere act of penning my thoughts of this Leviathan, they weary me, and make me faint with their outreaching comprehensiveness of sweep": "\ud83d\udd8a\ufe0f\ud83d\udcad\ud83d\udc0b\ud83d\ude29\ud83d\udca4\ud83c\udf0a\u2728", "we at last came to something which there was no mistaking": "\ud83d\udc65\ud83c\udf89\u27a1\ufe0f\ud83d\udd0d\u2728\ud83e\uddd0\ud83c\udd97", "No more my splintered heart and maddened hand were turned against the wolfish world.": "\ud83d\udc94\u270b\ud83e\ude93\ud83d\ude45\u200d\u2642\ufe0f\ud83d\udc3a\ud83c\udf0d", "Look at that hanging lower lip! what a huge sulk and pout is there!": "\ud83d\udc40\ud83d\ude2e\ud83d\udc44\ud83d\udc47\ud83d\ude12\ud83d\ude24", "higgledy-piggledy whale statements": "\ud83d\udc0b\u2728\ud83c\udf00\ud83d\udde3\ufe0f\ud83d\udcac", "Is it that by its indefiniteness it shadows forth the heartless voids and immensities of the universe": "\u2753\ud83c\udf0c\u2753\ud83d\udda4\ud83d\udd32\ud83d\udd06\ud83c\udf0c\ud83c\udf0c", "Yes, when a fellow\u2019s soaked through, it\u2019s hard to be sensible, that\u2019s a fact.": "\ud83d\udc4d\ud83d\udca7\ud83d\udc68\u200d\ud83d\udcbc\ud83c\udf27\ufe0f\ud83d\ude13\ud83e\udd14\ud83d\udcaf", "and with half-stifled melancholy gurglings the spray-column lowers and lowers to the ground\u2014so the last long dying spout of the whale": "\ud83c\udf27\ufe0f\ud83d\ude22\ud83d\udca7\u2b07\ufe0f\ud83d\udc0b\ud83d\udca8\u27a1\ufe0f\ud83c\udf0d", "the sperm whale, scientific or poetic, lives not complete in any literature. Far above all other hunted whales, his is an unwritten life.": "\ud83d\udc0b\ud83d\udd2c\ud83d\udcda\u274c\u270d\ufe0f\ud83c\udf0a\ud83c\udf0c\ud83d\udd1d\ud83d\udd0d\ud83c\udff4\u200d\u2620\ufe0f\ud83c\udf0a\u2716\ufe0f\ud83d\udcd6\u2728", "they were afraid of him": "\ud83d\ude28\ud83d\udc65\ud83d\udc64\ud83d\udc94", "But that same image, we ourselves see in all rivers and oceans. It is the image of the ungraspable phantom of life": "\ud83d\uddbc\ufe0f\ud83d\udc40\ud83c\udf0a\ud83c\udf0a\u27a1\ufe0f\ud83c\udf0a\ud83c\udf0a\ud83d\udd0d\ud83d\udc7b\ud83d\udcab\ud83d\udc96", "down there, some ten feet below the level of the deck, the poor harpooneer flounders about, half on the whale and half in the water, as the vast mass revolves like a tread-mill beneath him.": "\u2b07\ufe0f\ud83d\udd1f\ud83d\udc63\u2b07\ufe0f\ud83d\udef3\ufe0f\ud83d\ude1e\ud83c\udfa3\ud83d\udc0b\ud83d\udca6\ud83d\udd04\ud83c\udf00\ud83d\udcaa", "What do ye do when ye see a whale, men?": "\ud83e\udd14\u2753\ud83d\udc33\ud83d\udc40\ud83d\udc68\u200d\u2708\ufe0f\ud83d\udc68\u200d\u2708\ufe0f\ud83d\udc68\u200d\u2708\ufe0f", "Oh, immortal infancy, and innocency of the azure! Invisible winged creatures that frolic all round us! Sweet childhood of air and sky!": "\ud83d\udc76\u2728\ud83c\udf08\ud83d\udc99\ud83e\udd8b\ud83d\udd4a\ufe0f\ud83c\udf88\ud83c\udf3c\ud83c\udf24\ufe0f\ud83c\udf0c", "every eye counted every ripple": "\ud83d\udc41\ufe0f\ud83d\udc41\ufe0f\ud83d\udd22\ud83d\udca7\ud83c\udf0a", "power to the tail": "\u26a1\ud83d\udc0d", "we now gazed at the most wondrous phenomenon which the secret seas have hitherto revealed to mankind": "\ud83d\udc40\u2728\ud83c\udf0a\ud83c\udf0c\ud83d\udd0d\ud83d\udc64\ud83d\udcab", "There\u2019s hogsheads of sperm ahead": "\ud83d\udc16\ud83d\udca7\u27a1\ufe0f", "all at once the exhausted harpooneer hears the exciting cry\u2014\u201cStand up, and give it to him!\u201d": "\ud83c\udf0a\ud83d\ude29\ud83c\udfa3\ud83d\ude80\ud83d\udde3\ufe0f\ud83c\udfc3\u200d\u2642\ufe0f\u270a\ud83d\udc0b", "nothing but a whale, or a gale, or some violent, ungovernable, unintelligent destroyer": "\ud83d\udc0b\ud83d\udca8\ud83c\udf0a\ud83e\udd16\ud83d\udca5\ud83d\udd2a", "A continual cascade played at the bows; a ceaseless whirling eddy in her wake": "\ud83c\udfb6\ud83d\udca7\ud83c\udfbb\ud83c\udf0a\ud83d\udca8\ud83d\udd04\ud83c\udf2a\ufe0f", "far more terrible is it to behold, when fathoms down in the sea, you see some sulky whale, floating there suspended, with his prodigious jaw, some fifteen feet long, hanging straight down at right-angles with his body": "\ud83c\udf0a\ud83d\udc0b\ud83d\ude20\u2b07\ufe0f\u2696\ufe0f\ud83e\udd88\ud83d\udccf\ud83d\udd3d\ud83d\udccf\ud83d\udd3d", "regarded discreetly and coolly, seems it not but a mad idea, this; that in the broad boundless ocean, one solitary whale, even if encountered, should be thought capable of individual recognition from his hunter": "\ud83e\udd14\ud83c\udf0a\ud83d\udc0b\ud83d\udcad\ud83d\ude35\u200d\ud83d\udcab\ud83e\udd37\u200d\u2642\ufe0f\ud83d\udd0d\ud83c\udfa3", "let me look into a human eye; it is better than to gaze into sea or sky; better than to gaze upon God": "\ud83d\udc40\ud83d\udd0d\ud83d\udc41\ufe0f\ud83d\udc64\u2728\ud83c\udf0a\u2601\ufe0f\ud83c\udf0c\u2728\ud83d\ude4f", "it was plain that unless artificially upheld, the body would at once sink to the bottom": "\ud83e\udea4\u27a1\ufe0f\ud83d\udc64\u2b07\ufe0f\ud83d\udd73\ufe0f", "amid all the smoking horror and diabolism of a sea-fight, sharks will be seen longingly gazing up to the ship\u2019s decks": "\ud83c\udf0a\u2693\ufe0f\ud83d\udd25\ud83d\ude31\ud83e\udd88\ud83d\udc40\ud83d\udee5\ufe0f\ud83d\udef3\ufe0f\u2728", "dismasted man never entirely loses the feeling of his old spar, but it will be still pricking him at times": "\ud83e\uddd1\u200d\u2708\ufe0f\u2693\ufe0f\u274c\ud83e\ude9d\ud83d\udc94\ud83d\udd04\ud83d\udd70\ufe0f\ud83d\udd19\u2728", "So long as a man\u2019s eyes are open in the light, the act of seeing is involuntary": "\ud83d\udc40\u2728\ud83d\udc68\u200d\ud83e\uddb0\ud83c\udf1e\ud83d\udc41\ufe0f\u27a1\ufe0f\ud83d\udd04", "it\u2019s against my principles to drink with the man I\u2019ve diddled": "\ud83d\ude45\u200d\u2640\ufe0f\ud83c\udf79\ud83d\udeab\ud83d\udc68\u200d\u2764\ufe0f\u200d\ud83d\udc8b\u200d\ud83d\udc68", "beast, boat, or stone, down it goes all incontinently that foul great swallow of his, and perisheth in the bottomless gulf of his paunch": "\ud83d\udc09\ud83d\udee5\ufe0f\ud83e\udea8\u2b07\ufe0f\ud83d\udca8\ud83d\ude31\ud83d\udc94\ud83e\udd22\ud83d\udd73\ufe0f\ud83c\udf7d\ufe0f", "I myself am a savage, owning no allegiance but to the King of the Cannibals": "\ud83e\udd18\ud83c\udffd\ud83d\udc64\ud83c\udfde\ufe0f\ud83e\udd34\ud83c\udffd\ud83c\udf7d\ufe0f\ud83c\udf34\ud83e\udd81", "we whalemen of America now outnumber all the rest of the banded whalemen in the world": "\ud83c\uddfa\ud83c\uddf8\ud83d\udc0b\ud83d\udc68\u200d\u2708\ufe0f\ud83d\udc65\ud83d\udd1d\ud83c\udf0d\ud83c\udf0a\ud83d\udc0b\ud83d\udc65\u2728", "It\u2019s ominous, thinks I.": "\ud83d\ude1f\ud83d\udd2e\ud83e\udd14", "You must go home and be born over again; you don\u2019t know how to cook a whale-steak yet.": "\ud83c\udfe0\u27a1\ufe0f\ud83d\udc76\ud83d\udd04; \ud83e\udd37\u200d\u2642\ufe0f\ud83c\udf73\ud83d\udc0b\ud83e\udd69\u274c", "you had best not be too fastidious in your curiosity touching this Leviathan": "\ud83d\udc64\u274c\u26a1\ufe0f\ud83d\ude0c\ud83d\udd0d\ud83e\udd91\ud83c\udf0a", "be sure, exalted to Jove\u2019s high seat, the great Sperm Whale shall lord it": "\u2705\ud83d\udc51\u27a1\ufe0f\u2601\ufe0f\ud83d\udd1d, \ud83d\udc0b\ud83d\udcaa\ud83d\udc51", "sally out in canoes to give chase to the Leviathan": "\ud83d\udef6\ud83d\udc69\u200d\ud83e\uddb0\ud83c\udfde\ufe0f\u27a1\ufe0f\ud83e\udd91\ud83c\udf0a\ud83d\udc49\ud83d\udc0d", "the plague, as he called it, was at his sole command": "\ud83e\udda0, \ud83e\uddd4\ud83c\udffb\u200d\u2642\ufe0f\ud83d\udc49\ud83d\udde3\ufe0f, \ud83d\udfe1\ud83d\udc41\ufe0f\ud83d\udd74\ufe0f\u2728.", "Such lovely leewardings! They must lead somewhere\u2014to something else than common land, more palmy than the palms.": "\ud83c\udf05\ud83d\udc96\ud83c\udfde\ufe0f\ud83d\udeb6\u200d\u2642\ufe0f\u27a1\ufe0f\ud83d\uddfa\ufe0f\u2728\u27a1\ufe0f\ud83c\udf34\ud83c\udf34\ud83c\udf34\ud83c\udf3f\ud83c\udf1e", "This is my substitute for pistol and ball.": "\ud83d\udd2b\u27a1\ufe0f\u26bd\ufe0f\ud83c\udfb1", "With a long, weary hoist the jaw is dragged on board, as if it were an anchor": "\ud83e\uddd7\u200d\u2642\ufe0f\ud83d\udcaa\ud83d\ude13\u2693\ufe0f\ud83d\udd17\ud83d\udce6", "This weapon is always kept as sharp as possible; and when being used is occasionally honed, just like a razor.": "\ud83d\udde1\ufe0f\u2728\ud83e\ude92\ud83d\udd2a\ud83d\udd27\u2694\ufe0f\ud83d\udca1\ud83e\ude84", "The Titans, they say, hummed snatches when chipping out the craters for volcanoes": "\ud83e\ude90\ud83d\udc79\ud83c\udfb6\ud83e\udea8\ud83d\udd28\ud83c\udf0b\u2728", "the springs and motives which being cunningly presented to me under various disguises, induced me to set about performing the part I did": "\ud83c\udf38\u2728\ud83d\udd75\ufe0f\u200d\u2642\ufe0f\ud83c\udfad\ud83d\udc49\ud83c\udf00\ud83c\udfad\u2753\ud83d\udcad\ud83d\udcbc\ud83d\udd04\ud83c\udfac\ud83d\udcaa\u2728", "Crack, crack, old ship! so long as thou crackest, thou holdest!": "\ud83e\uddb4\ud83d\udd0a\u26f4\ufe0f! \ud83d\udd70\ufe0f\ud83d\udc4b\ud83c\udffd\ud83e\udd5a\ud83d\udca5, \ud83d\udd70\ufe0f\ud83d\udcdc\ud83c\udf0a\ud83c\udf0a!", "How can\u2019st thou endure without being mad?": "\ud83e\udd37\u200d\u2642\ufe0f\ud83d\ude29\u2753\ud83d\ude35\u200d\ud83d\udcab\ud83d\udcad\ud83d\udc94", "At one time the greatest whaling people in the world, the Dutch and Germans are now among the least": "\ud83d\udd70\ufe0f\ud83c\udf0a\ud83d\udc0b\ud83c\uddf3\ud83c\uddf1\ud83d\udc65\ud83e\udd1d\ud83c\udde9\ud83c\uddea\u274c\ud83d\udcc9", "knaves, fools, and murderers there may be": "\ud83e\udd78\ud83e\udd21\ud83d\udd2a", "a dead sperm whale, moored by night to a whaleship at sea": "\ud83d\udc0b\u26b0\ufe0f\ud83c\udf0a\ud83c\udf19\ud83d\udea2\ud83d\udc33", "mark the stranger\u2019s evil eye": "\ud83d\udc41\ufe0f\ud83d\udc64\ud83d\ude08\u2728", "up comes the bucket again, all bubbling like a dairy-maid\u2019s pail of new milk": "\ud83e\udea3\u2b06\ufe0f\ud83d\udca7\ud83d\udca8\ud83e\udd5b\ud83d\udc69\u200d\ud83c\udf3e\u2728", "a newly murdered thing of the sea": "\ud83c\udd95\ud83d\udd2a\ud83d\udc1a\ud83c\udf0a", "Let faith oust fact; let fancy oust memory; I look deep down and do believe.": "\ud83d\ude4f\u270a\ud83d\udcc9\ud83d\udcad\ud83e\uddd8\u200d\u2642\ufe0f\ud83d\udd0d\u2728\ud83d\udc96", "something that regularly begins at the beginning, and is at the middle when midway, and comes to an end at the conclusion": "\ud83d\udd04\ud83d\udcc5\ud83d\udc49\ud83c\udffd\ud83d\udd04\u23f3\ud83d\udeb6\u200d\u2642\ufe0f\u27a1\ufe0f\ud83d\udd1a\ud83d\udcdd", "here was the very spot for cheap lodgings": "\ud83c\udfe1\ud83d\udcb0\ud83d\udecf\ufe0f", "for the millionth time we say amen with Solomon\u2014Verily there is nothing new under the sun": "\ud83e\udd32\ud83d\udcb0\ud83d\udd01\u271d\ufe0f\ud83d\udcad\ud83d\udd76\ufe0f\u2600\ufe0f\u2728", "At last, gush after gush of clotted red gore, as if it had been the purple lees of red wine, shot into the frighted air": "\ud83c\udf77\ud83d\udca7\ud83d\udca6\ud83d\udd34\ud83d\ude31\ud83c\udf2c\ufe0f", "having little or no money in my purse, and nothing particular to interest me on shore, I thought I would sail about a little": "\ud83d\udcb8\ud83d\udc5b\ud83e\ude99\ud83d\udcc9\ud83c\udf0a\ud83d\udee5\ufe0f\ud83c\udf05\ud83e\udd14\ud83d\udcad", "the mother\u2019s pouring milk and blood rivallingly discolour the sea for rods": "\ud83d\udc69\u200d\ud83d\udc67\ud83e\udd5b\ud83e\ude78\ud83c\udf0a\ud83c\udff4\u200d\u2620\ufe0f", "so strange a dreaminess did there then reign all over the ship and all over the sea": "\ud83c\udf0a\ud83d\udef3\ufe0f\ud83d\udcad\u2728\ud83d\ude2e\u200d\ud83d\udca8\ud83c\udf0c\ud83c\udf0a", "But it is not so.": "\ud83d\ude45\u200d\u2642\ufe0f\u274c\u2728", "That same ocean rolls now; that same ocean destroyed the wrecked ships of last year.": "\ud83c\udf0a\u27a1\ufe0f\ud83c\udf0a\ud83d\udc94\ud83d\udea2\ud83d\udd1a\ud83d\udcc5", "that first adventurous little sloop put forth, partly laden with imported cobblestones\u2014so goes the story\u2014to throw at the whales": "\ud83d\udea4\u2728\ud83c\udf0a\ud83e\udea8\ud83d\udc0b", "I think it high time to take that individual aside and argue the point with him.": "\ud83e\udd14\ud83d\udd52\u27a1\ufe0f\ud83d\udeb6\u200d\u2642\ufe0f\ud83d\udc64\ud83d\udc49\ud83d\udcac\u2696\ufe0f\ud83d\udcad\ud83d\udde3\ufe0f", "the tallest boys stand in awe of you": "\ud83d\udc66\ud83d\udc66\ud83c\udffd\ud83d\uddfc\ud83d\ude32\ud83c\udf1f\ud83d\udc96", "that was freely given to the waves": "\ud83c\udf0a\u2728\ud83e\udd32\ud83d\udc99", "this critical act is not always unattended with the saddest and most fatal casualties": "\u26a0\ufe0f\ud83d\udcdc\u274c\ud83d\udc40\ud83d\udc94\ud83d\ude22\ud83d\udc80\ud83d\ude1e", "random allusions to whales": "\ud83d\udd04\ud83c\udf0a\ud83d\udc0b", "Yes, these eyes are windows, and this body of mine is the house. What a pity they didn\u2019t stop up the chinks and the crannies though": "\ud83d\udc41\ufe0f\ud83c\udfe0\ud83d\udc94\ud83d\udeaa\ud83e\ude9f\ud83d\udd0d\ud83c\udf2c\ufe0f", "Fain am I to stagger to this emprise under the weightiest words of the dictionary.": "\ud83d\ude05\ud83d\ude4b\u200d\u2642\ufe0f\u27a1\ufe0f\ud83d\ude35\ud83c\udfcb\ufe0f\u200d\u2642\ufe0f\ud83d\udcbc\ud83d\udcda\ud83d\udcac\ud83d\udcd6", "It was the whiteness of the whale that above all things appalled me.": "\ud83d\udc0b\u26aa\ud83d\ude31", "Every sailor swore he saw it once, but not a second time.": "\ud83c\udf0a\ud83d\udea2\ud83d\udc68\u200d\u2708\ufe0f\ud83d\udde3\ufe0f\ud83d\udc401\ufe0f\u20e3\u274c2\ufe0f\u20e3", "more tight than a harpstring": "\ud83c\udfb8\u27a1\ufe0f\ud83d\udd17\u2764\ufe0f", "I found myself unwittingly squeezing my co-laborers\u2019 hands in it, mistaking their hands for the gentle globules.": "\ud83e\udd32\ud83e\udd1a\ud83e\udd1d\ud83e\udd37\u200d\u2642\ufe0f\ud83d\udcbc\u2728\ud83d\udca6\ud83e\udd1a\ud83d\udc9e\ud83d\udc50", "what matters it, after all?": "\ud83e\udd14\u2753\ud83d\udcad\u2728", "the picture lies thus tranced": "\ud83d\uddbc\ufe0f\ud83e\udd25\ud83d\udca4\u2728", "There is, one knows not what sweet mystery about this sea": "\ud83c\udf0a\ud83e\udd14\u2728\u2753\ud83c\udf6c\ud83d\udd0d", "I am darkness leaping out of light, leaping out of thee!": "\ud83c\udf11\ud83d\udca8\u2728\ud83d\udca5\ud83d\udd7a\ud83d\udcab\ud83e\udec2", "A stark, bewildered feeling, as of death, came over me.": "\ud83d\ude33\ud83c\udf2b\ufe0f\ud83d\ude35\u200d\ud83d\udcab\ud83d\udc80\u2728", "That\u2019s queer, too.": "\ud83e\udd14\ud83c\udf08\u270c\ufe0f", "In his fiery eyes of scorn and triumph, you then saw Ahab in all his fatal pride.": "\ud83d\udd25\ud83d\udc40\ud83d\ude21\ud83c\udfc6\ud83d\udc40\ud83e\uddd1\u200d\u2708\ufe0f\ud83d\ude0e\u26b0\ufe0f\ud83d\udc51", "To scan the lines of his face, or feel the bumps on the head of this Leviathan; this is a thing which no Physiognomist or Phrenologist has as yet undertaken.": "\ud83d\udc41\ufe0f\ud83d\udccf\ud83d\udd8a\ufe0f\ud83d\ude2e\ud83d\udc64\ud83d\udd0d\ud83d\ude33\ud83d\udc68\u200d\ud83d\udd2c\ud83e\udde0\ud83e\uddd1\u200d\ud83d\udd2c\u2696\ufe0f\ud83d\udcad\u2753", "divide the spine": "\u2797 \ud83e\uddb4", "It was a Saturday night in December.": "\ud83c\udf19\ud83c\udf0c\ud83d\udecb\ufe0f\u2744\ufe0f\ud83d\udcc6\u2728", "Drink, ye harpooneers! drink and swear, ye men that man the deathful whaleboat\u2019s bow\u2014Death to Moby Dick!": "\ud83e\udd64\ud83c\udf7b\ud83d\udc68\u200d\u2708\ufe0f\u2693\ufe0f\ud83d\udee5\ufe0f\ud83d\udc80\ud83e\udd88\u2620\ufe0f\ud83d\udc94\ud83d\udc33\ud83d\udd25", "I abandon the glory and distinction of such offices to those who like them.": "\ud83d\ude45\u200d\u2642\ufe0f\ud83c\udfc6\ud83d\udeaa\u2728\ud83d\udc54\u27a1\ufe0f\ud83e\udd37\u200d\u2642\ufe0f\u2764\ufe0f\ud83d\udcdc", "He sleeps in his boots, don\u2019t he?": "\ud83d\ude34\ud83d\udc62\u2753", "the Yankees in one day, collectively, kill more whales than all the English, collectively, in ten years": "\u26be\ufe0f\ud83d\uddfd\u27a1\ufe0f\ud83d\udcc5\ud83d\udd2a\ud83d\udc0b\ud83d\udc94\ud83d\udd1d\ud83c\uddec\ud83c\udde7\ud83e\udd1d\ud83d\udd59\ud83d\udd1f\ud83d\uddd3\ufe0f", "incommunicable contemplations": "\ud83e\udd10\ud83d\udcad\u2728", "this whole enormous boneless mass is as one wad": "\ud83e\udd2f\ud83d\udc50\ud83c\udf56\u27a1\ufe0f1\ud83c\udf00", "I am tormented with an everlasting itch for things remote. I love to sail forbidden seas, and land on barbarous coasts.": "\ud83d\ude23\ud83c\udf0a\ud83d\udd0d\u2728\ud83d\uddfa\ufe0f\u2764\ufe0f\u26f5\ud83d\udeab\ud83c\udf0a\ud83c\udfdd\ufe0f\u2694\ufe0f\ud83c\udf0d", "And after sermon she and I did stay behind them in the pew, and went out by ourselves a good while after them, which we judge a very fine project hereafter to avoyd contention.": "\u26ea\ufe0f\ud83d\udc69\u200d\ud83e\uddb0\ud83e\udd1d\ud83e\ude91\ud83d\udeb6\u200d\u2642\ufe0f\u23f3\ud83c\udfc3\u200d\u2640\ufe0f\ud83d\udca1\ud83d\udcc5\ud83d\udd00\u270c\ufe0f", "Having my old black suit new furbished, I was pretty neat in clothes today, and my boy, his old suit new trimmed, very handsome.": "\ud83d\udc54\ud83d\udda4\u2728\ud83c\udd95\ud83d\udc54\ud83d\udd27\ud83d\udc4c\ud83e\udde5\ud83d\udc66\ud83d\udc54\u26ab\u2728\ud83c\udd95\u2702\ufe0f\ud83d\ude0e", "So to supper, which is also well served in. We had a lobster to supper, with a crabb Pegg Pen sent my wife this afternoon, the reason of which we cannot think; but something there is of plot or design in it, for we have a little while carried ourselves pretty strange to them.": "\ud83c\udf7d\ufe0f\ud83e\udd9e\ud83c\udf7d\ufe0f\ud83e\udd80\ud83d\udce6\ud83e\udd14\ud83d\udcad\ud83d\udd75\ufe0f\u200d\u2640\ufe0f\ud83d\udd75\ufe0f\u200d\u2642\ufe0f", "To the play, where coming late, and meeting with Sir W. Pen, who had got room for my wife and his daughter in the pit, he and I into one of the boxes, and there we sat and heard \u201cThe Little Thiefe,\u201d a pretty play and well done.": "\ud83c\udfad\ud83c\udfc3\u200d\u2642\ufe0f\u23f0\ud83e\udd1d\ud83e\udd35\ud83c\udfad\ud83d\ude4b\u200d\u2640\ufe0f\ud83e\ude91\ud83d\udc67\ud83c\udfad\ud83d\udc68\u200d\ud83e\uddb3\ud83e\udd1d\ud83e\ude91\ud83c\udf9f\ufe0f\ud83c\udfad\ud83d\udc42\ud83d\udc40\ud83d\udc49\ud83c\udfad\ud83e\uddd2\ud83c\udf1f\ud83d\udc4d", "In the middle of the play my Lady Paulina, who had taken physique this morning, had need to go forth, and so I took the poor lady out and carried her to the Grange, and there sent the maid of the house into a room to her, and she did what she had a mind to, and so back.": "\ud83c\udfad\ud83d\udc69\u200d\ud83c\udfa8\ud83e\ude7a\ud83c\udf05\ud83d\udeb6\u200d\u2640\ufe0f\ud83c\udfe1\ud83d\udc67\ud83d\udeaa\u2194\ufe0f\ud83d\ude4f\ud83e\udd13\ud83d\udd19", "In their coach I took them to Islington, and then, after a walk in the fields, I took them to the great cheese-cake house and entertained them, and so home.": "\ud83d\ude8d\u27a1\ufe0f\ud83d\udccd\ud83e\uddcd\u200d\u2642\ufe0f\ud83d\udeb6\u200d\u2642\ufe0f\ud83c\udf3e\u27a1\ufe0f\ud83e\uddc0\ud83c\udf70\ud83c\udfe0\ud83c\udf89\ud83c\udfe0", "Met Mr. Sanchy, Smithes, Gale, and Edlin at the play, but having no great mind to spend money, I left them there.": "\ud83d\udc68\u200d\ud83d\udcbc\ud83c\udfad\ud83d\udc54\ud83d\udc53\ud83c\udf43\ud83d\udcb0\u274c\ud83c\udfc3\u200d\u2642\ufe0f\ud83d\udeaa", "I find myself involuntarily pausing before coffin warehouses, and bringing up the rear of every funeral I meet": "\ud83e\udd14\u23f8\ufe0f\u26b0\ufe0f\ud83c\udfe2\u27a1\ufe0f\ud83d\udeb6\u200d\u2642\ufe0f\u26b0\ufe0f", "a sullen white surf beat against its steep sides; then all collapsed": "\ud83c\udfdd\ufe0f\ud83c\udf0a\ud83e\udd0d\u2601\ufe0f\ud83c\udf0a\ud83d\udd0a\u26f0\ufe0f\u2b07\ufe0f\ud83d\ude1e\ud83d\udc49\u2b07\ufe0f\ud83d\udd1a", "WHALING VOYAGE BY ONE ISHMAEL.": "\ud83d\udc0b\ud83d\udef3\ufe0f\ud83c\udf0a\ud83d\udc64\ud83d\udcdc", "At home and at the office all day.": "\ud83c\udfe0\ud83d\udcbb\ud83c\udfe2\ud83d\udd52", "I made up my mind that if it so turned out that we should sleep together, he must undress and get into bed before I did.": "\ud83e\udde0\ud83e\udd14\u27a1\ufe0f\ud83d\udecf\ufe0f\ud83d\ude34\ud83d\udc49\ud83d\udc55\ud83e\ude73\u27a1\ufe0f\ud83d\udecf\ufe0f\ud83d\udc68\ud83c\udffb\ud83d\udecc\ud83d\udc49\ud83d\udd1c\ud83d\udc68\ud83c\udffc", "if this vast local power in the tendinous tail were not enough, the whole bulk of the leviathan is knit over with a warp and woof of muscular fibres and filaments": "\ud83e\udd14\u2728\ud83d\udcaa\ud83d\udc0b\ud83c\udf00\ud83d\udd17\ud83d\udd0b\ud83c\udf0d\ud83d\udcc8\ud83c\udf0a\ud83d\udd17\ud83d\udcaa\ud83e\uddb4", "By barge Sir George, Sir Williams both and I to Deptford, and there fell to pay off the Drake and Hampshire, then to dinner, Sir George to his lady at his house, and Sir Wm. Pen to Woolwich, and Sir W. Batten and I to the tavern, where much company came to us and our dinner.": "\ud83d\udef6\ud83e\udd34\ud83e\udd34\ud83e\uddd4\u27a1\ufe0f\ud83c\udf0a\u27a1\ufe0f\ud83d\udccd\ud83c\udfaf\ud83c\udf7d\ufe0f\ud83e\udd34\u27a1\ufe0f\ud83d\udc78\ud83c\udfe0\ud83e\udd34\u27a1\ufe0f\ud83d\udccd\ud83c\udf77\ud83e\udd35\ud83e\udd35\u27a1\ufe0f\ud83c\udf7b\u27a1\ufe0f\ud83d\udc65\ud83c\udf7d\ufe0f", "I was much troubled to see a dead man lie floating upon the waters, and had done (they say) these four days, and nobody takes him up to bury him, which is very barbarous.": "\ud83d\ude1f\ud83e\uddd4\u26b0\ufe0f\ud83d\udd0d\ud83c\udf0a\ud83d\udd524\ufe0f\u20e3\ud83d\udcc5\ud83d\udc65\u274c\ud83d\udc46\u26b0\ufe0f\u26b0\ufe0f\ud83d\ude14\ud83d\udd2a", "in that dreamy mood losing all consciousness, at last my soul went out of my body": "\ud83d\ude34\ud83d\udcad\u2728\ud83d\ude0c\ud83e\udde0\u2796\ud83d\ude36\ud83d\udc7b\u27a1\ud83d\udd4a\ufe0f\ud83d\udcab", "And so home to my office, and there did promise to drink no more wine but one glass a meal till Whitsuntide next upon any score.": "\ud83c\udfe0\u27a1\ufe0f\ud83c\udfe2\ud83d\udcdc\ud83c\udf77\ud83d\udeab1\u20e3\ud83e\udd42\ud83c\udf7d\ufe0f\u23f3\ud83d\udd1c\u26ea\ud83d\udd1c\ud83d\udd22\ud83d\udcb0", "The great talk is, that the Spaniards and the Hollanders do intend to set upon the Portuguese by sea, at Lisbon, as soon as our fleet is come away; and by that means our fleet is not likely to come yet these two months or three; which I hope is not true.": "\ud83d\udde3\ufe0f\ud83c\uddea\ud83c\uddf8\ud83e\udd1d\ud83c\uddf3\ud83c\uddf1\u2693\ufe0f\u2694\ufe0f\ud83c\uddf5\ud83c\uddf9\ud83c\udf0a\ud83d\udccd\ud83c\uddf5\ud83c\uddf9\u26f4\ufe0f\ud83d\udee1\ufe0f\ud83d\udcc52\ufe0f\u20e3\ud83d\udd5b\u27953\ufe0f\u20e3\ud83d\ude4f\u274c\u2139\ufe0f\ud83d\ude45\u200d\u2642\ufe0f", "So to dinner, and in comes uncle Fenner and the two Joyces. I sent for a barrel of oysters and a breast of veal roasted, and were very merry; but I cannot down with their dull company and impertinent.": "\ud83c\udf7d\ufe0f\ud83d\udc68\u200d\ud83d\udc66\u200d\ud83d\udc66\ud83e\uddaa\ud83c\udf56\ud83d\ude04\ud83d\ude44\ud83d\ude12", "By the way home and on Ludgate Hill there being a stop I bought two cakes, and they were our supper at home.": "\ud83c\udfe0\ud83d\udee3\ufe0f\u26f0\ufe0f\ud83d\ude8f\ud83d\uded1\ud83c\udf70\ud83c\udf70\ud83c\udf7d\ufe0f\ud83c\udfe1", "Sir George showed me an account in French of the great famine, which is to the greatest extremity in some part of France at this day, which is very strange.": "\ud83e\udd34\ud83d\udcdc\ud83c\uddeb\ud83c\uddf7\ud83d\udcf0\ud83d\udde3\ufe0f\ud83c\udf5e\u27a1\ufe0f\ud83d\ude1e\ud83c\uddeb\ud83c\uddf7\ud83d\udc80\ud83d\udcc5\ud83d\ude32", "Thou knowest not how came ye, hence callest thyself unbegotten": "\ud83d\ude48\ud83e\udd14\u2753\ud83c\udf0c\u27a1\ufe0f\ud83e\uddd9\u200d\u2642\ufe0f\ud83e\udd37\u200d\u2642\ufe0f\u267e\ufe0f", "Through its inexpressible, strange eyes, methought I peeped to secrets which took hold of God.": "\ud83c\udf0c\ud83d\udc41\ufe0f\u200d\ud83d\udde8\ufe0f\ud83e\uddd0\ud83d\udd0d\ud83e\udd2b\u2728\ud83d\ude4f", "a hideous and intolerable allegory": "\ud83d\ude16\u274c\ud83e\udddf\u200d\u2642\ufe0f\ud83d\udcd6", "Yesterday came Col. Talbot with letters from Portugall, that the Queen is resolved to embarque for England this week.": "\ud83d\uddd3\ufe0f\u27a1\ufe0f\ud83e\udd35\ud83d\udcdc\ud83c\uddf5\ud83c\uddf9, \ud83d\udc51\ud83d\udea2\ud83c\uddec\ud83c\udde7\ud83d\udcc5.", "Nippers. Strictly this word is not indigenous to the whale\u2019s vocabulary.": "\ud83d\udd27\u274c\ud83d\udc0b\ud83d\udcd6\u274c\ud83c\ude36", "Hurrah for the white-ash breeze!": "\ud83c\udf89\ud83d\udc4f\u26aa\ud83c\udf3f\ud83d\udca8", "My Lord Windsor came to us to discourse of his affairs, and to take his leave of us; he being to go Governor of Jamaica with this fleet that is now going.": "\ud83d\ude47\u200d\u2642\ufe0f\ud83c\udff0\ud83e\uddd4\u27a1\ufe0f\ud83d\udde3\ufe0f\ud83d\udcdc\u270d\ufe0f\u2708\ufe0f\ud83c\udfdd\ufe0f\ud83e\udee1\u2693\ufe0f\ud83d\udef3\ufe0f\ud83c\udf0a\u231b", "Ye see an old man cut down to the stump; leaning on a shivered lance; propped up on a lonely foot. \u2019Tis Ahab": "\ud83d\udc74\ud83e\ude93\ud83c\udf33\ud83c\udf42\ud83d\udd2a\ud83e\udd3a\ud83e\ude9d\ud83d\udeb6\u200d\u2642\ufe0f\ud83d\udeb6\u200d\u2642\ufe0f\ud83e\uddb6\ud83d\udc94\ud83c\udff4\u200d\u2620\ufe0f", "Late at the office. Home with my mind full of business. So to bed.": "\ud83c\udf06\ud83c\udfe2\ud83d\udc54\ud83d\udcbc\ud83d\udecb\ufe0f\ud83e\udd2f\ud83d\udcad\ud83d\udecf\ufe0f", "were you to turn the whole affair upside down, it would still be pretty much the same thing": "\ud83d\udd04 \ud83e\udd14 \ud83d\udd04 \ud83d\udd04 \ud83e\udd37\u200d\u2642\ufe0f\ud83e\udd37\u200d\u2640\ufe0f \ud83e\udd37 \ud83d\udc81\u200d\u2642\ufe0f\ud83d\udc81\u200d\u2640\ufe0f", "Up early to my lute and a song.": "\ud83d\udd1d\ud83c\udf05\ud83c\udfbc\ud83c\udfb8\ud83c\udfb6", "I look, you look, he looks; we look, ye look, they look.": "\ud83d\udc41\ufe0f\ud83d\udc40\ud83d\udc41\ufe0f\u200d\ud83d\udde8\ufe0f\ud83d\udc40\ud83d\udc41\ufe0f\u200d\ud83d\udde8\ufe0f; \ud83d\udc40\ud83d\udc41\ufe0f\ud83d\udc41\ufe0f\u200d\ud83d\udde8\ufe0f\ud83d\udc40\ud83d\udc41\ufe0f\u200d\ud83d\udde8\ufe0f.", "With Sir W. Pen by water to Deptford; and among the ships now going to Portugall with men and horse, to see them dispatched.": "\ud83e\uddd4\u200d\u2642\ufe0f\ud83d\udea3\u200d\u2642\ufe0f\u27a1\ufe0f\ud83d\udea2\u2693\ud83c\uddf5\ud83c\uddf9\ud83d\udc65\ud83d\udc0e\ud83d\udc40\u2714\ufe0f", "Methinks my body is but the lees of my better being.": "\ud83e\udd14\ud83d\udc49\ud83d\udcaa\ud83e\uddcd\u27a1\ufe0f\u2615\ud83d\udff0\ud83d\udc4d\u27a1\ufe0f\ud83c\udfad\ud83e\udde0", "Captn. Minnes and the other Captains that were with us tell me that negros drowned look white and lose their blackness, which I never heard before.": "\ud83e\uddd1\u200d\u2708\ufe0f\ud83d\udd0d\ud83e\udd3f\u27a1\ufe0f\u26ab\ufe0f\ud83c\udf0a\u27a1\ufe0f\u26aa\ufe0f\ud83d\ude2e", "Do you think the archangel Gabriel thinks anything the less of me": "\ud83e\udd14\ud83d\ude07\ud83e\udd14\ud83d\udcad\ud83d\udc49\ud83e\udd37\u200d\u2642\ufe0f", "And so back to Greenwich by water, and there while something is dressing for our dinner, Sir William and I walked into the Park, where the King hath planted trees and made steps in the hill up to the Castle, which is very magnificent.": "\ud83d\udd19\ud83c\udf0a\ud83d\udee5\ufe0f\u2693\ud83c\udf33\ud83e\udd35\ud83d\udeb6\u200d\u2642\ufe0f\ud83c\udfde\ufe0f\ud83c\udf33\ud83e\udd34\ud83c\udf32\ud83e\ude9c\ud83c\udff0\ud83c\udf1f", "I did get a bever, an old one, but a very good one, of Sir W. Batten, for which I must give him something; but I am very well pleased with it.": "\ud83d\ude04\ud83d\udc4d\ud83e\uddab\ud83d\udc49\ud83d\udc74\u2728\ud83d\udc4c\ud83d\udc64\ud83d\udc3b\ud83d\udcb5\ud83d\ude0a\ud83c\udf81", "ambergris is supposed to be the cause, and by others the effect, of the dyspepsia in the whale": "\ud83c\udfdd\ufe0f\ud83d\udcbc\ud83d\udc0b\u27a1\ufe0f\ud83d\ude16\ud83d\udc0b\ud83d\udcc9", "Now this ambergris is a very curious substance": "\ud83d\udd70\ufe0f\ud83d\udd0d\ud83c\udf0a\ud83d\udc0b\ud83d\udc8e\ud83e\udd14", "My intention being to go this morning to White Hall to hear South, my Lord Chancellor\u2019s chaplain, the famous preacher and oratour of Oxford, it did rain, and the wind against me, that I could by no means get a boat or coach to carry me.": "\ud83c\udf27\ufe0f\ud83d\udeab\ud83d\udee5\ufe0f\ud83d\ude97\ud83d\udca8\u27a1\ufe0f\ud83c\udfdb\ufe0f\ud83d\udc42\ud83d\udc68\u200d\u2696\ufe0f\ud83d\udde3\ufe0f\ud83c\udf93\ud83d\udc49\ud83d\udca8\ud83d\udca8\ud83e\udded\u26d4", "To White Hall to Sir G. Carteret, and so to the Chappell, where I challenged my pew as Clerk of the Privy Seal and had it.": "\ud83c\udfdb\ufe0f\u27a1\ufe0f\ud83e\udd35\u200d\u2642\ufe0f\ud83d\udee1\ufe0f\u27a1\ufe0f\u26ea\ud83e\udeaa\ud83d\udc68\u200d\ud83d\udcbc\ud83d\udd12\ud83d\udcdc\u2714\ufe0f\ud83e\ude91", "Walked home with Mr. Blagrave to his old house in the Fishyard, and there he had a pretty kinswoman that sings, and we did sing some holy things, and afterwards others came in and so I left them, and by water through the bridge (which did trouble me) home.": "\ud83d\udeb6\u200d\u2642\ufe0f\ud83c\udfe0\ud83d\udc68\u200d\ud83e\uddb3\ud83c\udfe1\ud83d\udc1f\ud83e\uddd1\u200d\ud83c\udfa4\ud83c\udfb6\ud83d\ude4f\ud83c\udfb6\u2795\ud83d\udc6b\ud83c\udfa4\u27a1\ufe0f\ud83c\udfe0\ud83d\udea4\ud83c\udf09\ud83d\ude1f\ud83c\udfe0", "I attempted to persuade my wife in bed to go to Brampton this week, but she would not, which troubles me, and seeing that I could keep it no longer from her, I told her that I was resolved to go to Portsmouth tomorrow.": "\ud83d\ude4b\u200d\u2642\ufe0f\ud83d\udcad\ud83d\udcac\ud83d\udc49\ud83d\udc69\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83d\udecc\u27a1\ufe0f\ud83d\ude8c\u27a1\ufe0f\ud83d\uddd3\ufe0f\ud83c\udfd9\ufe0f\ud83d\udeab\ud83d\ude1f\ud83e\udd10\u274c\ud83d\udc49\ud83d\udc69\ud83d\udde3\ufe0f\ud83d\udef3\ufe0f\ud83c\udfd9\ufe0f\u27a1\ufe0f\ud83d\uddd3\ufe0f", "Sir Thos. Crew tells me how my Lady Duchess of Richmond and Castlemaine had a falling out the other day; and she calls the latter Jane Shore, and did hope to see her come to the same end that she did.": "\ud83e\udd35\u200d\u2642\ufe0f\ud83c\udfa9\ud83d\udde3\ufe0f\ud83e\udd14\ud83e\udd37\u200d\u2640\ufe0f\ud83d\udc78\ud83c\udff0\ud83d\ude21\ud83d\udc69\u200d\ud83e\uddb3\ud83d\ude21\ud83d\udc69\ud83d\udcac\u26d3\ufe0f\ud83d\udcad\ud83d\udc40\u27a1\ufe0f\ud83d\udd1a\ud83d\uded1", "you may fancy, for yourself, how it would fare with you, did you sideways survey objects through your ears": "\ud83d\udc42\ud83d\udc40\ud83d\udd04\ud83e\udd14\ud83d\udcd0\ud83d\udd2d\ud83e\uddbb\ud83d\udd0d", "My Lord Crew told me that news was come that the Queen is landed; at which I took leave, and by coach hurried to White Hall, the bells ringing in several places; but I found there no such matter, nor anything like it.": "\ud83d\ude4f\ud83d\udc51\ud83d\udde3\ufe0f\ud83d\udce9\ud83d\udea2\ud83d\udc51\ud83d\udeec; \ud83d\udc4b\ud83d\ude97\ud83d\udca8\ud83c\udfdb\ufe0f\ud83d\udd14\ud83d\udd14\ud83d\udd14\ud83d\udccd\u274c\u2753\ud83d\udcf0\ud83d\udeab\ud83d\udccd\u274c\ud83e\udd37\u200d\u2642\ufe0f.", "see what we whalemen are, and have been": "\ud83d\udc40\ud83c\udf0a\ud83d\udc0b\ud83d\udc68\u200d\u2708\ufe0f\ud83e\udd14\ud83d\udd70\ufe0f", "the word ambergris is but the French compound for grey amber, yet the two substances are quite distinct": "\ud83d\udd24\ud83d\udc0b\ud83c\uddeb\ud83c\uddf7\u2795\u26aa\ud83d\udfe0, \u27a1\ufe0f2\ufe0f\u20e3\ud83e\uddea\ud83d\udeab\u2b07\ufe0f\ud83d\udd04", "If your bitterest foe were walking straight towards you, with dagger uplifted in broad day, you would not be able to see him": "\ud83d\udc40\u274c\ud83e\udd1d\ud83d\udde1\ufe0f\ud83d\udc94\u27a1\ufe0f\ud83d\udc64\ud83d\udd5b\ud83c\udf1e, \ud83d\udc41\ufe0f\u274c\ud83d\udc64", "I cannot bawl very heartily and work very recklessly at one and the same time.": "\ud83d\ude45\u200d\u2642\ufe0f\ud83d\ude22\u2795\ud83d\udcaa\ud83d\ude2e\u200d\ud83d\udca8\u2795\u23f0\u2728\u231b", "After taking leave of my wife, which we could hardly do kindly, because of her mind to go along with me, Sir W. Pen and I took coach and so over the bridge to Lambeth, W. Bodham and Tom Hewet going as clerks to Sir W. Pen, and my Will for me.": "\ud83d\udc4b\u2764\ufe0f\ud83d\ude97\ud83c\udf09\u27a1\ufe0f\ud83c\udfe0\ud83e\uddd4\ud83d\ude97\ud83e\uddd4\ud83d\udcdc\u27a1\ufe0f\ud83e\uddd4\ud83c\udfe2\ud83d\udd0f\ud83e\uddd1", "Such a portentous and mysterious monster roused all my curiosity.": "\ud83d\udc09\ud83e\udd14\ud83d\udc40\u2753", "Utter confusion exists among the historians": "\ud83e\udd2f\ud83e\udd37\u200d\u2642\ufe0f\ud83d\udcda\u2753", "He, among good Storys, telling us a story of the monkey that got hold of the young lady\u2019s cunt as she went to stool to shit, and run from under her coats and got upon the table, which was ready laid for supper after dancing was done.": "\ud83d\ude4a\ud83d\udc81\u200d\u2640\ufe0f\ud83c\udf51\ud83d\udebd\ud83d\udca9\ud83c\udfc3\u200d\u2640\ufe0f\ud83d\udd74\ufe0f\ud83d\udc57\ud83c\udf7d\ufe0f\ud83d\udd7a\ud83d\udc83\ud83c\udf19", "We came to Gilford and there passed our time in the garden, cutting of sparagus for supper, the best that ever I eat in my life but in the house last year.": "\ud83e\uddd1\u200d\ud83e\udd1d\u200d\ud83e\uddd1\ud83c\udfe1\ud83c\udf37\ud83d\udd70\ufe0f\u2702\ufe0f\ud83e\udd66\ud83c\udf7d\ufe0f\ud83d\ude0b\ud83d\udc4d\ud83c\udfe0\ud83d\udd19\ud83d\udd70\ufe0f", "As you behold it, you involuntarily yield the immense superiority to him, in point of pervading dignity.": "\ud83d\udc40\ud83e\udd32\ud83e\udd2f\ud83d\udc51\ud83d\udcc8\ud83d\ude0c\ud83e\uddcd\u200d\u2642\ufe0f\ud83d\udcbc\ud83c\udf0c\u2728", "in the whale the sense of touch is concentrated in the tail": "\ud83d\udc0b\ud83d\udc46\ud83d\udc49\ud83e\uddb5\ud83c\udfaf\ud83d\udeab\ud83d\udd90\ufe0f\ud83d\udc0b\ud83d\udc49\ud83d\udc1f\ud83d\udea9", "this labyrinth is indisputable": "\ud83c\udf0c\ud83c\udf00\u2705", "Up early, and to Petersfield, and there dined well; and thence got a countryman to guide us by Havant, to avoid going through the Forest; but he carried us much out of the way.": "\u2600\ufe0f\u23f0\u27a1\ufe0f\ud83d\ude97\ud83c\udf7d\ufe0f\ud83d\ude0a\u27a1\ufe0f\ud83d\udc68\u200d\ud83c\udf3e\ud83d\uddfa\ufe0f\u27a1\ufe0f\ud83c\udf33\u274c\u27a1\ufe0f\ud83d\ude35\u200d\ud83d\udd04", "to chase that white whale on both sides of land, and over all sides of earth, till he spouts black blood and rolls fin out": "\ud83c\udfc3\u200d\u2642\ufe0f\ud83d\udc0b\u2b1c\ufe0f\ud83c\udf0d\u27a1\ufe0f\ud83c\udf0d\ud83d\udd04\ud83c\udf0a\ud83d\udd04\ud83c\udf2a\ufe0f\ud83e\ude78\u26ab\ud83d\udc0b\ud83c\udf00", "the audacity of these corsairs has of late been somewhat repressed": "\ud83d\ude32\ud83c\udff4\u200d\u2620\ufe0f\ud83d\udcaa\ud83d\udca5\ud83d\udcc9", "Upon our coming we sent away an express to Sir W. Batten to stop his coming, which I did project to make good my oath, that my wife should come if any of our wives came, which my Lady Batten did intend to do with her husband.": "\ud83d\udcc5\u27a1\ufe0f\ud83d\udce8\u2709\ufe0f\ud83d\udeab\ud83d\udc68\u200d\u2708\ufe0fSir W. Batten\ud83d\uded1\u27a1\ufe0f\ud83d\udeb6\u200d\u2642\ufe0f\ud83d\udcc5\ud83e\udd14\ud83e\udd1e\ud83d\udc8d\ud83d\udc69\u2696\ufe0f\ud83d\udeaa\ud83d\udc70\ud83e\uddcd\u200d\u2640\ufe0f\ud83e\uddd1\u200d\ud83e\udd1d\u200d\ud83e\uddd1\ud83d\udeaa,\ud83d\udc70Lady Batten\ud83d\udcc5\ud83d\udc6b\ud83d\udcc5\ud83d\ude4b\u200d\u2640\ufe0f\ud83e\uddd4\u2693\ufe0f", "we thus tore a white gash in the sea, on all sides menaced as we flew, by the crazed creatures to and fro rushing about us": "\ud83c\udf0a\ud83e\ude78\u26f5\ufe0f\u2693\ufe0f\ud83c\udf0a\ud83e\udd2f\ud83d\udc1f\u2694\ufe0f\ud83d\udca8\ud83d\udca5\ud83d\udea4\ud83d\ude28\ud83c\udf00", "The Doctor and I lay together at Wiard\u2019s, the chyrurgeon\u2019s, in Portsmouth, his wife a very pretty woman.": "\ud83e\uddd1\u200d\u2695\ufe0f\ud83d\udecc\ud83e\uddd1\ud83d\udccd\ud83d\udc91\u27a1\ufe0f\ud83e\ude7a\ud83c\udfe0,\ud83d\udc69\u200d\u2695\ufe0f\ud83c\udfe2,\ud83d\udccd\ud83d\udea2\ud83c\udf0a,\ud83d\udc70\ud83d\ude0a\ud83d\udc69", "in the forehead\u2019s wrinkles, you seem to track the antlered thoughts descending there to drink, as the Highland hunters track the snow prints of the deer": "\ud83d\udc74\ud83e\udd14\ud83e\udd8c\ud83d\udcad\u2b07\ufe0f\ud83d\udeb6\u200d\u2642\ufe0f\ud83c\udf28\ufe0f\ud83e\udd8c\ud83d\udc63\ud83c\udff4\ud83e\udd8c\ud83d\udd75\ufe0f\u200d\u2642\ufe0f", "when they stood their long night watches, his officers and men must have some nearer things to think of than Moby Dick": "\ud83c\udf19\ud83d\udc40\ud83d\udd70\ufe0f\u27a1\ufe0f\ud83d\ude34\ud83c\udfa3\ud83d\udc68\u200d\u2708\ufe0f\ud83d\udc68\u200d\ud83e\uddb1\ud83e\udd14\u2795\u27a1\ufe0f\ud83d\udc0b", "We lay very well and merrily; in the morning, concluding him to be of the eldest blood and house of the Clerkes, because that all the fleas came to him and not to me.": "\ud83d\ude34\ud83c\udf89\ud83c\udf1e\ud83e\udd14\ud83e\ude78\ud83c\udfe0\ud83e\udd9f\u27a1\ufe0f\ud83e\uddcd\u200d\u2642\ufe0f\ud83d\udeab\ud83e\uddcd\u200d\u2642\ufe0f", "the main body of the crew striking up a wild chorus, now commence heaving in one dense crowd at the windlass": "\ud83e\uddd1\u200d\ud83d\ude80\ud83d\udc65\ud83c\udfb6\ud83c\udf3f\ud83d\ude4c\ud83d\udeb6\u200d\u2642\ufe0f\ud83d\udc65\u2693\ufe0f", "All of us to the Pay-house; but the books not being ready, we went to church to the lecture, where there was my Lord Ormond and Manchester, and much London company, though not so much as I expected.": "\ud83d\udc65\u27a1\ufe0f\ud83c\udfe6; \ud83d\udcda\u274c\u23f3, \u27a1\ufe0f\u26ea\ud83c\udfa4, \ud83d\udc40\ud83e\udd34\ud83d\udd74\ufe0f&\ud83c\udf06\ud83e\uddd1\u200d\ud83e\udd1d\u200d\ud83e\uddd1, \ud83e\udd14\u274c\ud83d\udcc8.", "It flashed like a bleached bone. What the devil\u2019s the matter with me?": "\u26a1\ufe0f\ud83d\udc80\u2753\ud83d\ude08\u2753", "W. Pen and I walked to the King\u2019s Yard, and there lay at Mr. Tippets\u2019s, where exceeding well treated.": "\ud83d\udc6b\ud83d\udeb6\u200d\u2642\ufe0f\u27a1\ufe0f\ud83d\udc51\ud83d\udee4\ufe0f, \ud83c\udfe1\ud83d\udccdMr.\ud83c\udf7d\ufe0f, \ud83d\ude0a\ud83e\udd1d", "the wild thrilling sounds that were heard, were the voices of newly drowned men in the sea": "\ud83c\udf0a\ud83d\udd0a\ud83d\ude31\ud83d\udc65\ud83d\udd0a, \ud83d\udc64\ud83d\udd0a\ud83d\udc65\ud83c\udf0a", "I now demand of you to speak out": "\ud83e\udef4\ud83d\udde3\ufe0f\u2757", "I don\u2019t fancy having a man smoking in bed with me. It\u2019s dangerous. Besides, I ain\u2019t insured.": "\ud83d\udeab\ud83d\udc68\ud83d\udeac\ud83d\udecf\ufe0f\ud83d\ude33\ud83d\udd25\u274c\ud83d\ude2c\ud83d\udcbc", "But who could show a cheek like Queequeg?": "\ud83e\udd14\ud83e\udd37\u200d\u2642\ufe0f\ud83c\udfad\ud83e\uddd4", "All the morning at Portsmouth, at the Pay, and then to dinner, and again to the Pay.": "\ud83c\udf05\u23f0\u27a1\ufe0f\u2693\ud83d\udcb0\u27a1\ufe0f\ud83c\udf7d\ufe0f\u27a1\ufe0f\ud83d\udcb0", "Got the Doctor to go lie with me, and much pleased with his company; but I was much troubled in my eyes, by reason of the healths I have this day been forced to drink.": "\ud83d\udc68\u200d\u2695\ufe0f\u27a1\ufe0f\ud83d\udecc\ud83d\ude0a\ud83d\udc40\ud83d\ude29\ud83c\udf77\ud83e\udd42\ud83d\udd2b\ud83c\udf7b", "the harpoon, whose other naked, barbed end slopingly projects from the prow": "\ud83e\ude9d\u27a1\ufe0f\ud83d\udee5\ufe0f\ud83d\udccf", "Sir George and I, and his clerk Mr. Stephens, and Mr. Holt our guide, over to Gosport; and so rode to Southampton.": "\ud83e\udd34\ud83d\udc68\u200d\ud83d\udcbc\ud83e\uddd1\u200d\ud83d\udcbc+\ud83c\udfc7\u2192\ud83d\uddfa\ufe0f\ud83d\udeb4\u200d\u2642\ufe0f\u2192\ud83d\udccd", "In our way, besides my Lord Southampton\u2019s parks and lands, which in one view we could see 6,000l. per annum, we observed a little church-yard, where the graves are accustomed to be all sowed with sage.": "\ud83c\udfde\ufe0f\ud83d\udee4\ufe0f\ud83d\udc51\ud83d\udc406\ufe0f\u20e30\ufe0f\u20e30\ufe0f\u20e30\ufe0f\u20e3\ud83d\udcb7/\ud83d\udcc5\u26ea\ufe0f\ud83e\udea6\ud83c\udf3f", "A sound like the moaning in squadrons over Asphaltites of unforgiven ghosts of Gomorrah, ran shuddering through the air.": "\ud83d\udd0a\ud83d\udc7b\ud83c\udf2b\ufe0f\ud83d\udee3\ufe0f\ud83e\udea6\ud83c\udff4\u200d\u2620\ufe0f\ud83c\udf00\ud83d\ude28\ud83d\udca8", "At Southampton we went to the Mayor\u2019s and there dined, and had sturgeon of their own catching the last week, which do not happen in twenty years, and it was well ordered.": "\ud83c\udfd9\ufe0f\ud83c\udf74\ud83d\udc68\u200d\u2696\ufe0f\ud83c\udf7d\ufe0f\ud83d\udc1f\u23f3\ud83d\uddd3\ufe0f2\ufe0f\u20e30\ufe0f\u20e3\ud83d\uddd3\ufe0f\ud83d\udc4c", "They brought us also some caveare, which I attempted to order, but all to no purpose, for they had neither given it salt enough, nor are the seedes of the roe broke, but are all in berryes.": "\ud83d\udc65\ud83d\udecd\ufe0f\ud83d\udc1f\ud83e\uddc2\u274c\u26a0\ufe0f\ud83e\udd44\u274c\ud83c\udf0a\ud83e\udd5a\ud83d\udfe0\ud83d\udd0d\ud83d\udcc9\ud83c\udf47", "The towne is one most gallant street, and is walled round with stone, &c., and Bevis\u2019s picture upon one of the gates; many old walls of religious houses, and the key, well worth seeing.": "\ud83c\udfd9\ufe0f\ud83c\udfdb\ufe0f\ud83d\udd1d\ud83d\udee4\ufe0f\ud83c\udfd7\ufe0f\ud83e\uddf1\ud83d\udd04\u2694\ufe0f\ud83e\uddf1\ud83d\uddbc\ufe0f\ud83d\udeaa\ud83c\udff0\ud83c\udfdb\ufe0f\ud83d\udd4d\ud83d\udc40\ud83d\udc41\ufe0f", "After dinner to horse again, being in nothing troubled but the badness of my hat, which I borrowed to save my beaver.": "\ud83c\udf7d\ufe0f\u27a1\ufe0f\ud83d\udc0e\ud83d\udd19\ud83d\ude0c\ud83d\udeab\ud83d\ude1f\ud83e\udde2\ud83d\ude1e\ud83d\udcc9\ud83c\udfa9\ud83d\udd04\ud83d\udcb0\ud83e\uddab", "I always go to sea as a sailor, because they make a point of paying me for my trouble, whereas they never pay passengers a single penny": "\ud83e\udded\ud83d\udea2\ud83e\uddd1\u200d\u2708\ufe0f\ud83d\udcb0\u27a1\ufe0f\ud83d\ude0c\ud83d\udcbc\u274c\ud83e\uddf3\ud83d\udcb8", "prevent all communications": "\ud83d\udeab\ud83d\udcde\ud83d\udce7\ud83d\udcac", "The more I consider this mighty tail, the more do I deplore my inability to express it.": "\ud83e\udd14\ud83d\udc0b\ud83d\udc49\ud83d\ude14\ud83d\udcc9\ud83d\udde3\ufe0f\u2757", "Sir W. Pen got trimmed before me, and so took the coach to Portsmouth to wait on my Lord Steward to church, and sent the coach for me back again.": "\ud83e\udd35\u2702\ufe0f\ud83d\udeb6\u200d\u2642\ufe0f\u27a1\ufe0f\ud83d\ude8c\u27a1\ufe0f\ud83c\udfd9\ufe0f\u27a1\ufe0f\u26ea\ud83d\udc51\u2b05\ufe0f\ud83d\ude8c\u21a9\ufe0f", "her only friend her bitterest foe": "\ud83d\udc69\u200d\u2764\ufe0f\u200d\ud83d\udc69\ud83d\udd04\ud83d\ude20", "At chappell we had a most excellent and eloquent sermon. And here I spoke and saluted Mrs. Pierce, but being in haste could not learn of her where her lodgings are, which vexes me.": "\u26ea\ud83d\udc4d\ud83d\udde3\ufe0f\ud83d\udcdc\ud83d\ude0a\ud83d\ude4b\u200d\u2642\ufe0f\ud83e\udd1d\ud83d\udc69\u200d\ud83e\uddb3\ud83c\udfc3\u2753\ud83c\udfe0\ud83d\ude24", "the rest were buried before they died; you sail upon their tomb": "\ud83d\udc80\u26b0\ufe0f\u23f3\u26f5\u26b0\ufe0f", "After dinner Sir W. Batten and I, the Doctor, and Ned Pickering by coach to the Yard, and there on board the Swallow in the dock hear our navy chaplain preach a sad sermon, full of nonsense and false Latin; but prayed for the Right Honourable the principal officers.": "\ud83c\udf7d\ufe0f\ud83d\udc1f\ud83d\udeb6\u200d\u2642\ufe0f\ud83d\udd2c\ud83e\uddd1\u200d\u2695\ufe0f\ud83d\ude96\ud83c\udfe0\ud83d\udea2\ud83d\udde3\ufe0f\ud83d\ude14\ud83d\udcdc\ud83e\udd26\u200d\u2642\ufe0f\ud83d\udc4e\ud83d\ude4f\ud83e\udd35\ud83d\udd25", "Back again by coach to Portsmouth, and then visited the Mayor, Mr. Timbrell, our anchor-smith, who showed us the present they have for the Queen; which is a salt-sellar of silver, the walls christall, with four eagles and four greyhounds standing up at the top to bear up a dish.": "\ud83d\udd19\ud83d\ude8c\u27a1\ufe0f\ud83d\udef3\ufe0f\ud83c\udfd9\ufe0f,\ud83d\udc68\u200d\u2696\ufe0f\ud83e\udd1d\ud83d\udc68\u200d\ud83d\udd27\ud83d\udee0\ufe0f\ud83c\udf81\ud83d\udc78; \ud83e\uddc2\u26d3\ufe0f\ud83e\udd48\ud83c\udff0\ud83d\udc8e,\ud83e\udd85\ud83e\udd85\ud83e\udd85\ud83e\udd85\ud83d\udc15\ud83d\udc15\ud83d\udc15\ud83d\udc15\u2b06\ufe0f\ud83c\udf7d\ufe0f.", "tormented to madness, he was now churning through the water, violently flailing with his flexible tail": "\ud83d\ude29\ud83e\udd2f\ud83c\udf0a\ud83e\udd38\u200d\u2642\ufe0f\ud83d\udd04\ud83d\udc1f", "The Doctor and I begun philosophy discourse exceeding pleasant. He offers to bring me into the college of virtuosoes and my Lord Brouncker\u2019s acquaintance, and to show me some anatomy, which makes me very glad; and I shall endeavour it when I come to London.": "\ud83e\uddd1\u200d\u2695\ufe0f\ud83e\udd1d\ud83d\ude0a\ud83c\udf93\ud83d\udde3\ufe0f\ud83d\udcda\ud83d\udd74\ufe0f\ud83e\uddd1\u200d\ud83c\udfeb\ud83d\udd2c\ud83d\udc40\ud83c\udfdb\ufe0f\ud83e\udec0\ud83d\ude04\ud83d\udc49\ud83d\udd70\ufe0f\ud83c\udfd9\ufe0f\ud83d\udee4\ufe0f\ud83d\udc49\ud83c\uddec\ud83c\udde7\ud83d\udccd", "Then comes the Doctor, and we carried them by coach to their lodging, which was very poor, but the best they could get, and such as made much mirth among us.": "\ud83d\udd70\ufe0f\u27a1\ufe0f\ud83d\udc68\u200d\u2695\ufe0f\ud83e\ude7a\ud83d\ude8d\ud83c\udfe1\u27a1\ufe0f\ud83d\ude02", "There\u2019s a most doleful and most mocking funeral! The sea-vultures all in pious mourning, the air-sharks all punctiliously in black or speckled.": "\u26b0\ufe0f\ud83c\udf0a\ud83e\udd85\ud83d\udda4\ud83e\udd88\u2b1b\ud83d\udd32", "I went to the ladies, and there took them and walked to the Mayor\u2019s to show them the present, and then to the Dock, where Mr. Tippets made much of them, and thence back again, the Doctor being come to us to their lodgings.": "\ud83d\udc69\u200d\ud83e\uddb0\u27a1\ufe0f\ud83d\udeba\ud83d\udeb6\u200d\u2640\ufe0f\u27a1\ufe0f\ud83d\udc68\u200d\ud83d\udcbc\ud83c\udfe0\ud83d\uddbc\u27a1\ufe0f\ud83c\udfd7\ud83d\udef3\ud83e\udd1d\u27a1\ufe0f\ud83d\udd19\ud83d\udc68\u200d\u2695\ufe0f\ud83c\udfe0", "Homewards, and called in at Antony Joyce\u2019s, where we found his wife brought home sick from church, and was in a convulsion fit.": "\ud83c\udfe0\u27a1\ufe0f\ud83d\udc68\u200d\ud83d\udc69\u200d\ud83d\udc66\ud83c\udfe0\ud83e\udd12\ud83d\ude91\ud83c\udfe5\u26ea\ufe0f\ud83d\ude37\ud83d\ude35\u200d\ud83d\udcab", "My arme not being well, I staid within all the morning, and dined alone at home, my wife being gone out to buy some things for herself, and a gown for me to dress myself in.": "\ud83e\uddbe\ud83d\udeab\ud83c\udfe0\ud83c\udf05\ud83c\udf7d\ufe0f\ud83c\udfe0\ud83d\ude4d\u200d\u2642\ufe0f\ud83d\udeab\ud83d\udc69\u200d\ud83e\uddb0\ud83c\udfec\ud83d\udc5c\ud83d\udc57\ud83d\udc68\u200d\ud83e\uddb0\ud83d\udc57", "How then is this? Are the green fields gone? What do they here?": "\ud83e\udd14\ud83c\udf3f\ud83c\udfde\ufe0f\ud83d\udc49\u26d4\u2753\ud83e\udd37\u200d\u2642\ufe0f\ud83d\udc40\ud83d\uddfa\ufe0f\u2753", "This morning I got my seat set up on the leads, which pleases me well.": "\u2600\ufe0f\u23f0\ud83d\udeb6\u200d\u2642\ufe0f-->\ud83e\ude91\ud83d\udd27\ud83d\ude80\ud83c\udfc6\ud83d\ude0a", "I find it a hard matter to settle to business after so much leisure and pleasure.": "\ud83e\udd14\ud83d\ude13\ud83d\udcbc\ud83e\udd2f\ud83c\udf89", "Went to Mrs. Turner\u2019s: and thence found her out at the Theatre, where I saw the last act of the \u201cKnight of the Burning Pestle,\u201d which pleased me not at all.": "\ud83c\udfe0\u27a1\ufe0f\ud83d\udc75\u274c\ud83c\udfad\u27a1\ufe0f\ud83d\udc40\ud83c\udfad\ud83c\udfad\ud83d\udee1\ufe0f\ud83d\udd25\ud83d\udd28\u274c\ud83d\ude42", "And so after the play done, she and The. Turner and Mrs. Lucin and I, in her coach to the Park; and there found them out, and spoke to them; and observed many fine ladies, and staid till all were gone almost.": "\ud83c\udfad\u27a1\ufe0f\ud83d\ude97\ud83d\udc69\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83d\udc6b\ud83c\udfde\ufe0f\ud83d\udc40\ud83d\udc4b\ud83d\udc83\u2728\u23f3\ud83d\udeb6\u200d\u2640\ufe0f\ud83d\udc57\ud83d\udd52\u23f3", "And when it comes to sleeping with an unknown stranger, in a strange inn, in a strange town, and that stranger a harpooneer, then your objections indefinitely multiply": "\ud83d\ude34\ud83e\udd14\ud83c\udf03\ud83c\udfe8\ud83d\udecc\ud83e\udd37\u200d\u2642\ufe0f\ud83c\udf06\ud83d\udc64\ud83d\udca5\ud83d\udd2a\ud83d\ude31\u2795\u2795\u2795", "Sperm, sperm\u2019s the play! This at least is duty; duty and profit hand in hand.": "\ud83d\udc1f\ud83c\udfad! \u270b\ud83c\udfad\ud83d\udcc8\u270b\ud83d\udd90\ufe0f\ud83d\udcbc\u270b\ud83e\udd1d\ud83d\udcbc.", "Sir G Carteret told me that the Queen and the fleet were in Mount\u2019s Bay on Monday last, and that the Queen endures her sickness pretty well.": "\ud83e\udd35\u200d\u2642\ufe0f\ud83c\uddec\ud83c\udde7\ud83d\udc51\ud83d\udea2\ud83c\udf0a\u26f0\ufe0f\ud83d\udcc5\ud83d\udc69\u200d\u2695\ufe0f\ud83c\udfe5\ud83e\udd12\ud83d\ude42", "He also told me how Sir John Lawson hath done some execution upon the Turks in the Straight, of which I am glad, and told the news the first on the Exchange, and was much followed by merchants to tell it.": "\ud83d\udc68\u200d\ud83d\udcbc\ud83d\udde3\ufe0f\ud83d\udde1\ufe0f\u2694\ufe0f\ud83d\udd4c\u26f4\ufe0f\ud83c\udf0a\ud83d\ude0a\ud83d\udcf0\u2728\ud83c\udfe2\ud83d\udd25\ud83d\udd74\ufe0f\ud83d\udcbc\ud83d\udc65\ud83d\udd00\ud83d\udcc8", "Sir G. Carteret comes, and he and I walked in the garden, and, among other discourse, tells me that it is Mr. Coventry that is to come to us as a Commissioner of the Navy; at which he is much vexed, and cries out upon Sir W. Pen, and threatens him highly.": "\ud83d\udc68\u200d\u2708\ufe0f\ud83c\udfdb\ufe0f\ud83d\udeb6\u200d\u2642\ufe0f\ud83c\udf33\ud83d\udde3\ufe0f\ud83e\udd1d\ud83d\udcdc\ud83d\udc68\u200d\ud83d\udcbb\ud83d\udea2\ud83d\ude20\ud83d\ude21\ud83e\udd2c\ud83d\udd0a\ud83d\udc74\u2693\ud83d\udd2a", "And looking upon his lodgings, which are now enlarging, he in passion cried, \u201cGuarda mi spada; for, by God, I may chance to keep him in Ireland, when he is there:\u201d for Sir W. Pen is going thither with my Lord Lieutenant. But it is my design to keep much in with Sir George.": "\ud83d\udc40\ud83c\udfe0\u27a1\ufe0f\ud83d\udccf\ud83d\ude2d\ud83d\udcac\ud83d\udc40\ud83d\udde1\ufe0f\ud83d\ude4f\ud83c\uddee\ud83c\uddea\ud83d\udd12\ud83d\udc68\u200d\u2708\ufe0f\ud83d\udeeb\u2708\ufe0f\u27a1\ufe0f\ud83c\uddee\ud83c\uddea\ud83d\udd04\ud83d\udc68\u200d\u2708\ufe0f\ud83e\udd1d\ud83d\udc68\u200d\u2708\ufe0f", "Foolish toy! babies\u2019 plaything of haughty Admirals, and Commodores, and Captains; the world brags of thee, of thy cunning and might": "\ud83e\udd21\ud83e\uddf8\ud83d\udc76\u2693\ufe0f\ud83e\uddd4\u200d\u2642\ufe0f\ud83c\udfa9\ud83c\udf0d\ud83c\udfa9\ud83e\udd39\u200d\u2642\ufe0f\ud83d\udcaa", "Moby Dick seeks thee not. It is thou, thou, that madly seekest him!": "\ud83d\udc0b\ud83d\udd0d\u274c\ud83d\udc64\u2716\ufe0f\ud83d\udd01\ud83d\udc64\ud83d\udd0d\ud83e\udd2a\ud83d\udd0d\ud83d\udc33", "To White Hall; and there walked an hour or two in the Park, where I saw the King now out of mourning, in a suit laced with gold and silver, which it was said was out of fashion.": "\ud83d\udc51\u27a1\ufe0f\ud83c\udfdb\ufe0f\ud83d\udeb6\u200d\u2642\ufe0f\u23f2\ufe0f2\ufe0f\u20e3\u23f0\ud83c\udf33\ud83c\udfde\ufe0f\ud83d\udc40\ud83e\udd34\ud83d\ude14\u27a1\ufe0f\ud83d\ude04\ud83d\udc57\ud83d\udc57\u2728\ud83d\udcb0\ud83e\ude99\ud83d\udc40\ud83d\udde3\ufe0f\u274c\ud83d\udd70\ufe0f", "To the Wardrobe; and there consulted with the ladies about our going to Hampton Court tomorrow, and thence home, and after settled business there my wife and I to the Wardrobe.": "\ud83d\udeaa\ud83d\udc5a\ud83d\udc57\ud83e\udd14\ud83d\udc69\ud83d\udc69\u200d\ud83e\uddb1\u27a1\ufe0f\ud83c\udff0\ud83d\udcc5\u27a1\ufe0f\ud83c\udfe0\ud83e\udd1d\ud83d\udcc8\ud83d\udc69\u200d\u2764\ufe0f\u200d\ud83d\udc68\u27a1\ufe0f\ud83d\udeaa", "some invisible, gracious agency preserved me": "\ud83e\udee5\u2728\ud83d\ude4f\ud83d\udee1\ufe0f\ud83d\ude0a", "And so to barge again, and there we had good victuals and wine, and were very merry; and got home very well.": "\ud83c\udfdb\ufe0f\u27a1\ufe0f\u26f4\ufe0f\ud83c\udf7d\ufe0f\ud83c\udf77\ud83d\ude0a\ud83c\udfe0\u2714\ufe0f", "In vain, oh, ye strangers, ye fly our sad burial; ye but turn us your taffrail to show us your coffin!": "\ud83e\udea6\ud83d\ude14\ud83d\udc65\ud83c\udf0a\ud83d\udca8\ud83e\udea6\u26b1\ufe0f", "To walk to Pauls churchyard, and there evened all reckonings to this day.": "\ud83d\udeb6\u200d\u2642\ufe0f\u27a1\ufe0f\u26ea\ufe0f\u2696\ufe0f\ud83d\udcc5\ud83d\udc4d", "they, in the heathenish sharked waters, and by the beaches of unrecorded, javelin islands, battled with virgin wonders and terrors": "\ud83e\uddd1\u200d\ud83e\udd1d\u200d\ud83e\uddd1\ud83c\udf0a\ud83e\udd88\ud83c\udfdd\ufe0f\ud83c\udfd6\ufe0f\u2694\ufe0f\ud83e\udeb6\ud83d\ude32\ud83d\ude28", "I knew no one in the place.": "\ud83d\udc64\u274c1\ufe0f\u20e3\ud83d\udc65\ud83c\udf0d\u2716\ufe0f\ud83c\udfe0", "To my brother\u2019s, and finding him in a lie about the lining of my new morning gown, saying that it was the same with the outside, I was very angry with him and parted so.": "\ud83d\udc68\u200d\ud83d\udc66\u27a1\ufe0f\ud83c\udfe0\ud83e\udd25\ud83e\udde5\ud83d\ude21\ud83d\udc50", "Home, and there came Mr. Morelock of Chatham, and brought me a stately cake, and I perceive he has done the same to the rest, of which I was glad.": "\ud83c\udfe0, \u2795 \ud83e\uddd1\u200d\ud83d\udcbc\u27a1\ufe0f\ud83e\uddd4\u200d\u2642\ufe0f\ud83c\udfe0\ud83d\udccd\ud83c\udfd8\ufe0f, \u2795 \ud83c\udf81 \ud83c\udf82, \u2795 \ud83d\udc40\ud83d\ude03 \u27a1\ufe0f \u2b07\ufe0f, \ud83d\ude04", "spasmodically dilating and contracting his spout-hole, with sharp, cracking, agonized respirations": "\ud83d\udc0b\ud83d\udd01\u2b06\ufe0f\u2b07\ufe0f\ud83d\ude2e\u200d\ud83d\udca8\ud83d\udca5\ud83d\ude16\ud83d\ude24", "those grand fresh-water seas of ours,\u2014Erie, and Ontario, and Huron, and Superior, and Michigan,\u2014possess an ocean-like expansiveness, with many of the ocean\u2019s noblest traits": "\ud83c\udf0a\ud83c\udf0a\ud83c\uddfa\ud83c\uddf8\ud83d\udd1d\ud83c\udf0a\ud83c\udf0a\ud83d\udc40\ud83c\udf0a\ud83c\udf0a\ud83c\udfdd\ufe0f\ud83c\udf0a\ud83c\udf0a\ud83c\udf0a\ud83c\udf0a\u26f4\ufe0f\ud83c\udf0a\ud83c\udf0a\ud83c\udf0a\ud83c\udf24\ufe0f\ud83c\udf0a\ud83c\udf0a\ud83c\udf0a\ud83c\udf0a\ud83c\udf0a\ud83c\udf0a", "We two watchmen never rest.": "\ud83d\udc6b\ud83d\udc40\u23f2\ufe0f\ud83d\udeab\ud83d\udecc\ud83d\udd1a", "I pondered some time without fully comprehending the reason for this.": "\ud83e\udd14\u23f3\u2753\ud83e\udd37\u200d\u2642\ufe0f\ud83d\udcad", "I found a number of young seamen": "\ud83d\udd0d\u27a1\ufe0f#\ufe0f\u20e3\ud83d\udc66\ud83e\uddd1\u200d\u2708\ufe0f\ud83c\udf0a", "All the bells of the town rung, and bonfires made for the joy of the Queen\u2019s arrival, who came and landed at Portsmouth last night.": "\ud83d\udd14\ud83d\udd14\ud83c\udfd9\ufe0f\ud83c\udf89\ud83d\udd25\ud83d\udc51\ud83d\ude0a\ud83d\udea2\ud83d\udccd\ud83c\udf03", "But I do not see much thorough joy, but only an indifferent one, in the hearts of people, who are much discontented at the pride and luxury of the Court, and running in debt.": "\ud83e\udd14\ud83d\ude15\ud83d\ude10\ud83d\udc94\ud83d\ude1e\ud83d\udc51\ud83e\udd11\ud83d\udcb8\ud83c\udfc3\u200d\u2642\ufe0f\ud83d\udcb3", "Where unrecorded names and navies rust, and untold hopes and anchors rot": "\ud83c\udf0a\u2753\ud83d\udea2\u2693\ud83c\udf0c\u26d3\ufe0f\ud83d\udee0\ufe0f\ud83d\udcad\ud83d\udc94", "life dies sunwards full of faith; but see! no sooner dead, than death whirls round the corpse, and it heads some other way": "\ud83c\udf31\ud83c\udf1e\ud83d\ude4f; \ud83d\udc40! \ud83d\udc80, \u26b0\ufe0f\ud83d\udcab\ud83d\udd04, \ud83d\udeb6\u200d\u2642\ufe0f\ud83e\udded\u27a1\ufe0f\u21a9\ufe0f.", "with my shoulders leaning against the slackened royal shrouds, to and fro I idly swayed in what seemed an enchanted air": "\ud83e\uddcd\u200d\u2642\ufe0f\ud83e\udea2\ud83d\udc51\ud83c\udf2c\ufe0f\ud83d\udd04\u2728\ud83c\udf2c\ufe0f", "Up early, Mr. Hater and I to the office, and there I made an end of my book of contracts which I have been making an abstract of.": "\u23f0\u2600\ufe0f\ud83d\udc68\u200d\ud83d\udcbc\u27a1\ufe0f\ud83c\udfe2\u270d\ufe0f\ud83d\udcda\ud83d\udcc4\ud83d\udd1a", "To Moorefields, and walked and eat some cheesecake and gammon of bacon, but when I was come home I was sick, forced to vomit it up again.": "\ud83d\udc49\ud83d\udeb6\u200d\u2642\ufe0f\ud83c\udf70\ud83e\udd53\ud83e\udd22\ud83e\udd2e\ud83c\udfe0", "even this wears off in time": "\ud83d\udd70\ufe0f\u27a1\ufe0f\ud83d\udee1\ufe0f\ud83d\ude1e\u23f3", "My wife and I by coach to the Opera, and there saw the 2nd part of \u201cThe Siege of Rhodes,\u201d but it is not so well done as when Roxalana was there, who, it is said, is now owned by my Lord of Oxford.": "\ud83d\udc69\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83d\ude8c\ud83c\udfad\ud83d\udc402\ufe0f\u20e3\ud83c\udfad\ud83c\udfb5\ud83c\udff0\ud83c\uddec\ud83c\uddf7\ud83d\ude15\ud83c\udfdb\ufe0f\ud83d\udc78\u2728\ud83d\udc42\ud83d\udcdc\ud83c\udfad\ud83d\udc51\ud83d\udccd\ud83c\udff0\ud83d\udcda\ud83d\udc8d", "Thence to Tower-wharf, and there took boat, and we all walked to Halfeway House, and there eat and drank, and were pleasant.": "\u27a1\ufe0f\ud83c\udff0\u2693\ud83d\udea4\u27a1\ufe0f\ud83d\udeb6\u200d\u2642\ufe0f\ud83c\udf74\ud83e\udd64\ud83d\ude0a", "And so finally home again in the evening, and so good night, this being a very pleasant life that we now lead, and have long done; the Lord be blessed, and make us thankful.": "\ud83c\udfe0\ud83c\udf07\ud83d\ude4c\ud83c\udf19\ud83d\udca4\ud83d\ude0a\ud83d\ude4f\ud83c\udf1f\ud83c\udf08\ud83d\ude4f", "But, though I am much against too much spending, yet I do think it best to enjoy some degree of pleasure now that we have health, money, and opportunity, rather than to leave pleasures to old age or poverty, when we cannot have them so properly.": "\ud83e\udd14\ud83d\udcb0\ud83d\udc4e\ud83e\udd11\ud83e\udd14\ud83d\udc4d\ud83d\ude0a\ud83d\udd52\ud83c\udfe5\ud83d\udcb8\ud83d\udeaa\ud83c\udf89\ud83d\ude0c\ud83c\udf88\ud83d\ude03\ud83d\ude0c\ud83c\udfc3\u200d\u2642\ufe0f\ud83c\udf40\ud83e\udd1d\u23f3\ud83d\udc49\ud83d\udc75\ud83d\udcb5\ud83d\ude1e\ud83d\udeb7\ud83d\udc74\ud83d\udeab\ud83d\ude15", "where strange shapes of the unwarped primal world glided to and fro before his passive eyes": "\ud83c\udf0c\ud83c\udf00\ud83c\udf0d\ud83d\udc7b\ud83d\udc40", "To the Theatre to \u201cThe French Dancing Master,\u201d and there with much pleasure gazed upon her (Lady Castlemaine); but it troubles us to see her look dejectedly and slighted by people already. The play pleased us very well; but Lacy\u2019s part, the Dancing Master, the best in the world.": "\ud83c\udfad\u27a1\ufe0f\ud83d\udd7a\ud83c\uddeb\ud83c\uddf7\ud83d\udc68\u200d\ud83c\udfeb\ud83d\ude0a\ud83d\udc40\ud83d\udc69\u200d\ud83e\uddb0\ud83d\udc78\ud83d\ude14\ud83d\udc65\ud83d\udc4e\ud83c\udfad\ud83d\udc4f\ud83d\udc4d\ud83d\udc83\ud83d\udd7a\ud83d\udcaf\ud83c\udf0d", "My wife and I went and saw Mrs. Turner, whom we found not well, and her two boys Charles and Will come out of the country, grown very plain boys after three years being under their father\u2019s care in Yorkshire.": "\ud83d\udc69\u200d\u2764\ufe0f\u200d\ud83d\udc68\u27a1\ufe0f\ud83d\udc40\ud83d\udc75\ud83d\ude14\ud83d\udc66\ud83d\udc66\ud83c\udf33\ud83c\udfe1\ud83d\udd19\u23f33\ufe0f\u20e3\ud83d\udcc8\ud83d\ude4d\u200d\u2642\ufe0f", "There! there again! there she breaches! right ahead! The White Whale, the White Whale!": "\ud83d\udc33\ud83d\udea2\ud83d\udc33\u2b06\ufe0f\ud83d\udc33\ud83d\udc0b\ud83d\udc0b", "here goes for a cool, collected dive at death and destruction, and the devil fetch the hindmost": "\ud83c\udfca\u200d\u2642\ufe0f\ud83d\ude0e\ud83d\udca6\ud83d\udc80\ud83d\udd25\ud83d\ude08\ud83d\udc50", "I find nothing in them that is pleasing; and I see they have learnt to kiss and look freely up and down already, and I do believe will soon forget the recluse practice of their own country. They complain much for lack of good water to drink.": "\ud83d\ude45\u200d\u2642\ufe0f\ud83d\ude0a\ud83d\ude48\ud83d\udc44\ud83d\udc40\ud83d\ude0a\u2195\ufe0f\ud83d\udd1c\ud83d\ude15\ud83c\udfde\ud83d\udeb1", "We felt very nice and snug, the more so since it was so chilly out of doors": "\ud83d\ude0a\ud83d\udecb\ufe0f\ud83d\udd25\u2744\ufe0f\ud83d\udeaa", "Thence homewards by coach, through Moorefields, where we stood awhile, and saw the wrestling.": "\ud83c\udfe0\u27a1\ufe0f\ud83d\ude8c\u27a1\ufe0f\ud83c\udf33\ud83d\udeb6\u200d\u2642\ufe0f\u23f8\ufe0f\ud83d\udc40\ud83e\udd3c\u200d\u2642\ufe0f", "To my brother\u2019s, where I found my father, poor man, come, which I was glad to see. He tells me his alterations of the house and garden at Brampton, which please me well.": "\ud83d\udc68\u200d\ud83d\udc67\u200d\ud83d\udc66\ud83c\udfe0\u27a1\ufe0f\ud83d\udc40\ud83d\udc74\ud83d\ude0a\ud83c\udfe1\ud83c\udf33\ud83d\udcc8\ud83d\udc4d", "There you stand, lost in the infinite series of the sea, with nothing ruffled but the waves.": "\ud83c\udf0a\ud83e\udd14\ud83c\udf0a\ud83c\udf0a\ud83c\udf0a\ud83c\udf0a\ud83d\udd04\ud83d\udcad\ud83c\udf0a\ud83d\ude0c\ud83c\udf0a", "My sensations were strange. Let me try to explain them.": "\ud83e\udd14\ud83d\ude33\ud83d\udd0d\ud83e\udd2f\ud83d\udcac", "Comes my father by appointment to dine with me, which we did very merrily, I desiring to make him as merry as I can, while the poor man is in town.": "\ud83d\udc68\u200d\ud83d\udc66\ud83d\udcc5\ud83c\udf7d\ufe0f\ud83d\ude0a\u27a1\ufe0f\ud83c\udf89\ud83d\udd7a\ud83d\ude04\u2b05\ufe0f\ud83c\udfd9\ufe0f", "I have several such dried bits, which I use for marks in my whale-books.": "\ud83d\udc41\ufe0f\ud83d\udcda\ud83d\udcd6\ud83d\udc33\ud83d\udcda\ud83e\udeb6\ud83d\udcd9\ud83d\udcbe\ud83d\udc0b\ud83d\udcd3\ud83d\udcd5", "his torn body and gashed soul bled into one another; and so interfusing, made him mad": "\ud83e\udd15\ud83d\udc94\u27a1\ufe0f\ud83e\ude78\u2194\ufe0f\ud83e\udd2f", "There, then, he sat, the sign and symbol of a man without faith, hopelessly holding up hope in the midst of despair.": "\ud83c\udfde\ufe0f\ud83e\ude91\ud83d\udd74\ufe0f\ud83d\udd04\u2753\ud83d\ude4d\u200d\u2642\ufe0f\u274c\ud83d\ude4b\u200d\u2642\ufe0f\ud83d\ude4f\ud83d\udc94\ud83e\udd32\ud83d\ude1e", "Pantheistic vitality seemed to lurk in their very joints and bones, after what might be called the individual life had departed.": "\ud83c\udf3f\u2728\ud83e\uddb4\ud83c\udf0c\ud83d\udc80\u27a1\ufe0f\ud83e\uddcd\u200d\u2642\ufe0f\ud83c\udfc3\u200d\u2642\ufe0f", "In what rapt ether sails the world, of which the weariest will never weary?": "\ud83c\udf0c\ud83c\udf0d\u26f5\ufe0f\u2049\ufe0f\ud83d\ude29\ud83d\udd04\u2728\u2764\ufe0f\u200d\ud83d\udd25", "In Lumbard Street was called out of a window by Alderman Backwell, where I went, and saluted his lady, a very pretty woman.": "\ud83c\udfe2\ud83e\ude9f\ud83d\udcde\ud83c\udf06\ud83e\uddd4\u27a1\ufe0f\ud83e\udd1d\ud83d\udc6e\u200d\u2642\ufe0f\ud83c\udfe2\ud83d\udeb6\u200d\u2642\ufe0f\ud83d\udcbc\ud83e\udd1d\ud83d\udc69\ud83d\ude0a", "Here was Mr. Creed, and it seems they have been under some disorder in fear of a fire at the next door, and had been removing their goods, but the fire was over before I came.": "\ud83d\udc68\u200d\ud83d\udcbc\ud83d\udd25\ud83c\udfe0\ud83d\ude28\ud83d\udce6\ud83d\udd25\ud83d\udd1a\ud83c\udfc3\u200d\u2642\ufe0f", "Thence home, and with my wife and the two maids, and the boy, took boat and to Foxhall, where I had not been a great while.": "\ud83c\udfe0\ud83d\udc6b\ud83d\udc69\u200d\ud83c\udf73\ud83d\udc69\u200d\ud83c\udf73\ud83d\udc66\ud83d\udea4\u27a1\ufe0f\ud83e\udd8a\ud83c\udfe1\ud83d\udccd\ud83d\udcc6\u23f3", "To the Old Spring Garden, and there walked long, and the wenches gathered pinks. Here we staid, and seeing that we could not have anything to eat, but very dear, and with long stay, we went forth without any notice taken of us, and so we might have done if we had had anything.": "\ud83d\udc63\ud83c\udfe1\ud83c\udf38\ud83d\udc26\ud83d\udc6d\ud83c\udf3a\u23f3\ud83c\udf7d\ufe0f\u274c\ud83d\udcb0\u231b\ud83d\udeb6\u200d\u2642\ufe0f\ud83d\udeb6\u200d\u2640\ufe0f\ud83d\udc40\ud83d\udeaa\ud83d\udeab\ud83d\udcad\ud83d\udd52", "Thence to the New one, where I never was before, which much exceeds the other; and here we also walked, and the boy crept through the hedge and gathered abundance of roses.": "\ud83c\udfde\ufe0f\u27a1\ufe0f\u2728\u27a1\ufe0f\ud83c\udd95\ud83c\udfe0\ud83d\ude4b\u200d\u2642\ufe0f\ud83d\udeab\ud83d\udc40\ud83c\udf1f\u27a1\ufe0f\ud83c\udd9a\ud83c\udf3f\u27a1\ufe0f\ud83d\udeb6\u200d\u2642\ufe0f\ud83c\udf3f\ud83d\udc66\ud83c\udf33\ud83d\udc0d\ud83d\udc90\ud83c\udf39\ud83c\udf39\ud83c\udf39", "After a long walk, passed out of doors as we did in the other place, and here we had cakes and powdered beef and ale, and so home again by water with much pleasure.": "\ud83d\udeb6\u200d\u2642\ufe0f\u27a1\ufe0f\ud83d\udeaa\u27a1\ufe0f\ud83c\udfe1\ud83c\udf70\ud83e\udd69\ud83c\udf7a\u27a1\ufe0f\ud83c\udfe0\u26f5\ud83d\ude0a", "This day, being the King\u2019s birth-day, was very solemnly observed; and the more, for that the Queen this day comes to Hampton Court.": "\ud83d\udc51\ud83c\udf82\ud83d\udd14\ud83d\udc51\ud83d\udcc5\ud83d\udd0d\ud83d\ude0a\ud83d\udcc5\ud83d\udc51\ud83d\udc51\ud83d\udccd\ud83c\udff0", "I made up my accounts, and find myself \u2018de claro\u2019 worth about 530l., and no more, so little have I increased it since my last reckoning; but I confess I have laid out much money in clothes.": "\ud83e\uddee\ud83d\udcbc\ud83d\udcca\u27a1\ufe0f\ud83d\udcc8\ud83d\udcb7530\ud83e\uddd0\u2795\ud83d\udd1a\ud83d\udcc9\ud83d\udcb8\ud83d\udc55\ud83d\udecd\ufe0f", "Upon a suddaine motion I took my wife, and Sarah and Will by water, with some victuals with us, as low as Gravesend, intending to have gone into the Hope to the Royal James, to have seen the ship and Mr. Shepley.": "\ud83c\udf0a\ud83d\udea4\u26f5\ud83d\udc69\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83d\udc67\ud83d\udc66\ud83e\udd6a\u26f4\ufe0f\ud83d\udccd\u2693\ud83d\udea2\ud83d\udc40\ud83e\uddd4", "But meeting Mr. Shepley in a hoy, bringing up my Lord\u2019s things, she and I went on board, and sailed up with them as far as half-way tree, very glad to see Mr. Shepley.": "\ud83d\udee5\ufe0f\ud83d\udc68\u200d\ud83d\udcbc\ud83e\udd1d\ud83d\udce6\ud83e\uddf3\ud83d\udc83\u2194\ufe0f\ud83c\udf33\ud83d\ude0a\ud83d\udc40\ud83d\udc68\u200d\ud83d\udcbc", "Here we saw a little Turk and a negroe, which are intended for pages to the two young ladies.": "\ud83d\udc40\ud83d\udc66\ud83c\udffd\ud83c\uddf9\ud83c\uddf7\u2795\ud83d\udc66\ud83c\udfff\ud83d\udcdc\u27a1\ufe0f\ud83d\udc69\u200d\ud83e\uddb0\ud83d\udc69\u200d\ud83e\uddb1", "Sink all coffins and all hearses to one common pool!": "\ud83d\udef3\ufe0f\u26b0\ufe0f\ud83d\udef3\ufe0f\ud83d\udeab\u26b0\ufe0f\ud83d\udefb\u26b0\ufe0f\u27951\u20e3\ud83c\udf0a", "Many birds and other pretty noveltys there was, but I was afeard of being louzy, and so took boat again, and got to London before them, all the way, coming and going, reading in the \u201cWallflower\u201d with great pleasure.": "\ud83d\udc26\ud83c\udf3a\ud83c\udd95\ud83d\ude28\ud83e\udeb3\ud83d\udef6\u27a1\ufe0f\ud83d\udcda\ud83c\udf38\ud83d\ude0a", "Mr. Shepley came to sup with me. So we had a dish of mackerell and pease, and so he bid us good night, going to lie on board the hoy, and I to bed.": "\ud83d\udc68\u200d\ud83e\uddb3\ud83c\udf7d\ufe0f\ud83d\udc1f\ud83c\udf7d\ufe0f\ud83c\udf7d\ufe0f\ud83d\udecc\ud83c\udf19\ud83d\udea2\ud83d\udecc", "Came Anthony Joyce, who duns me for money for the tallow which he served in lately by my desire, which vexes me, but I must get it him the next by my promise.": "\ud83c\udfe0\ud83e\udd35\ud83d\udcbc\ud83e\udd11\ud83d\udc49\ud83d\udcb0\u27a1\ufe0f\ud83d\udca1\ud83d\udd6f\ufe0f\u23f0\ud83e\udd14\ud83d\ude20\ud83d\udcad\ud83e\udd1d\ud83d\ude4f\ud83d\udcc5\ud83d\udcad", "This particular feat of the shark seems all but miraculous. How at such an apparently unassailable surface, they contrive to gouge out such symmetrical mouthfuls, remains a part of the universal problem of all things.": "\ud83e\udd88\u2728\ud83e\udd14\u2753\ud83c\udf0a\ud83d\ude2e\u2728\ud83c\udf00\ud83e\udd88\ud83d\udd0d\ud83d\udcad\ud83e\udd2f\ud83c\udf0d\ud83d\udd0d\ud83d\udd04", "Had Sarah to comb my head clean, which I found so foul with powdering and other troubles, that I am resolved to try how I can keep my head dry without powder.": "\ud83d\udc69\u200d\ud83e\uddb0\ud83d\udc49\ud83d\udd1f\ud83d\udd04\ud83e\uddd6\u200d\u2640\ufe0f\ud83e\uddfc\ud83d\udc69\u200d\ud83e\uddb1\ud83e\udd22\ud83e\uddf9\ud83d\udca8\ud83d\udd19\ud83d\udd1c\u274c\ud83d\udca7\ud83d\udcc5\u274c\ud83d\udd32", "And I did also in a suddaine fit cut off all my beard, which I had been a great while bringing up, only that I may with my pumice-stone do my whole face, as I now do my chin, and to save time, which I find a very easy way and gentile.": "\ud83e\ude92\ud83d\ude32\u2702\ufe0f\ud83e\uddd4\u27a1\ufe0f\ud83d\ude0c\ud83e\uddfd\ud83d\ude03\u231a\ufe0f\ud83e\ude9e\ud83d\ude0a", "This month ends with very fair weather for a great while together. My health pretty well, but only wind do now and then torment me about the fundament extremely.": "\ud83d\udcc5\ud83c\udf1e\ud83c\udf08\ud83d\udd25\ud83d\udc4c\ud83d\udcaa\ud83d\ude05\ud83d\udca8\ud83d\ude16\ud83c\udf51\ud83c\udf2a\ufe0f", "The Queen is brought a few days since to Hampton Court; and all people say of her to be a very fine and handsome lady, and very discreet; and that the King is pleased enough with her which, I fear, will put Madam Castlemaine\u2019s nose out of joynt.": "\ud83d\udc51\ud83d\udc69\u200d\ud83e\uddb0\u27a1\ufe0f\ud83c\udff0\ud83d\uddd3\ufe0f\ud83d\udd19\ud83d\udc69\ud83c\udf80\ud83d\udc4d\ud83d\udc6b\ud83d\ude0a\ud83d\udc4c\ud83e\udd14\ud83d\ude1f\ud83d\udc78\ud83d\ude20\ud83d\udd27\ud83d\udc43\ud83d\udee0\ufe0f\ud83d\ude2c", "the valiant butchers over the deck-table are thus cannibally carving each other\u2019s live meat with carving-knives all gilded and tasselled": "\ud83e\uddb8\u200d\u2642\ufe0f\ud83d\udd2a\ud83d\udc68\u200d\ud83c\udf73\u2694\ufe0f\ud83c\udf56\ud83d\udc68\u200d\ud83c\udf73\ud83d\udd2a\u2728\ud83c\udf80", "To church, where a Presbyter made a sad and long sermon, which vexed me.": "\ud83d\udc49\u26ea\ufe0f, \ud83d\udccd\ud83d\udc68\u200d\u2696\ufe0f\ud83d\udde3\ufe0f\ud83d\ude14\ud83d\udcd6\ud83d\ude1e\u23f3\ud83d\udde8\ufe0f, \ud83d\ude20\ud83d\ude41.", "This day my wife put on her slasht wastecoate, which is very pretty.": "\ud83d\udcc5\ud83d\udc69\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83d\udc57\u2728\ud83d\ude0a", "Yesterday (Sir R. Ford told me) the Aldermen of the City did attend her in their habits, and did present her with a gold Cupp and 1000l. in gold therein.": "\ud83d\udd70\ufe0f\ud83d\udc68\u200d\ud83d\udcbc\ud83c\udfd9\ufe0f\ud83d\udc54\ud83e\udd35\u200d\u2642\ufe0f\ud83c\udf81\ud83d\udc69\u200d\ud83e\uddb3\ud83e\udd47\ud83c\udfc6\ud83d\udcb0\ud83d\udd22\ud83e\ude99", "But mark the other head\u2019s expression.": "\ud83e\udd14\ud83d\udc49\ud83d\ude2f", "Home and to bed, my mind troubled about Sir W. Pen, his playing the rogue with me today, as also about the charge of money that is in my house, which I had forgot.": "\ud83c\udfe0\ud83d\udecf\ufe0f\ud83e\udd14\ud83e\udd2f\ud83e\udd14\ud83e\uddd4\ud83c\udfad\ud83d\udd04\ud83e\udd14\ud83d\udcb8\ud83c\udfe1\ud83e\udd14\u274c\ud83e\udde0", "those who glared like devils in the forking flames, the morn will show in far other, at least gentler, relief": "\ud83d\ude08\ud83d\udd25\ud83c\udf05\ud83d\ude07\ud83d\udcab", "I to my Lord\u2019s, who I find resolved to buy Brampton Manor of Sir Peter Ball, at which I am glad.": "\ud83d\udc64\u27a1\ufe0f\ud83d\ude4f's, \ud83d\udc64\ud83d\ude0a\ud83d\udddd\ufe0f\ud83c\udfe1\ud83c\udf33\ud83d\udc0f\ud83d\udc68\u200d\u2696\ufe0f, \ud83d\ude03", "It was his death stroke.": "\ud83d\udc64\ud83d\udc80\u2694\ufe0f", "I went to my bookseller\u2019s, and paid off all for books to this day, and do not intend to buy any more of any kind a good while, though I had a great mind to have bought the King\u2019s works, as they are new printed in folio, and present it to my Lord.": "\ud83d\udc64\u27a1\ufe0f\ud83d\udcda\ud83c\udfea\ud83d\udcb8\ud83d\udcda\ud83d\udcc5\ud83d\udeab\ud83d\uded2\ud83d\udcda\u23f3\ud83e\udd14\ud83d\udcd6\ud83d\udc51\ud83d\udcda\ud83c\udd95\ud83d\udda8\ufe0f\ud83d\udcd6\ud83c\udf81\ud83e\udd34", "fix your eye upon this strange, crested, comb-like incrustation on the top of the mass\u2014this green, barnacled thing": "\ud83d\udd27\ud83d\udc41\ufe0f\ud83d\udd1d\ud83e\udd84\ud83e\udd81\ud83e\udd14\ud83d\udfe2\ud83c\udf0a\ud83d\udc1a", "three centuries ago the tongue of the Right Whale was esteemed a great delicacy in France, and commanded large prices there": "3\ufe0f\u20e3 \ud83d\udd70\ufe0f \ud83d\udc0b \ud83d\udc45 \ud83c\udf1f \ud83c\udf74 \ud83c\uddeb\ud83c\uddf7 \ud83d\udcb0\u2b06\ufe0f\ud83d\udcb2", "So that I am vexed with all my heart at Pall for writing to him so much concerning my mother\u2019s illness (which I believe was not so great), so that he should be forced to hasten down on the sudden back into the country without taking leave, or having any pleasure here.": "\ud83d\ude20\ud83d\udc94\ud83d\udcdc\u270d\ufe0f\ud83e\udd12\ud83e\udd14\u27a1\ufe0f\ud83d\ude28\ud83c\udfc3\u200d\u2642\ufe0f\ud83d\udca8\ud83c\udfe1\ud83d\udeab\ud83d\udc4b\ud83d\ude14\ud83c\udfd9\ufe0f", "This evening Savill the Paynter came and did varnish over my wife\u2019s picture and mine, and I paid him for my little picture 3l., and so am clear with him.": "\ud83c\udf06\ud83c\udfa8\ud83d\udc68\u200d\ud83c\udfa8\ud83d\udd8c\ufe0f\ud83d\uddbc\ufe0f\ud83d\udc69\u200d\ud83c\udfa8\ud83d\uddbc\ufe0f\ud83e\uddcd\u200d\u2640\ufe0f\ud83d\udcb03\ufe0f\u20e3\ud83d\udcb7\ud83d\udcac\u2714\ufe0f", "I trust you will have renounced all ignorant incredulity, and be ready to abide by this": "\ud83d\ude4f\ud83e\udd1e\ud83e\udd1d\ud83d\ude07\ud83d\udcdc\u274c\ud83d\ude15\ud83e\udd14\ud83d\udd04\ud83e\udd17\ud83d\udccb", "a supply of that hard white whalebone with which the fishermen fashion all sorts of curious articles, including canes, umbrella-stocks, and handles to riding-whips": "\ud83e\uddb4\ud83e\udd88\ud83c\udfa3\ud83d\udee0\ufe0f\ud83c\udf02\ud83e\uddaf\ud83c\udfc7", "man\u2019s insanity is heaven\u2019s sense": "\ud83d\udc68\ud83e\udd2a\ud83c\udf0c\ud83e\udd14", "I tried on my riding cloth suit with close knees, the first that ever I had; and I think they will be very convenient, if not too hot to wear any other open knees after them.": "\ud83e\udde5\ud83e\udd14\ud83d\udc56\ud83d\udeb4\u200d\u2642\ufe0f\ud83d\udc40\ud83d\udc4d\u2744\ufe0f\ud83d\udd25\ud83d\udc4e\ud83d\udc56", "Among many other businesses, I did get a vote signed by all, concerning my issuing of warrants, which they did not smell the use I intend to make of it; but it is to plead for my clerks to have their right of giving out all warrants, at which I am not a little pleased.": "\ud83d\uddc2\ufe0f\ud83e\udd1d\ud83d\udcbc\u270d\ufe0f\ud83d\udcdc\ud83d\udc65\ud83d\udd0d\ud83e\udd14\u2753\u25b6\ufe0f\ud83d\udcdc\ud83d\udcdd\ud83d\udd8b\ufe0f\ud83d\udee1\ufe0f\ud83d\udc4d\ud83d\udc69\u200d\ud83d\udcbc\ud83d\udcdc\u2696\ufe0f\ud83d\udcaa\ud83d\ude0a", "I was preparing to hear some good stories about whaling": "\ud83d\udc42\ud83d\udcd6\ud83d\udc0b\ud83d\udcda\ud83d\udde3\ufe0f\u2728", "To dinner, by Mr. Gauden\u2019s invitation, to the Dolphin, where a good dinner; but what is to myself a great wonder; that with ease I past the whole dinner without drinking a drop of wine.": "\ud83c\udf7d\ufe0f\ud83d\udc49\ud83d\udc64\ud83c\udf77\ud83d\udcdc\u2709\ufe0f\ud83c\udf74\ud83d\udc2c\ud83d\udc49\ud83d\ude0a\ud83c\udf74\ud83c\udf7d\ufe0f\u2753\ud83d\ude2e\ud83d\udc4d\ud83c\udf7d\ufe0f\ud83d\udeab\ud83c\udf77", "It being the longest day in the year, I made all my people go to bed by daylight.": "\ud83d\udcc5\ud83c\udf1e\u27a1\ufe0f\ud83d\udd5b, \ud83d\udc41\ufe0f\ud83d\udc65\ud83d\udeb6\ud83d\udecc\u2600\ufe0f.", "But after I was a-bed and asleep, a note came from my brother Tom to tell me that my cozen Anne Pepys, of Worcestershire, her husband is dead, and she married again, and her second husband in town, and intends to come and see me tomorrow.": "\ud83d\udecc\ud83d\udca4\ud83d\udcdc\ud83d\udc68\u200d\ud83d\udc69\u200d\ud83d\udc66\u200d\ud83d\udc66\u27a1\ufe0f\ud83d\udc70\ud83d\udc94\ud83d\ude07\ud83d\udd01\ud83d\udc8d\ud83e\uddd4\ud83c\udfd9\ufe0f\u27a1\ufe0f\ud83d\udc41\ufe0f\u200d\ud83d\udde8\ufe0f\ud83d\udcc5", "cajoling me into the delusion that it was a choice resulting from my own unbiased freewill and discriminating judgment": "\ud83e\udec4\ud83e\udd17\u27a1\ufe0f\ud83e\udd14\ud83c\udf00\ud83d\udc49\ud83e\udd2f\ud83d\udcad\ud83e\udd0f\ud83e\udd39\u200d\u2642\ufe0f\ud83c\udd93\ud83e\udd1d\ud83e\udde0\u2696\ufe0f\ud83d\udd0d", "Up by 4 o\u2019clock in the morning, and read Cicero\u2019s Second Oration against Catiline, which pleased me exceedingly; and more I discern therein than ever I thought was to be found in him; but I perceive it was my ignorance, and that he is as good a writer as ever I read in my life.": "\u23eb\ud83d\udd53\ud83c\udf04\ud83d\udcda\ud83e\uddd4\ud83c\udffb\ud83d\udcdc\ud83e\udd14\ud83d\udc4d\ud83c\udffc\ud83d\udcd6\ud83d\ude03\ud83e\uddd0\ud83d\udcc8\ud83e\udd14\ud83d\udcda\ud83e\udd14\ud83d\udcc8\ud83e\udd37\u200d\u2642\ufe0f\u270d\ufe0f\ud83d\udcda\ud83d\udcd6\ud83d\ude2e", "Oh, grassy glades! oh, ever vernal endless landscapes in the soul": "\ud83c\udf3f\ud83d\ude2e\ud83c\udf3c\ud83c\udf3f! \ud83c\udf33\ud83d\ude2e, \u267e\ufe0f\ud83c\udf43\ud83d\udc9a\ud83c\udf04\u267e\ufe0f\ud83c\udf04\ud83e\uddd8\u200d\u2642\ufe0f\ud83d\udc96", "My wife and I, and Sarah and the boy, a most pleasant walk to Halfway house, and so home and to bed.": "\ud83d\udc69\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83d\udc69\u200d\u2764\ufe0f\u200d\ud83d\udc66\ud83d\udc66\ud83d\udeb6\u200d\u2642\ufe0f\ud83d\udeb6\u200d\u2640\ufe0f\ud83d\udeb6\u200d\u2642\ufe0f\ud83d\udeb6\u200d\u2640\ufe0f\ud83d\ude0a\ud83c\udfe0\ud83d\udecc", "all their eyes gleaming in that pale phosphorescence, like a far away constellation of stars": "\ud83d\udc40\u2728\ud83c\udf0c\u2728\ud83d\udd2d\u2728\ud83c\udf1f\u2728\ud83d\udcab\u2728", "I name no names. Shame upon them! Put one foot upon the table. Shame upon all cowards.": "\ud83e\udee3\u274c\ud83d\udd20\ud83d\ude14\u2b07\ufe0f\ud83d\udc46\ud83e\uddb6\ud83e\ude91\ud83d\ude14\u2b07\ufe0f\ud83d\udeab\ud83d\ude28\ud83e\uddb8\u200d\u2642\ufe0f", "Having a room got ready for us, we all went out to the Tower-hill; and there, over against the scaffold, made on purpose this day, saw Sir Henry Vane brought. A very great press of people.": "\ud83c\udfe0\u2705\ud83e\uddd1\u200d\ud83e\udd1d\u200d\ud83e\uddd1\ud83d\udeb6\u200d\u2642\ufe0f\u27a1\ufe0f\ud83d\uddfc\ud83d\udd1d\u26f0\ufe0f\ud83d\udc40\ud83d\udc65\ud83d\udd28\ud83e\ude9c\ud83d\udcc5\ud83d\udc40\ud83e\uddd4\ud83c\udfc3\u200d\u2642\ufe0f\ud83d\udc65\ud83d\udce2\ud83d\udc65", "He made a long speech, many times interrupted by the Sheriff and others there; and they would have taken his paper out of his hand, but he would not let it go. The trumpets were brought under the scaffold that he might not be heard.": "\ud83d\udc68\u200d\ud83d\udde3\ufe0f\ud83d\uddef\ufe0f\u23f3\ud83d\udcdc\ud83d\udcac\u270b\ud83d\udc6e\u200d\u2642\ufe0f\ud83d\ude20\ud83e\udd1a\ud83d\udc65\ud83d\udeab\ud83d\udcc4\ud83e\udd1a\ud83d\udd14\ud83d\udd0a\ud83d\udd07\ud83c\udfd7\ufe0f\ud83d\udd15\u27a1\ufe0f\ud83d\udd07", "Then he prayed, and so fitted himself, and received the blow; but the scaffold was so crowded that we could not see it done.": "\ud83d\ude4f\u27a1\ufe0f\ud83d\udcaa\ud83d\udd2a\ud83d\udc40\ud83d\ude1e\ud83d\udce6\ud83d\udeab\ud83d\udd0d", "One asked him why he did not pray for the King. He answered, \u201cNay,\u201d says he, \u201cyou shall see I can pray for the King: I pray God bless him!\u201d": "\u261d\ufe0f\ud83e\udd14\u2753\ud83d\ude47\u200d\u2642\ufe0f\ud83e\udd34\u2753\ud83d\ude45\u200d\u2642\ufe0f\ud83d\udcac\ud83e\udd37\u200d\u2642\ufe0f\ud83d\ude0a\ud83d\udc40\ud83d\ude4f\ud83e\udd34\ud83d\ude4f\ud83d\ude4f\ud83d\ude4f\ud83d\ude07", "may I ask whether this is the sort of bitters by which he blows back the life into a half-drowned man?": "\ud83e\uddd0\u2753\ud83e\udd14\u27a1\ufe0f\ud83c\udf77\ud83e\udd14\ud83d\udca8\ud83c\udf00\ud83d\ude05\u27a1\ufe0f\ud83e\udd15\ud83e\udd75\ud83d\udedf", "I hear my Lord Peterborough is come unexpected from Tangier, to give the King an account of the place, which, we fear, is in none of the best condition.": "\ud83d\udc42\ud83e\udd34\ud83c\udff0\ud83d\udeec\ud83d\ude2e\ud83c\udf0d\u27a1\ufe0f\ud83d\udc51\ud83d\udcdc\ud83d\udccd\ud83d\ude28\u274c\ud83d\udc4d\ud83d\udcf6", "We had certain news that the Spaniard is before Lisbon with thirteen sail; six Dutch, and the rest his own ships; which will, I fear, be ill for Portugall.": "\ud83d\udcf0\ud83d\ude1f\ud83d\udc68\u200d\u2708\ufe0f\ud83c\uddea\ud83c\uddf8\u26f5\ufe0f\u27a1\ufe0f\ud83c\uddf5\ud83c\uddf9\u2693\ufe0f\ud83d\udcac1\ufe0f\u20e33\ufe0f\u20e3\u26f4\ufe0f\u2693\ufe0f6\ufe0f\u20e3\ud83c\uddf3\ud83c\uddf1\u26f4\ufe0f\u2795\ud83d\udd22\ud83c\uddea\ud83c\uddf8\u26f4\ufe0f\ud83d\ude30\ud83d\ude2c\ud83c\uddf5\ud83c\uddf9", "Did you ever see any parson a wearing mourning for the devil?": "\ud83e\udd14\ud83d\udc40\ud83d\udc68\u200d\u2695\ufe0f\ud83d\ude14\ud83d\udda4\ud83d\ude08\u2753", "even Captain Ahab was by no means unobservant of the paramount forms and usages of the sea": "\u2693\ud83e\uddd4\u200d\u2642\ufe0f\u274c\ud83d\udc40\ud83c\udf0a\u26f5\ud83d\udee1\ufe0f\ud83d\udcdc", "Yonder, to windward, all is blackness of doom; but to leeward, homeward\u2014I see it lightens up there": "\ud83c\udf2b\ufe0f\u2b06\ufe0f\ud83d\udca8\u26ab\ud83d\udc80;\u2b07\ufe0f\ud83c\udfe0\ud83c\udf05\u2728", "Thou canst not tell where one drop of water or one grain of sand will be to-morrow noon": "\ud83e\udd14\ud83d\udca7\u2753\ud83d\udd52\ud83c\udf0a\ud83d\udd0d\ud83c\udf3e\u2753\ud83d\udd52\ud83c\udf1e", "To church again; but my wife not being dressed as I would have her, I was angry, and she, when she was out of doors in her way to church, returned home again vexed.": "\ud83d\udc49\u26ea\ufe0f\ud83d\udd04; \ud83d\udc69\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83d\udeab\ud83d\udc57\ud83d\ude20, \ud83d\ude21\u21a9\ufe0f\ud83c\udfe0\ud83d\ude21.", "he had just recalled a little duty ashore, which he was leaving undone; and therefore had changed his mind about dying": "\ud83d\udc68\u200d\ud83d\udcad\u2693\ufe0f\ud83d\udcdd\ud83c\udfdd\ufe0f\u274c\u27a1\ufe0f\ud83e\udd14\ud83d\udc80\u270b", "Home, and found my wife and Sarah gone to a neighbour church, at which I was not much displeased. By and by she comes again, and, after a word or two, good friends.": "\ud83c\udfe0\u27a1\ufe0f\ud83d\udc69\u200d\u2764\ufe0f\u200d\ud83d\udc68\u274c\u27a1\ufe0f\u26ea\ud83e\udd37\ud83d\ude0a\u27a1\ufe0f\ud83d\udc69\ud83d\ude42\u2764\ufe0f\ud83e\udd1d", "you are struck by the general contrast between these heads": "\ud83d\udc49\ud83e\udd2f\ud83d\ude32\ud83c\udd9a\ud83e\udde0\ud83d\udde3\ufe0f", "She told me that her brother was married and had a wife worth 500l. to him, and did inquire how he might dispose the money to the best advantage, but I forbore to advise her till she could certainly tell me how things are with him, being loth to meddle too soon with him.": "\ud83d\udc69\u200d\ud83d\udde3\ufe0f\u27a1\ufe0f\ud83d\udc68\u200d\ud83e\uddb1\ud83d\udc92\ud83d\udc70\ud83d\udcb0\ud83d\udcb5\ud83e\udd14\ud83d\udcad\u2753\ud83d\udde3\ufe0f\ud83d\udcb0\ud83d\udc4d\ud83e\udd14\u2753\ud83e\udd14\ud83e\udd10\ud83e\uddd1\u200d\ud83d\udcbc\u23f3\ud83d\udd0d\ud83d\udc68\u200d\ud83e\uddb1\ud83d\ude45\u200d\u2642\ufe0f\u23f0", "the whole round sea was one huge cheese, and those sharks the maggots in it": "\ud83c\udf0a\ud83e\uddc0\ud83e\udd88\ud83e\udeb1", "With my wife to the Wardrobe, and dined there; and in the afternoon with all the children by water to Greenwich, where I showed them the King\u2019s yacht, the house, and the park, all very pleasant; and so to the tavern, and had the musique of the house, and so merrily home again.": "\ud83d\udc6b\ud83d\udeaa\ud83c\udf7d\ufe0f\ud83d\udd5b\ud83e\uddd2\ud83d\udee5\ufe0f\u27a1\ufe0f\ud83c\uddec\ud83c\udde7\ud83d\udccd\ud83d\udc51\ud83d\udee5\ufe0f\ud83c\udfe0\ud83c\udf33\ud83c\udfb6\ud83c\udf7b\ud83d\ude0a\ud83c\udfe0", "To the office, and at Sir W. Batten\u2019s, where we all met by chance and talked, and they drank wine; but I forebore all their healths. Sir John Minnes, I perceive, is most excellent company.": "\ud83c\udfe2\u27a1\ufe0f\ud83d\udc65\ud83c\udf77\ud83d\udeab\ud83c\udfe5\ud83d\udc68\u200d\ud83d\ude80\ud83e\udd1d\ud83d\ude04", "Home and to bed betimes by daylight.": "\ud83c\udfe1\ud83d\udecf\ufe0f\u23f0\ud83c\udf05", "in many natural objects, whiteness refiningly enhances beauty, as if imparting some special virtue of its own": "\ud83c\udf3f\u26aa\ufe0f\u2728\ud83c\udf37\u2795\ud83c\udf38\ud83c\udf1f\ud83c\udf08", "Thence to Wright\u2019s, the painter\u2019s: but, Lord! the difference that is between their two works.": "\ud83d\udc68\u200d\ud83c\udfa8\u27a1\ufe0f\ud83d\udc68\u200d\ud83c\udfa8\ud83c\udfa8\ud83d\ude32\ud83e\udd2f\u27972\ud83d\uddbc\ufe0f\ud83c\udfa8", "So home, and after some merry discourse in the kitchen with my wife and maids as I now-a-days often do, I being well pleased with both my maids, to bed.": "\ud83c\udfe0\ud83d\ude04\ud83d\udde3\ud83d\udc69\u200d\ud83c\udf73\ud83d\udc69\u200d\u2764\ufe0f\u200d\ud83d\udc68\ud83d\udc69\u200d\ud83c\udf73\ud83d\ude0a\ud83d\udecf\ud83d\udca4", "oh, ever vernal endless landscapes in the soul; in ye,\u2014though long parched by the dead drought of the earthy life,\u2014in ye, men yet may roll": "\ud83d\ude2e\ud83c\udf3f\ud83c\udf04\ud83d\udd04\u2728\ud83c\udfde\ufe0f\ud83e\uddd8\u200d\u2642\ufe0f;\ud83d\udccd\ud83c\udf33,\u2014\ud83d\udd04\ud83c\udf35\ud83e\udd75\ud83c\udf3e\u2620\ufe0f\ud83c\udf35\ud83c\udf0e\ud83d\udc80,\u2014\ud83d\udccd\ud83c\udf33,\ud83d\udc68\u200d\ud83e\uddb0\ud83d\udcaa\ud83d\udc68\u200d\ud83e\uddb3\ud83c\udf00\u2194\ufe0f", "Immense as whales, the motion of whose vast bodies can in a peaceful calm trouble the ocean till it boil.": "\ud83d\udc0b\ud83c\udf0a\ud83d\udd04\ud83d\udccf\ud83d\ude0c\ud83c\udf0a\ud83d\udd09\ud83d\udd25", "Up by five o\u2019clock, and while my man Will was getting himself ready to come up to me I took and played upon my lute a little.": "\u2600\ufe0f\ud83d\udd1d5\ufe0f\u20e3\u23f0\ud83d\udc68\u200d\ud83e\uddb0\u27a1\ufe0f\ud83d\udd1c\ud83d\udc4d\ud83c\udfb6\ud83c\udfb8\ud83c\udfb5\ud83d\udd7a", "suddenly in the distance, they saw a great heap of tumultuous white water": "\ud83c\udf0a\ud83d\udc40\ud83d\ude32\ud83d\ude2e\u200d\ud83d\udca8\ud83c\udf0c", "We sat long to-day, and had a great private business before us about contracting with Sir W. Rider, Mr. Cutler, and Captain Cocke, for 500 ton of hemp, which we went through, and I am to draw up the conditions.": "\ud83e\ude91\u23f3\ud83d\udc54\ud83d\udde3\ufe0f\ud83d\udcdc\ud83e\udd1d\ud83e\uddd4\ud83d\udd0d\ud83d\udc49\ud83d\udcdd", "Mr. Holliard had been with my wife to-day, and cured her of her pain in her ear by taking out a most prodigious quantity of hard wax that had hardened itself in the bottom of the ear, of which I am very glad.": "\ud83d\udc68\u200d\u2695\ufe0f\ud83e\uddd1\u200d\ud83e\udd1d\u200d\ud83e\uddd1\ud83d\udc42\u27a1\ufe0f\ud83d\ude0a\ud83e\uddbb\u274c\ud83c\udf6f\ud83d\uddd1\ufe0f\ud83c\udf89", "what that is none know but those who have tried it": "\ud83e\udd14\ud83e\udd37\u200d\u2642\ufe0f\ud83d\udd75\ufe0f\u200d\u2642\ufe0f\ud83d\udc65\ud83e\udd47\ud83d\udd0d\ud83d\udcad", "Though, God knows! the King is not able to set out five ships at this present without great difficulty, we neither having money, credit, nor stores.": "\ud83e\udd14\ud83d\ude4f\ud83d\udc51\ud83d\udeab\ud83d\udef3\ufe0f5\u23f3\ud83d\udeab\ud83e\udd11\ud83e\udd1d\ud83d\udd0b", "the true form of the whale was unknown": "\ud83d\udc0b\u2753\ud83d\udcad", "This day genteel woman came to me, claiming kindred of me, as she had once done before, and borrowed 10s. of me, promising to repay it at night, but I hear nothing of her. I shall trust her no more.": "\ud83d\udc69\u200d\ud83e\uddb0\u27a1\ufe0f\ud83e\udd1d\ud83d\udc68\u200d\ud83e\uddb0\ud83d\udcbc\ud83d\udc69\u200d\ud83e\uddb0\ud83d\udcb0\ud83d\udd1f\ud83d\udd52\ud83d\udd04\ud83c\udf1c\u274c\ud83d\udd14\ud83e\udd37\u200d\u2642\ufe0f\ud83d\udeab\ud83d\udd12\ud83d\udc94", "Squeeze! squeeze! squeeze! all the morning long; I squeezed that sperm till I myself almost melted into it": "\ud83d\udc50\ud83d\udc50\ud83d\udc50\u2600\ufe0f\u23f0\u23f3\ud83d\udc49\ud83d\udc50\ud83d\udc0b\ud83e\ude75\u27a1\ufe0f\ud83d\ude05\ud83d\udd25\ud83d\ude0c\ud83c\udf0a", "I find it to be the very effect of my late oaths against wine and plays, which, if God please, I will keep constant in, for now my business is a delight to me, and brings me great credit, and my purse encreases too.": "\ud83e\udd14\u270b\ud83c\udf77\ud83c\udfad\ud83d\ude4f\ud83d\ude07\ud83d\udcc8\ud83d\udcbc\ud83d\ude0a\ud83d\udc4d\ud83d\udcb0\ud83d\udcc8", "Yea, woe to him who, as the great Pilot Paul has it, while preaching to others is himself a castaway!": "\ud83d\udc4d\ud83d\ude14\ud83e\uddd4\ud83d\udcd6\ud83d\udef3\ufe0f\ud83d\udce2\u27a1\ufe0f\ud83d\udc65\ud83e\udd26\u200d\u2642\ufe0f\ud83d\udeab\u27a1\ufe0f\ud83c\udf0a\ud83d\udc94", "these two laws touching Fast-Fish and Loose-Fish, I say, will, on reflection, be found the fundamentals of all human jurisprudence": "\ud83d\udc1f\u2696\ufe0f\ud83e\udd14\u27a1\ufe0f\ud83d\udd0d\ud83e\udde0\u27a1\ufe0f\ud83d\udcda\u2696\ufe0f\ud83d\udc65\ud83c\udf0d", "What\u2019s the matter with you? What\u2019s the matter with you, shipmate?": "\ud83e\udd14\u2753\ud83e\udd37\u200d\u2642\ufe0f\ud83e\udd14\u2753\ud83e\udd37\u200d\u2642\ufe0f\ud83d\udef3\ufe0f\ud83d\udc6b", "To the settling of my own accounts, and I do find upon my monthly ballance, which I have undertaken to keep from month to month, that I am worth 650l., the greatest sum that ever I was yet master of. I pray God give me a thankfull, spirit, and care to improve and encrease it.": "\ud83d\udcca\ud83d\udcbc\ud83d\udd22\ud83d\udcc5\ud83d\udcb0\ud83d\udcb7\ud83d\udcaa\ud83d\udd1d\ud83d\ude4f\ud83d\udd4a\ufe0f\ud83d\ude4c\ud83d\udcc8\ud83d\udcc8", "To church with my wife, who this day put on her green petticoat of flowred satin, with fine white and gimp lace of her own putting on, which is very pretty.": "\u26ea\ufe0f\ud83d\udc6b\ud83d\udc9a\ud83d\udc57\ud83c\udf38\u2728\ud83e\udd0d\ud83e\uddf5\ud83d\udc57\ud83d\ude0d", "But even Solomon, he says, \u201cthe man that wandereth out of the way of understanding shall remain\u201d (i.e., even while living) \u201cin the congregation of the dead.\u201d": "\ud83e\udd14\u27a1\ufe0f\ud83d\udc51\ud83e\udd34\ud83d\udd04\ud83d\udeb6\u200d\u2642\ufe0f\ud83d\udee4\ufe0f\u274c\ud83e\udde0\u27a1\ufe0f\ud83d\udd78\ufe0f\ud83d\udc65\ud83d\udc80", "Thou saw\u2019st the locked lovers when leaping from their flaming ship; heart to heart they sank beneath the exulting wave": "\ud83d\udc40\ud83d\udd12\ud83d\udc91\ud83d\udd25\ud83d\udea2\u2764\ufe0f\u27a1\ufe0f\u2764\ufe0f\ud83c\udf0a\u2b07\ufe0f", "Sir W. Penn do much fawn upon me, and I perceive would not fall out with me, and his daughter mighty officious to my wife, but I shall never be deceived again by him, but do hate him and his traitorous tricks with all my heart.": "\ud83e\uddd4\u200d\u2642\ufe0f\ud83e\uddce\u200d\u2642\ufe0f\ud83d\udc36\ud83d\udc48\ud83e\udd1d\ud83e\udd28\u27a1\ufe0f\ud83d\udc69\ud83e\uddda\u200d\u2640\ufe0f\u2764\ufe0f\ud83d\udc91\ud83d\udeab\ud83d\ude21\ud83d\udc49\ud83e\udd25\ud83d\udc94\ud83d\udeab\u2764\ufe0f", "Went first on board the King\u2019s pleasure boat. Then to Greenwich Park; and with much ado she was able to walk up to the top of the hill, and so down again, and took boat, and so through bridge to Blackfryers, she being much pleased with the ramble in every particular of it.": "\ud83d\udeb6\u200d\u2642\ufe0f\u27a1\ufe0f\ud83d\udee5\ufe0f\ud83d\udc51\u27a1\ufe0f\ud83d\udee5\ufe0f\u27a1\ufe0f\ud83d\udee5\ufe0f\u27a1\ufe0f\ud83d\udeb6\u200d\u2640\ufe0f\u27a1\ufe0f\ud83c\udf33\u27a1\ufe0f\ud83d\udeb6\u200d\u2640\ufe0f\u2b06\ufe0f\u26f0\ufe0f\u27a1\ufe0f\u2b07\ufe0f\u26f0\ufe0f\u27a1\ufe0f\ud83d\udee5\ufe0f\u27a1\ufe0f\ud83c\udf09\u27a1\ufe0f\u2693\u27a1\ufe0f\ud83d\ude0a\ud83c\udf33\u26f0\ufe0f\ud83d\udee5\ufe0f", "This I take to be as bad a juncture as ever I observed.": "\u2639\ufe0f\ud83d\udd0d\ud83e\udd14\u27a1\ufe0f\ud83d\ude1e\ud83d\udcc9\ud83d\ude1f\ud83d\udc41\ufe0f", "To Redriffe by land, Mr. Cowly, the Clerk of the Cheque, with me, discoursing concerning the abuses of the yard, in which he did give me much light.": "\u27a1\ufe0f\ud83d\udee4\ufe0f\u27a1\ufe0f\ud83d\udeb6\u200d\u2642\ufe0f\ud83d\udc68\u200d\ud83d\udcbc\ud83d\uddd2\ufe0f\ud83d\udcac\ud83d\udca1", "Up by four o\u2019clock, and before I went to the office I practised my arithmetique, and then, when my wife was up, did call her and Sarah, and did make up a difference between them, for she is so good a servant as I am loth to part with her.": "\u23eb \ud83d\udd53, \ud83d\udd5b \ud83c\udfe2 \u2795\ud83d\udcda, \ud83d\udc70 \ud83d\udcde\ud83d\udc69\u200d\ud83e\uddb3\ud83e\udd1d, \ud83d\udc81\u200d\u2640\ufe0f\ud83d\udc4c\ud83d\udd22\ud83d\ude0c\u2764\ufe0f", "So to the office all the morning, where very much business, but it vexes me to see so much disorder at our table, that, every man minding a several business, we dispatch nothing.": "\ud83c\udfe2\ud83c\udf05\ud83d\udd52\ud83d\udcbc\ud83d\udcc8\ud83d\ude16\ud83d\udd0d\ud83d\uddc2\ufe0f\u274c\ud83d\udc40\ud83d\udd04\ud83c\udf7d\ufe0f\ud83d\udd0d\ud83d\udc68\u200d\ud83d\udcbc\ud83e\udd37\u200d\u2642\ufe0f\ud83d\udd22\ud83d\udde3\ufe0f\ud83d\udeab", "One often hears of writers that rise and swell with their subject, though it may seem but an ordinary one.": "\ud83d\udc42\ud83d\udc64\u270d\ufe0f\u2b06\ufe0f\ud83c\udf0a\ud83d\uddd2\ufe0f\u27a1\ufe0f\ud83d\udcdc\ud83e\udd14\ud83d\udcc8\ud83d\udd0d\ud83d\udcd8\u27a1\ufe0f\ud83d\udd04\u270f\ufe0f", "I told Mr. Turner my whole mind, and how it was in my power to do him a discourtesy about his place of petty purveyance, and at last did make him see (I think) that it was his concernment to be friendly to me and what belongs to me.": "\ud83d\udde3\ufe0f\u27a1\ufe0f\ud83e\uddd1\u200d\ud83d\udcbc\ud83d\udcad\ud83d\udde3\ufe0f\ud83d\udc50\ud83d\udcaa\ud83d\ude20\ud83c\udfe0\ud83d\udecd\ufe0f\ud83d\ude12\ud83e\udd14\ud83e\uddd0\ud83c\udfeb\u2795\ud83e\udd1d\ud83d\ude0a\ud83e\udec2", "I did discourse with Mr. Turner about the faults of our management of the business of our office, of which he is sensible, but I believe is a very knave.": "\ud83d\udde3\ufe0f\ud83e\udd1d\ud83d\udc68\u200d\ud83d\udcbc\ud83d\udcac\ud83e\udd14\ud83e\uddd1\u200d\ud83d\udcbc\u2699\ufe0f\ud83c\udfe2\ud83d\udd0d\ud83d\ude14\ud83e\udd14\ud83e\uddb9", "Think, think of thy whale-boat, stoven and sunk! Beware of the horrible tail!": "\ud83e\udd14\ud83e\udd14\ud83d\udc0b\ud83d\udea4\ud83d\udca5\ud83c\udf0a\u26a0\ufe0f\ud83d\ude31\ud83d\udc0b\ud83d\udc4b", "Nantucket! Take out your map and look at it. See what a real corner of the world it occupies": "\ud83d\uddfa\ufe0f\ud83d\udd0d\ud83c\udf0d\u27a1\ufe0f\ud83d\udccd", "And all the while the thick-lipped leviathan is rushing through the deep, leaving tons of tumultuous white curds in his wake": "\ud83c\udf0a\ud83d\udc0b\ud83d\udca8\ud83c\udf2a\ufe0f\u26aa\ud83d\udc33", "he found himself hard by the very latitude and longitude where his tormenting wound had been inflicted": "\ud83d\udc68\ud83d\udd0d\ud83e\udded\ud83d\udccd\ud83d\ude16\ud83d\udc94\ud83d\udccd\ud83d\udccc", "It was a very dubious-looking, nay, a very dark and dismal night, bitingly cold and cheerless.": "\ud83c\udf0c\ud83e\udd14\ud83e\udd28\ud83c\udf11\ud83c\udf27\ufe0f\ud83e\udd76\ud83d\udd2a\ud83c\udf2b\ufe0f", "he swam away to the leeward, but with such a steady tranquillity, and making so few ripples as he swam": "\ud83c\udfca\u200d\u2642\ufe0f\u27a1\ufe0f\ud83c\udf0a\ud83d\ude0c\ud83d\udd07\ud83c\udf0a\u2728", "I am buoyed by breaths of once living things, exhaled as air, but water now.": "\ud83d\ude0c\ud83d\udca8\ud83c\udf3f\u27a1\ufe0f\ud83c\udf2c\ufe0f\ud83e\udee7\u27a1\ufe0f\ud83c\udf0a", "the beheading of the Sperm Whale is a scientific anatomical feat, upon which experienced whale surgeons very much pride themselves": "\u2694\ufe0f\ud83d\udc0b\ud83d\udd2c\ud83d\udc69\u200d\u2695\ufe0f\ud83d\udc33\ud83c\udfc6", "what monstrous cannibal and savage could ever have gone a death-harvesting with such a hacking, horrifying implement": "\ud83e\udd14\ud83d\udc79\ud83c\udf7d\ufe0f\ud83d\ude31\ud83d\udc64\u2620\ufe0f\ud83e\ude93\ud83d\ude28\ud83d\udd2a", "Here I am, proud as Greek god, and yet standing debtor to this blockhead for a bone to stand on!": "\ud83e\uddcd\u200d\u2642\ufe0f\ud83c\uddec\ud83c\uddf7\ud83d\udcaa\ud83e\udd14\ud83d\udcb8\ud83d\udc68\u200d\ud83e\uddb2\ud83e\uddb4\ud83e\uddb6", "the ivory-tusked Pequod sharply bowed to the blast, and gored the dark waves in her madness, till, like showers of silver chips, the foam-flakes flew over her bulwarks": "\ud83d\udc18\ud83d\udea2\ud83c\udf0a\ud83d\udca8\ud83c\udfaf\ud83c\udf0a\ud83e\udd2a\ud83c\udf0a\ud83c\udf0a\ud83c\udf0a\ud83c\udf0a\ud83d\udca5\u2728\ud83d\udea2\ud83d\udee1\ufe0f", "Are you a believer in ghosts, my friend?": "\ud83d\udc7b\u2753\ud83e\udd14\ud83e\uddd1\u200d\ud83e\udd1d\u200d\ud83e\uddd1", "the two\u2014ship and whale, seemed yoked together like colossal bullocks, whereof one reclines while the other remains standing": "\ud83d\udea2\ud83d\udc0b\ud83d\udd17\ud83d\udc02\ud83d\udc02\ud83d\udecc\ud83d\udc02", "going plump on a flying whale with your sail set in a foggy squall is the height of a whaleman\u2019s discretion": "\ud83d\udc0b\u2708\ufe0f\ud83c\udf2b\ufe0f\ud83c\udf2c\ufe0f\u26f5\ud83d\udd1d\ud83e\udded\ud83d\udcad", "Strangest problems of life seem clearing; but clouds sweep between\u2014Is my journey\u2019s end coming?": "\ud83e\udd14\ud83c\udf2b\ufe0f\u27a1\ufe0f\u2600\ufe0f\ud83c\udf25\ufe0f\u2753\ud83d\udeb6\u200d\u2642\ufe0f\ud83c\udfc1\ud83d\udd1c", "Yes, the long calm was departing. A low advancing hum was soon heard": "\ud83d\udc4d, \ud83c\udf05\u2b05\ufe0f\ud83d\ude0c\ud83d\udcc9. \ud83d\udcc9\ud83d\udd1c\ud83d\udc42\ud83d\udd08\ud83d\udcc8.", "what disordered slippery decks of a whale-ship are comparable to the unspeakable carrion of those battle-fields": "\ud83e\udd14\ud83d\udc0b\u2693\ufe0f\ud83d\udef3\ufe0f\u2753\ud83d\udd04\ud83c\udf0a\ud83e\udd2f\u2694\ufe0f\ud83d\udc80\ud83e\ude96\u26b0\ufe0f", "Would that I could keep squeezing that sperm for ever!": "\ud83e\udd14\ud83e\udd32\ud83d\udca6\u267e\ufe0f\u2728", "his distended eyes turned full upon old Ahab": "\ud83d\udc40\ud83d\udd04\ud83d\udc74\ud83e\uddd4\u200d\u2642\ufe0f", "So have I seen Passion and Vanity stamping the living magnanimous earth, but the earth did not alter her tides and her seasons for that.": "\ud83d\udc40\ud83d\ude21\u2728\ud83d\udc63\ud83c\udf0d\u270b\ud83d\udcaa\ud83c\udf0a\ud83c\udf31\u2194\ufe0f", "What a noble thing is that canticle in the fish\u2019s belly! How billow-like and boisterously grand!": "\ud83d\udc1f\ud83c\udfb6\ud83c\udf0a\ud83c\udfa9\ud83d\udca5"}
+{
+  "The devil fetch ye, ye ragamuffin rapscallions; ye are all asleep. Stop snoring, ye sleepers": {
+    "emoji": "😈🔥📥👉, 👉👕🔄💂‍♂️💂‍♀️; 👉👥😴💤💤. ⛔️💤💤, 👉😴💤💤👥",
+    "date": "2024-01-01T00:00:00"
+  },
+  "sharks now freshly and more keenly allured by the before pent blood which began to flow from the carcass": {
+    "emoji": "🦈🦈🦈🔜🌿🆕➕🔪🎯💉💧🟥🤤🎬💫➡️🥩🍖🔮💔💟🕐🌊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "BLOODY BATTLE IN AFFGHANISTAN.": {
+    "emoji": "💉⚔️🤼‍♂️🔥🇦🇫",
+    "date": "2024-01-01T00:00:00"
+  },
+  "So in this vale of Death, God girds us round; and over all our gloom, the sun of Righteousness still shines a beacon and a hope.": {
+    "emoji": "😌➡️💀⛰️, 🙏💪🌍↪️; ⬆️😞🌑, ☀️⚖️💡✨🚦💡🕯️💡🤞.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Consider, once more, the universal cannibalism of the sea": {
+    "emoji": "🤔,🔂, 🌐🍴🌊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Look at the crowds of water-gazers there.": {
+    "emoji": "👀👥👥👥⛲👀👥👥👥",
+    "date": "2024-01-01T00:00:00"
+  },
+  "What all men’s minds and opinions but Loose-Fish?": {
+    "emoji": "❓🤔👨‍👩‍👧‍👦💭💬🐟💨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "He announced himself as the archangel Gabriel, and commanded the captain to jump overboard.": {
+    "emoji": "🗣️👤🔜👼Gabriel, 🎤⛴️👨‍✈️👉⏩🌊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Quick! forge me the harpoon.": {
+    "emoji": "⚡️🔨🔥🛠️🐳🔱",
+    "date": "2024-01-01T00:00:00"
+  },
+  "all of us are Ahabs": {
+    "emoji": "🌍👫👬👭➡️🐋🎣🧔🏽",
+    "date": "2024-01-01T00:00:00"
+  },
+  "as if, the longer linked with life, the less man has to do with aught that looks like death": {
+    "emoji": "🤔💭, ⏳🔗🧑‍🤝‍🧑🌱🌍, ➖🕺🔎🤷‍♂️🔜💀👀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Beelzebub himself might climb up the side and step down into the cabin to chat with the captain, and it would not create any unsubduable excitement in the forecastle.": {
+    "emoji": "😈👣⬆️👈🏔️➕💃⬇️🚪🚢🗣️🗣️👮‍♂️, ➕🚫🌪️🤯🔥✨🎪🎉🔦.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "a score of voices from all parts of the vessel, simultaneously with the three notes from aloft, shouted forth the accustomed cry": {
+    "emoji": "🔢🗣️🗣️🗣️🔀🌐🛥️, ⏱️👥👥👥🎵🎵🎵🔝, 🔊🔊🔊📣📣📣🗣️📢📢📢🔀🔧👥👥👥🗣️🗣️🗣️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "this earthly air, whether ashore or afloat, is terribly infected with the nameless miseries of the numberless mortals who have died exhaling it": {
+    "emoji": "🌍💨, 🏞️🚢, 😱😷 🚫📛 😢😢 🌐💀 👥 💔😵 💬🌬️👋",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the first boat always hovers at hand to assist its consort": {
+    "emoji": "1️⃣🚤🔄✋🆘🤝🚤",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Be cool at the equator; keep thy blood fluid at the Pole.": {
+    "emoji": "😎🆒🌍🌓;🤲🩸💧📍🏔️.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "But when Leviathan is the text, the case is altered.": {
+    "emoji": "🔍🐉📜, 💼🔄",
+    "date": "2024-01-01T00:00:00"
+  },
+  "For the most part, in this tropic whaling life, a sublime uneventfulness invests you": {
+    "emoji": "👉🏻🌏⚖️, 🌴🐳🎣🏞️, 🙌🌌📅🧥👤",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Thou who, in all Thy mighty, earthly marchings, ever cullest Thy selectest champions from the kingly commons; bear me out in it, O God!": {
+    "emoji": "🙏🌍🚶‍♂️💪🙏🕴️🏆⤵️👑👥, 🙏🙏🙏🗣️🆙🌬️👈🔛🙋‍♂️, 🛐🙏!",
+    "date": "2024-01-01T00:00:00"
+  },
+  "does it not bear a faint resemblance to a gigantic fish? even the great leviathan himself?": {
+    "emoji": "❓🚫🐻🔍👥🐠❓🌎🦈🤷‍♂️🤔",
+    "date": "2024-01-01T00:00:00"
+  },
+  "great hearts sometimes condense to one deep pang, the sum total of those shallow pains kindly diffused through feebler men’s whole lives": {
+    "emoji": "💟👍💖⏰🌀➡️1️⃣🔵😖, ➕💢🎯🔢👥🥺😢🤲🌍💫👬👴💔🕰🌍🕊️🕰️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "There go the ships; there is that Leviathan whom thou hast made to play therein": {
+    "emoji": "👉⛵⛵⛵; 👉🐋🙏🛠️🎭👇",
+    "date": "2024-01-01T00:00:00"
+  },
+  "this six-inch chapter is the stoneless grave of Bulkington": {
+    "emoji": "📖6️⃣〰️🔠➡️⚰️🚫💎🪦🧑‍🦱🟠",
+    "date": "2024-01-01T00:00:00"
+  },
+  "you are now to be apprised of the nature of the substance which so impregnably invests all that apparent effeminacy": {
+    "emoji": "👉👤🔛👀🔍↪️🧪🌐🤔💼🚫✨🔬👀👈🌸👗💪",
+    "date": "2024-01-01T00:00:00"
+  },
+  "why all the living so strive to hush all the dead": {
+    "emoji": "❓🌍🌳👫🏻🦁🐦💪🔇💀👻⚰️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "every strange, half-seen, gliding, beautiful thing that eludes him; every dimly-discovered, uprising fin of some undiscernible form, seems to him the embodiment of those elusive thoughts": {
+    "emoji": "🌍👽👀🕺🏽💖✨🏞️🏃‍♂️💨; 💡😔🔬⛰️🦈🔍🏞️👤, 🧩🤔🌫️💭💭",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I would fain feel this pulse, and let mine beat against it; blood against fire!": {
+    "emoji": "👁️❤️🙏🏼✋💓, ➕👋☮️💢↔️💖; 💉↔️🔥!",
+    "date": "2024-01-01T00:00:00"
+  },
+  "all that stirs up the lees of things": {
+    "emoji": "🌎 ➡️🔄⬆️ 🍷🥘🔍🔬📚🎨📸💡🌱",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the wildest winds of heaven and earth conspire to cast her on the treacherous, slavish shore": {
+    "emoji": "🌪️🌬️🌎🌌🤝🎭👩⛵️🌊🌴⚓️⛓️🏖️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "This is the Pequod, bound round the world! Tell them to address all future letters to the Pacific ocean!": {
+    "emoji": "👈🏼🔵🚢🐳 Pequod, ➰🌏! 🗣️👥📝✉️🔮 Pacific🌊!",
+    "date": "2024-01-01T00:00:00"
+  },
+  "In old England the greatest lords think it great glory to be slapped by a queen": {
+    "emoji": "🏴👴🤴💭👑💫🤚👸",
+    "date": "2024-01-01T00:00:00"
+  },
+  "His spout was short, slow, and laborious; coming forth with a choking sort of gush, and spending itself in torn shreds": {
+    "emoji": "👨‍🦰🐳💦📏🐢😫➡️🚰💥⏱️🔚🌪️🎟️🧻",
+    "date": "2024-01-01T00:00:00"
+  },
+  "indeed, he is expected to set an example of superhuman activity": {
+    "emoji": "👍, 👨‍💼⏳🔜➡️🔨👣🏆🦸‍♂️🏃‍♂️💼🎯🌐",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the other will be utterly excluded from your contemporary consciousness": {
+    "emoji": "👥🚫🚪🚫🕒💭",
+    "date": "2024-01-01T00:00:00"
+  },
+  "A Fast-Fish belongs to the party fast to it.": {
+    "emoji": "🅰️⏩🐠🔐🎉📎🔛🔒",
+    "date": "2024-01-01T00:00:00"
+  },
+  "there is nothing wonderful": {
+    "emoji": "❌🚫🌈🎊🎉",
+    "date": "2024-01-01T00:00:00"
+  },
+  "“Bouton de Rose,”—Rose-button, or Rose-bud; and this was the romantic name of this aromatic ship.": {
+    "emoji": "\"🌹🔘,\" - 🌹🔘, or 🌹🌱; and this was the 😍 name of this 🎶🚢.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "exceedingly juicy": {
+    "emoji": "🔝🥤🍉",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the sharks, also, with their jewel-hilted mouths, are quarrelsomely carving away under the table at the dead meat": {
+    "emoji": "🦈🦈, 💎🗡️👄, 🔛➡️, 😡🔪🔪⬇️🍽️➡️💀🍖",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the six men composing the crew pull into the jaws of death, with a halter around every neck": {
+    "emoji": "6️⃣👨‍👨‍👦‍👦🎼🛶➡️💀👄, 🔄🔗🔃👤👤👤👤👤👤👔",
+    "date": "2024-01-01T00:00:00"
+  },
+  "The harpoon was hurled.": {
+    "emoji": "🔱🤾‍♂️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "it’s a wicked world in all meridians; I’ll die a pagan.": {
+    "emoji": "😈🌍↔️🧭; 🙋‍♂️💀🕉️.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "it must symbolize something unseen": {
+    "emoji": "👉👥🔮📖⚠💡👀🚫",
+    "date": "2024-01-01T00:00:00"
+  },
+  "All Loose-Fish.": {
+    "emoji": "🐠🐠🐠🐟🐟🐟💨💨💨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I am so rich, I could have given bid for bid with the wealthiest Prætorians at the auction of the Roman empire": {
+    "emoji": "💁‍♂️💰🤑, 💁‍♂️🔄💰🙋‍♂️🆚💸💵🤵‍♂️🏛️🔨🏦🏛️🏟️🤝🌍📜🏷️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the fabled heavens with all their countless tents really lie encamped beyond my mortal sight": {
+    "emoji": "📖✨🌌⛺⛺⛺🔢👀👉🚫👓👨‍🦳🌄",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Jonah merely meant a life-preserver—an inflated bag of wind—which the endangered prophet swam to, and so was saved from a watery doom": {
+    "emoji": "👨‍🦰👉🤷‍♂️💭🚫🔪🕰️, 🌬️➕🛍️💨 (🏊‍♂️✊🔜) = ⛑️💦🔮➕🙏.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "when I go to sea, I go as a simple sailor, right before the mast, plumb down into the forecastle, aloft there to the royal mast-head": {
+    "emoji": "🕰️⬅️🚶‍♂️🌊, 👉🚶‍♂️➡️👍🧑⚓️, 👉👍🔍🚢⚓️, ⤵️🔜👇🚢👈, ↖️👆👑🚢⚓️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I will send you to hell.": {
+    "emoji": "😈🔜📲🔜👉🔥👹",
+    "date": "2024-01-01T00:00:00"
+  },
+  "upon first cutting into him with the spade, the entire length of a corroded harpoon was found imbedded in his flesh": {
+    "emoji": "🕰️🥇✂️👨‍⚕️🔪, 🔍🗡️📏⬅️🗑️🪓🔎🍖🤕💉",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Now, how had this noble rescue been accomplished?": {
+    "emoji": "🤔❓, 🔎💡👑🚑🏅💪💯❓",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the whaleman is wrapped by influences all tending to make his fancy pregnant with many a mighty birth.": {
+    "emoji": "🐋👨🌬️🔄🌐🌟➡️🤰💭💪🐣🔚",
+    "date": "2024-01-01T00:00:00"
+  },
+  "he cannot be thus circumstanced without a shudder that makes the very marrow in his bones to quiver in him like a shaken jelly": {
+    "emoji": "🚫➡️🚹🌀👥💦🥶, 💀(🍖➡️🦴)🦠🍮👈😱🕺",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the blubber wraps the body of the whale, as the rind wraps an orange": {
+    "emoji": "🐋➡️🌐, 🍊🍃🔁🍊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "But this is not the half; look again.": {
+    "emoji": "👆,👀, 🔍️,🙅‍♂️, 1️⃣/2️⃣",
+    "date": "2024-01-01T00:00:00"
+  },
+  "in her murderous hold this frigate earth is ballasted with bones of millions of the drowned": {
+    "emoji": "👩💀🤝🛳️🌍🔮💀💀💀🌊🌊🌊👥👥👥",
+    "date": "2024-01-01T00:00:00"
+  },
+  "his ship was indeed what in the Fishery is technically called a clean one (that is, an empty one)": {
+    "emoji": "👨🚢👌🐟🏭📚🗣️🧼1️⃣ (➡️🕳️1️⃣)",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Whales, sharks, and monsters, arm’d in front or jaw, With swords, saws, spiral horns, or hooked fangs.": {
+    "emoji": "🐋, 🦈, 👾, 💪🔔, 🔙 or 🦷, 🗡️,🪚,🌀🦄, or 🪝🧛‍♀️.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "all three of us lifelessly swung from the spars, and for every swing that we made there was a nod from below from the slumbering helmsman": {
+    "emoji": "👨‍👦‍👦⛔️💫🔀📏 ➕🔁🤕🕺🏽🔛🚢🔨, ➕➰💫🕺🏽🔛🔁➡️🙇‍♂️🔽⬇️🔙😴⛵🤵‍♂️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Methinks we have hugely mistaken this matter of Life and Death.": {
+    "emoji": "🤔💭, 👥🚫❗️💡🔄⚖️, ⚠️🤷‍♀️™️💡❓💫⬇️🚧👁️‍🗨️🔚🍂☠️🚫🔁🎭",
+    "date": "2024-01-01T00:00:00"
+  },
+  "then Gemini, or the Twins—that is, Virtue and Vice": {
+    "emoji": "➡️♊, 👥 (👼👹)",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Give it up, Sub-Subs!": {
+    "emoji": "🤲🛑, 🚢🚢!",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Madman! look through my eyes if thou hast none of thine own.": {
+    "emoji": "😡🤪! 👀👁️👁️👈👇🕵️‍♂️ if ⬅️👤❌🚫of 👤👀👈.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Full in this rapid wake, and many fathoms in the rear, swam a huge, humped old bull": {
+    "emoji": "🌕👉🌊💨🌊, ➕🔢📏👇🔙, 🏊‍♂️🐳🐋👴🐂",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Nor was this all.": {
+    "emoji": "❌👥👉⭐👨‍🤝‍👨🌙👤💭🔛",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Dissect him how I may, then, I but go skin deep; I know him not, and never will.": {
+    "emoji": "🔪👨‍⚕️🤷‍♂️🔎, ➡️, 🙋‍♂️💨👉🏻💆‍♂️🔝; 🙋‍♂️🤔🕵️‍♂️🚫, ❌🔄💭.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "all sailors of all sorts are more or less capricious and unreliable—they live in the varying outer weather, and they inhale its fickleness": {
+    "emoji": "👥⛵✨🎭🤷‍♂️ ⚖️👀💭—🏠🌦🌈🌪🔮, 😵💨🌀🌦🎲🔄",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the mate commanded him to get a broom and sweep down the planks, and also a shovel, and remove some offensive matters consequent upon allowing a pig to run at large": {
+    "emoji": "👥🗣️👉🙍‍♂️➡️🧹🧱,🔍🧹⬇️🍃,🙏🔍🥄🕳️,➕🔄🚮🦨🗑️🐖🆓🏃‍♂️☑️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "A Loose-Fish is fair game for anybody who can soonest catch it.": {
+    "emoji": "🅰️🐟💨🎯🎮🔄🙋‍♂️🙋‍♀️💨🔜🎣🎣🎣",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Fate reserved the doubloon for me.": {
+    "emoji": "🔮💾🔄💰👈🏻🙋‍♂️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "But then again, what has the whale to say?": {
+    "emoji": "🤔➡️🔄, 🤷‍♂️🗣️🐋?",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Beneath the unclouded and mild azure sky, upon the fair face of the pleasant sea, wafted by the joyous breezes, that great mass of death floats on and on, till lost in infinite perspectives.": {
+    "emoji": "👇🔵🌌🌤️, 🔛👩‍🦰💙🌊, 🌬️😆💨, 👇⚰️🗺️⭐🚣‍♂️➡️➡️, 📛⛔🔁⏸️🔍.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Thus they rushed; each man with might and main clinging to his seat, to prevent being tossed to the foam": {
+    "emoji": "💨💨👥🏃‍♂️💪💺👥🤲🙅‍♂️🌊🌊👋🏄‍♂️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "he tried to shut down the dead lid of his murderous jaw": {
+    "emoji": "👨‍💼🔪👄🔽🚫🪦💀🚪⚰️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "God! God! God!—crack my heart!—stave my brain!—mockery! mockery! bitter, biting mockery of grey hairs": {
+    "emoji": "🙏! 🙏! 🙏! - 💔 my ❤️! - 🤯 my 🧠! - 🎭! 🎭! 😖😖, 🦷🦷 mockery of 🧓👨‍🦳👵👴!",
+    "date": "2024-01-01T00:00:00"
+  },
+  "from unavoidable circumstances, considerable of it is spilled, leaks, and dribbles away, or is otherwise irrevocably lost in the ticklish business of securing what you can": {
+    "emoji": "🔄↩️⛔🚫👥💼, 😮📏💧↘️⬇️, 💦, 🍶☔ 💨, ➡️⛔🔙🔒💔↩️👀🤚🎯🏆🔒💼🍀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the secret of our paternity lies in their grave, and we must there to learn it": {
+    "emoji": "🔒🤫👨‍👧‍👦💡📍☠️⚰️👥📚👀👈",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Ahab stands alone among the millions of the peopled earth, nor gods nor men his neighbors!": {
+    "emoji": "🧔🕴️🚶‍♂️💫🌍👫👭👬🚫🙏🚶‍♂️🚫👥🏠🏘️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "however prolonged and exhausting the chase, the harpooneer is expected to pull his oar meanwhile to the uttermost": {
+    "emoji": "🔀⏳🏃‍♂️😓🔁, 🎯🐳🧑‍🚣‍♂️👈👍🔜 🚣‍♂️💪🏽➡️🔚🔄❗️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "they regarded it, not as a foreshadowing of evil in the future, but as the fulfilment of an evil already presaged": {
+    "emoji": "👥👀🎭, ❌🔮👹🕰️, ➡️💫👹🔮🕠",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Whether that mark was born with him, or whether it was the scar left by some desperate wound, no one could certainly say.": {
+    "emoji": "❓✅🎯👶🍼👨‍🍼, ❓✅🎯🍁🤕💔😔, 🚫🙍‍♂️👍💬🤷‍♂️.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "The vast tackles have now done their duty. The peeled white body of the beheaded whale flashes like a marble sepulchre": {
+    "emoji": "🌌🎣👍✅💼. 🔪🤍🐋🚀💥⚪💡🏛️.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Woe to him whose good name is more to him than goodness!": {
+    "emoji": "😢➡️👤👋🌟📛🥇➡️👤💖🤝👍",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Can’t ye see the world where you stand?": {
+    "emoji": "🚫👀🌍📍👣❓",
+    "date": "2024-01-01T00:00:00"
+  },
+  "it is hidden away behind its vast outworks, like the innermost citadel within the amplified fortifications of Quebec": {
+    "emoji": "🤫🔍👈🔛🏰⛰️, 👍✔️↩️🏞️🏰🔍⛓️➡️🔊🏗️🔛🇨🇦🏰",
+    "date": "2024-01-01T00:00:00"
+  },
+  "And of all these things the Albino whale was the symbol.": {
+    "emoji": "💫✨🐳🐋🕊️🎭🕹️🚼🔖",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Inlanders all, they come from lanes and alleys, streets and avenues—north, east, south, and west.": {
+    "emoji": "🏞️👥👥, 🚶‍♀️🚶‍♂️🔄🛣️🔀🏘️, 🛤️🛣️- 🧭🔝, 🧭➡️, 🧭⬇️, 🧭⬅️.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "every boat was a buoy; the sunken whale being suspended a few inches beneath them by the cords": {
+    "emoji": "⛵⛵⛵ = ⚓; 🐋💦👇🏽🔗🔗🔗💧💧💧🔗⛵⛵⛵",
+    "date": "2024-01-01T00:00:00"
+  },
+  "O Nature, and O soul of man!": {
+    "emoji": "🌿🌳, 🔮🙎‍♂️!",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Each silent worshipper seemed purposely sitting apart from the other, as if each silent grief were insular and incommunicable.": {
+    "emoji": "🔇🙏🔛🔂😶🙇‍♂️🤔💺➡️🚶‍♂️🚶‍♀️, ➡️🔇😭🏝️😶🔏📴.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "infantileness of ease undulates through a Titanism of power": {
+    "emoji": "👶➡️🏞️😌🌊🔄🏔️💪🔱💥",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Unconsciously my chirography expands into placard capitals.": {
+    "emoji": "😴✍️💭📈➡️📜🔠",
+    "date": "2024-01-01T00:00:00"
+  },
+  "give me the privilege of making my own summer with my own coals": {
+    "emoji": "🙏🎁👉👑🔨🛠️👈☀️🔥⛱️🥥🔥",
+    "date": "2024-01-01T00:00:00"
+  },
+  "how then can this one small heart beat": {
+    "emoji": "❓🔜🔮❓💓🔬🗝️✊🩸",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the weapon is instantly at hand to its hurler": {
+    "emoji": "🔫⏱️✋🔄🤾‍♂️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Stubb scattered the dead ashes over the water; and, for a moment, stood thoughtfully eyeing the vast corpse he had made.": {
+    "emoji": "'Stubb💭🔀👨‍🌾🧹🪦⚱️🔝💧; ➕, 🅰️💭, ⏱️🚶‍♂️💭👁️👁️🌊💀☠️🤲🔨🔧.'",
+    "date": "2024-01-01T00:00:00"
+  },
+  "in tormented chase of that demon phantom that, some time or other, swims before all human hearts; while chasing such over this round globe, they either lead us on in barren mazes or midway leave us whelmed": {
+    "emoji": "😰🏃‍♀️👿👻🕓🕟🕗,🏊‍♂️🧡💔🌍; 😰🏃‍♀️➡️🌎, 😕🔀🏜️☹️😵‍💫🔚+🌊🆘",
+    "date": "2024-01-01T00:00:00"
+  },
+  "That head upon which the upper sun now gleams, has moved amid this world’s foundations.": {
+    "emoji": "☝️👤💡🔛🌞↪️, 🚶‍♂️💫🌍🏗️🔀.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "but the reason why the grave-digger made music must have been because there was none in his spade": {
+    "emoji": "🍑, 🤔💬👍🏽 🔹🆚 🔀 ⚰️👷🔺🎵👾 🆘🈶 🛑📵 🎵🔄 🏺🪓⛏️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the motion of a Sperm Whale’s flukes above water dispenses a perfume, as when a musk-scented lady rustles her dress in a warm parlor": {
+    "emoji": "🌊🐋👋👆💦💨👃🌹, 🌐👩👃💋💃👗💨🔥🏠",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Jeremy Bentham’s skeleton, which hangs for candelabra in the library of one of his executors": {
+    "emoji": "👨‍🦳🦴💀, 🏗️🕯️📚📖🏣👨⚖️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "with my own hand I ply my own shuttle and weave my own destiny into these unalterable threads": {
+    "emoji": "✋🤚🔄🚀💫, 🔮⏳ ➡️🚫⏪🧵🧶🔮⚖🔄🔮.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "in what eternal, unstirring paralysis, and deadly, hopeless trance, yet lies antique Adam who died sixty round centuries ago": {
+    "emoji": "🤔🕰️🔄, 🔒⛔💤, ☠️😞💭, 🛏️👴⏳Adam⚰️⌛6️⃣0️⃣🔄🗓️🤷‍♂️👈",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Ignorance is the parent of fear": {
+    "emoji": "🤔👨‍👩‍👧‍👦🕸️😱",
+    "date": "2024-01-01T00:00:00"
+  },
+  "these savages have an innate sense of delicacy, say what you will; it is marvellous how essentially polite they are": {
+    "emoji": "👥🐅🐯🥁👈🧪💡🌹🎩💭💬🤷‍♂️; 🌌🤯💁‍♀️👍🏼🔬🎁🎊👏🏼💝🙏🏼",
+    "date": "2024-01-01T00:00:00"
+  },
+  "one continual stream of Venetianly corrupt and often lawless life": {
+    "emoji": "1️⃣🔄🌊🇮🇹💰🔥⚖️❌🤷‍♀️💀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Oh, won’t ye pull for your duff, my lads—such a sog! such a sogger! Don’t ye love sperm?": {
+    "emoji": "😮❗️🙏🏽💪👜💼👬🌊🌊🌊💦💦❗️😍😍❓🐳",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Delight is to him—a far, far upward, and inward delight": {
+    "emoji": "😃👉👤 - 🚀⤴️⤴️🔝, ➕🔍🎉",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Hurrah for the gold cup of sperm oil, my heroes!": {
+    "emoji": "🎉🏆🥇🥤🐳💦, 🙌🦸‍♂️!",
+    "date": "2024-01-01T00:00:00"
+  },
+  "But flukes! man, what makes thee want to go a whaling, eh?": {
+    "emoji": "❗️🐳⚓️! 👨‍🎤, 🤔❓, 💡👉🛶🐳🎣, ❓",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I’m quite certain that he’s no more fit to command a whale-ship than a St. Jago monkey. In fact, tell him from me he’s a baboon.": {
+    "emoji": "😊🔒👍🏻🤔👦❌💪🛳🐋 ➡️ 👓🐒. ✅💬, 🗣👉👦💌👈🐒.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "this is what ye have shipped for, men! to chase that white whale on both sides of land, and over all sides of earth": {
+    "emoji": "👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈👈",
+    "date": "2024-01-01T00:00:00"
+  },
+  "What does the whaler do when she meets another whaler in any sort of decent weather? She has a “Gam,” a thing so utterly unknown to all other ships that they never heard of the name even": {
+    "emoji": "❓❓🐳👩‍🦰🤔💭🕑➡️🤝➡️🐳👩‍🦰🌤️☀️🌥️? 👩‍🦰🕑\"Gam,\" 👥🎉👀❗️❌💡❓⚓🚢👂🔉❓📛⏭️⛔❕",
+    "date": "2024-01-01T00:00:00"
+  },
+  "oil is a sliding thing": {
+    "emoji": "⛽️➡️🔀🍮",
+    "date": "2024-01-01T00:00:00"
+  },
+  "then scepticism, then disbelief, resting at last in manhood’s pondering repose of If": {
+    "emoji": "🔜❓🧐🔜❌🙅‍♂️💭, 🛏️🔄🔚👨‍🦱💭✋🤔🔄'If'",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Alike, joy and sorrow, hope and fear, seemed ground to finest dust, and powdered, for the time, in the clamped mortar of Ahab’s iron soul.": {
+    "emoji": "👥🔀, 😄🤝😢, 🤞🤝😨, 👀👍🔬💨, ⌛🔁🤏, 🕰️, 🔒💊🤲🪓⚙️🔮🚶‍♂️🤎.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "For sleeping man, ’twas hard to choose between such winsome days and such seducing nights.": {
+    "emoji": "💤😴👨, ⚖️🤔📊🌞🏞️☀️🎉🌻🌷🌈🆚🌚🌌🖤😍🌜🌃🌟🌠➰💫🌚.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Suddenly bubbles seemed bursting beneath my closed eyes": {
+    "emoji": "🌫️💥😮👀🌊🔽👁️👁️⛔",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I thought it was high time, now or never, before the light was put out, to break the spell in which I had so long been bound.": {
+    "emoji": "💭💡⏰⬆️⏱️, 🕰️➡️🚫🕰️, 🔜🔦🚫💡🔚, 🗡️⚡️💔🔮✨📖🔄✨🔗⏳🔟💯.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "for hours he fell into the deeper midnight of the insatiate maw": {
+    "emoji": "⏳🕓🕔🕕🕖🕗🕘🕙🕚🕛🕜🕝🕞🕟🕠🕡🎩🕳️🌑🌑🌑👄🍽️🌀💤👇🌚🌚🌚",
+    "date": "2024-01-01T00:00:00"
+  },
+  "It never wriggles.": {
+    "emoji": "❌🐍🔄",
+    "date": "2024-01-01T00:00:00"
+  },
+  "This whole book is but a draught—nay, but the draught of a draught.": {
+    "emoji": "📖➡️🍺➡️❌, ➡️🍺🍺.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the proverbial evanescence of a thing writ in water, a wake": {
+    "emoji": "📜💬💨🌊✍👀💦⏰",
+    "date": "2024-01-01T00:00:00"
+  },
+  "in his poor opinion, the wondrous whale was but a species of magnified mouse, or at least water-rat, requiring only a little circumvention and some small application of time and trouble in order to kill and boil": {
+    "emoji": "🤔💭🚫💰, 🌟🐋 ➡️ 🔍🐭, 🤷‍♂️💦🐀, 🙏⏲️🔄 ➕ ⏳⚙️🤏 2️⃣ 🗡️➕🔥🍲",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the Nor’ West Passage, so long a problem to man, was never a problem to the whale": {
+    "emoji": "🧭🌍⬅️🚢🕗🚶‍♂️❓, 🚫❓🐋",
+    "date": "2024-01-01T00:00:00"
+  },
+  "these marvels (like all marvels) are mere repetitions of the ages": {
+    "emoji": "👉🌠 (➡️🕰️) (👍💫) ➡️🔂🎭⌛",
+    "date": "2024-01-01T00:00:00"
+  },
+  "this sunken-eyed young Platonist will tow you ten wakes round the world, and never make you one pint of sperm the richer": {
+    "emoji": "👀👇🧒💡🌐🚛🔟🌊🌍, 👎💰1️⃣🍺💦",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the Cape winds began howling around us, and we rose and fell upon the long, troubled seas that are there": {
+    "emoji": "🏞️💨🧩🅱️🌀🔄🤟, 🆙 📈⬇️ ↩⤵️🔛🌊🔃🌊, 🌫️💦⚠️📍👩‍👩‍👧‍👦👀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Chief among these motives was the overwhelming idea of the great whale himself.": {
+    "emoji": "👑💡🌊🐋💡",
+    "date": "2024-01-01T00:00:00"
+  },
+  "it seemed as if this were the Loom of Time, and I myself were a shuttle mechanically weaving and weaving away at the Fates": {
+    "emoji": "🤔➡️🕰️👍🏻👨‍🔬⌛, ➕👤💁‍♀️🏎️😴💭➰💭👀🔮🎚️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "if these secret golden keys did seem to open in him his own secret golden treasuries, yet did his breath upon them prove but tarnishing": {
+    "emoji": "🔐🔑🔑✨💫🤫💫🧒💫🔒💰💰💰💰✨💫🤫💫, ➡️😤💨🔐🔑🔑👈🔍💔😵🥈🤷🤔",
+    "date": "2024-01-01T00:00:00"
+  },
+  "The skeleton dimensions I shall now proceed to set down are copied verbatim from my right arm, where I had them tattooed": {
+    "emoji": "💀📏👇🔜✍️💾🔁💬📋👉💪,✍️📍🖊️🎨📌",
+    "date": "2024-01-01T00:00:00"
+  },
+  "For that business is an exceedingly laborious one; is not very soon completed; and requires all hands to set about it.": {
+    "emoji": "👉🏻📚💼📈💼 ➡️🔥💪🕰️💯1️⃣; 🚫⌛⌛💖💯1️⃣; ⏩🙏👐🚀🅰🅱🔍🔍💯1️⃣.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "a headlong wave shot the boat far ahead, and its seethings drowned all speech": {
+    "emoji": "🌊🏹🚤🔜🌬️🔇🗣️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Would to God these blessed calms would last.": {
+    "emoji": "🙏🙌🙏🌟🌈🛐🌬️🕊️🔁⏳🙏",
+    "date": "2024-01-01T00:00:00"
+  },
+  "floating in the lovely sunset sea and sky, sun and whale both stilly died together": {
+    "emoji": "💭💖🌅🌊🌌, ☀️🐳😌☠️🤝",
+    "date": "2024-01-01T00:00:00"
+  },
+  "But Ahab’s glance was averted; like a blighted fruit tree he shook, and cast his last, cindered apple to the soil.": {
+    "emoji": "🔁 Ahab's 👀 was 🔄; like a 🍏🌳 infected by🦠 he 🤝, and 🎯 his last, 🔥🍎 to the 🌱.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "But what I am driving at here is this.": {
+    "emoji": "🤔💭🚗👈📍📌👀👇",
+    "date": "2024-01-01T00:00:00"
+  },
+  "singing some pagan psalmody": {
+    "emoji": "🎤🎵📜🌙🌲",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I find so many great demi-gods and heroes, prophets of all sorts": {
+    "emoji": "👀💡🔎👥🎖️🏅🧡💪⚡️🏋️‍♂️🔱, 🔮💬🕊️🎆🌍🌈💫🔮",
+    "date": "2024-01-01T00:00:00"
+  },
+  "a vacated thing, a formless somnambulistic being, a ray of living light, to be sure, but without an object to colour, and therefore a blankness in itself": {
+    "emoji": "🅰️❎📦, 🅰️👤💤🚶‍♂️, 🅰️🔦💡💡🌞☀️, ✅👍, 🚫🎯 ➡️🎨🎨, ❗❌➕ ⬛⚫◼️⬛⬛.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Truth hath no confines.": {
+    "emoji": "📖➡️🚫🚧",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Almost rather had I seen Moby Dick and fought him, than to have seen thee, thou white ghost!": {
+    "emoji": "👀🐋💔🥊🆚👀👻⚪️❗",
+    "date": "2024-01-01T00:00:00"
+  },
+  "it arched forth its vast archangel wings, as if to embrace some holy ark": {
+    "emoji": "💫🌐🌈🕊️👐, 🤲💒🚢🙏",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I prospectively ascribe all the honor and the glory to whaling; for a whale-ship was my Yale College and my Harvard.": {
+    "emoji": "👁️🔮✍️🌟🏆🔛🐋🎣; 🐋🚢👈🎓🏫🔁Yale College🏛️📚 & Harvard.📚🏛️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I shall let it abide here till the White Whale is dead": {
+    "emoji": "👁️🔜🔁👇🏽👀🚪⏱️⬛🐳☠️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "in his inclement, howling old age, Ahab’s soul, shut up in the caved trunk of his body, there fed upon the sullen paws of its gloom": {
+    "emoji": "👤🌧️🔊👴🌜🕳️📦👤🚫😕🍴🖐️🌑",
+    "date": "2024-01-01T00:00:00"
+  },
+  "fatal to the last degree of fatality; those repeated disastrous repulses, all accumulating and piling their terrors upon Moby Dick": {
+    "emoji": "💀🔚🎚️☠️; 🔁😱🏳️, 📚🏗️😨🔛🐳",
+    "date": "2024-01-01T00:00:00"
+  },
+  "in one of the Pagan temples, there stood for many ages the vast skeleton of a whale": {
+    "emoji": "📌1️⃣➡️1️⃣🕍🏯, 🔎🕰️🕰️🕰️🐋💀🧍‍♂️⬆️🔢🌅🌅🌅",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Because no man can ever feel his own identity aright except his eyes be closed": {
+    "emoji": "🕵️‍♂️⛔👨‍🦱➡️💭🆗👁️🙈",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Retribution, swift vengeance, eternal malice were in his whole aspect": {
+    "emoji": "⚖️🏃‍♂️💨, ⚔️🔥, 👹⏳ were in his 🍂👁️‍🗨️👤🌐",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I survived myself; my death and burial were locked up in my chest.": {
+    "emoji": "😀👏✅💪; ☠️⚰️🔒🆙➡️💖.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Does not this whole head seem to speak of an enormous practical resolution in facing death?": {
+    "emoji": "❓❌🌐💡💭🗣️🤔✨💪🛠️👊💀❓",
+    "date": "2024-01-01T00:00:00"
+  },
+  "they cast long gleams of light over the turbid sea": {
+    "emoji": "👥🪄🌟🔦📏✨🌊🌫️🌊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "In tempestuous times like these, after everything above and aloft has been secured, nothing more can be done but passively to await the issue of the gale.": {
+    "emoji": "🌩⌛🕰️👍👥, ⏭️🌐⬆️✈️🔒, 🚫➕🔜✅💼👍🔄🔜☮️🕊️☀️🌪️🔚.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "There are only two books in being which at all pretend to put the living sperm whale before you, and at the same time, in the remotest degree succeed in the attempt.": {
+    "emoji": "📚✌️🔛🐋💦👀, ⏰🔛, 🏞️🔭🎯👌.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Buoyed up by that coffin, for almost one whole day and night, I floated on a soft and dirgelike main.": {
+    "emoji": "🎈⬆️⚰️,🔄🕐1️⃣🌞🌚, 🏊‍♂️👍🌀📓🌊🎵🎶.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "So man’s insanity is heaven’s sense": {
+    "emoji": "👉🙎‍♂️🤪🔄🌌🎯",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Of such a letter, Death himself might well have been the post-boy.": {
+    "emoji": "📨☠️👦📮",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Our sail was now set, and, with the still rising wind, we rushed along; the boat going with such madness through the water": {
+    "emoji": "👥⛵️⏩🔛, ➕, 🍃🔝💨, 🏃‍♂️💨💨; 🛶🤪💨💦🌊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "—I come to report a fair wind to him. But how fair? Fair for death and doom": {
+    "emoji": "\"➡️🚶‍♂️📝💨😊👨‍⚖️↩️🤔💭🌤️? 🌤️☠️😱\"",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Who but a fool would take his left hand by his right, and say to himself, how d’ye do?": {
+    "emoji": "🤷‍♂️🤔🤪🤚👈👊👉🗣️👤💭🤗❓",
+    "date": "2024-01-01T00:00:00"
+  },
+  "his shipmates called him mad": {
+    "emoji": "👨‍👦‍👦🚢📞🤪",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Spain—a great whale stranded on the shores of Europe.": {
+    "emoji": "🇪🇸➖🐋👍🏖️🇪🇺",
+    "date": "2024-01-01T00:00:00"
+  },
+  "he and the sharks were at times half hidden by the blood-muddled water": {
+    "emoji": "👨🦈🕰️👥🔮🩸💦",
+    "date": "2024-01-01T00:00:00"
+  },
+  "that great mass of death floats on and on, till lost in infinite perspectives": {
+    "emoji": "👉🟣✨💀🌊➡️➡️➡️, ⏭️💔🆚🔚🎢🌀🔄🔄🔄",
+    "date": "2024-01-01T00:00:00"
+  },
+  "we know the sea to be an everlasting terra incognita": {
+    "emoji": "👥🧠🌊➡️🔄🌍🚫❓",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the ocean’s invisible flood-tide lifted him higher and higher towards his destined heaven": {
+    "emoji": "🌊👻🌊🔝🚹🆙🆙➡️🔮☁️🌌",
+    "date": "2024-01-01T00:00:00"
+  },
+  "In a strait-jacket, he swung to the mad rockings of the gales": {
+    "emoji": "👤➡️🔒🧥, 👤▶️↪️ 🌀 👉↕️ 🔮🌬️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "You shuddered as you gazed": {
+    "emoji": "😨👀👈",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I’ll ten times girdle the unmeasured globe; yea and dive straight through it, but I’ll slay him yet!": {
+    "emoji": "💬🔟✖️ 👥🌍⭕; 👍 🏊‍♂️ ⤵️↔️,  ❗️ 👥🗡️👤🔜!",
+    "date": "2024-01-01T00:00:00"
+  },
+  "it was my cheerful duty to attend upon him while taking that hard-scrabble scramble upon the dead whale’s back": {
+    "emoji": "😀💼👈🏾💁‍♂️🤝⌚🕺🏃‍♂️💪🥵🔝🐋💀🔙",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Avast! How will that help him; jamming that iron-bound bucket on top of his head? Avast, will ye!": {
+    "emoji": "⚓️❗️🤔❓🆘🤷‍♂️🍓💢🔩🔒🪣💠🔝👤👨‍🦲❓⚓️🤚👈❗️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "nor one single star can revolve, but by some invisible power": {
+    "emoji": "🚫1️⃣🌟⭐️🔄, ➡️🎯🔍🌈💪🤲",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the whale would by all hands be considered a noble dish, were there not so much of him": {
+    "emoji": "🐋🍽️👍🙏👑🍛, 🚫👥🤷‍♂️🤔❓📏📐🕰️🐋",
+    "date": "2024-01-01T00:00:00"
+  },
+  "straightway upon the ship’s getting out of sight of land, his insanity broke out in a freshet": {
+    "emoji": "➡️🚢👁️🌊🏞️, 🤪💥🆕🔀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "it is one of the more curious things about this Leviathan, that his skeleton gives very little idea of his general shape": {
+    "emoji": "🤔➡️1️⃣❓✨🕵️‍♂️📚🐋, 👉⚰️🦴🗣️👥🔬💡🔍📏🔄👤💡.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "A vile wind that has no doubt blown ere this through prison corridors and cells, and wards of hospitals, and ventilated them, and now comes": {
+    "emoji": "👹💨🚫❓💨↩️🔛🕰️🔁🚔🚪🚪💙➖🏥🛏️🔁💨🔄🌬️🔛🔜🔜",
+    "date": "2024-01-01T00:00:00"
+  },
+  "all that cracks the sinews and cakes the brain": {
+    "emoji": "🌍➖🔨💥✳️💪🔗🍰🧠",
+    "date": "2024-01-01T00:00:00"
+  },
+  "change places": {
+    "emoji": "🔄📍",
+    "date": "2024-01-01T00:00:00"
+  },
+  "The predestinated day arrived": {
+    "emoji": "📆🔮👍🎉",
+    "date": "2024-01-01T00:00:00"
+  },
+  "almost hidden in a discoloured, rolling, and oftentimes tumultuous and bursting sea": {
+    "emoji": "🕵️‍♂️🔎🤏🌊💨🔄🤯💦",
+    "date": "2024-01-01T00:00:00"
+  },
+  "The whale, therefore, must see one distinct picture on this side, and another distinct picture on that side; while all between must be profound darkness and nothingness to him.": {
+    "emoji": "🐋, ➡️, 🔭🪞 1️⃣📷🎑➡️👇📐, ➕👥📷🎑➡️🔛👥📐; 🌌⬛🔛🔝🌠🕳️🚫🔜👥.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "placed before the strict and piercing truth, this whole story will fare like that fish, flesh, and fowl idol of the Philistines": {
+    "emoji": "👉➡️🔨😠🔍🔆, 📖⚖️🐠, 🥩,🐓🏺🙏🏼🏛️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Wet the line! wet the line!": {
+    "emoji": "💦🎣! 💦🎣!",
+    "date": "2024-01-01T00:00:00"
+  },
+  "GRAND CONTESTED ELECTION FOR THE PRESIDENCY OF THE UNITED STATES.": {
+    "emoji": "🎖️🏆🥊🗳️👀🗳️👤🇺🇸🎩🦅🔝",
+    "date": "2024-01-01T00:00:00"
+  },
+  "when this hell in himself yawned beneath him, a wild cry would be heard through the ship": {
+    "emoji": "🕰️⏬😈🔥😱👇, 🌪️😱📣👂🏻🚢",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Wonderfullest things are ever the unmentionable; deep memories yield no epitaphs": {
+    "emoji": "🌟💫🌍💬🚫; 🕳️🔮💭🚫🪦",
+    "date": "2024-01-01T00:00:00"
+  },
+  "And still deeper the meaning of that story of Narcissus": {
+    "emoji": "🔍🕳️➕📖🤔 🕰️⏩📚💭 Narcissus👱‍♂️💧🌼",
+    "date": "2024-01-01T00:00:00"
+  },
+  "lines suddenly vibrated in the water, distinctly conducting upwards to them, as by magnetic wires the life and death throbs of the whale": {
+    "emoji": "〰️🌊🔀📈↕️👥🧲🔌🧬💔💓🐋",
+    "date": "2024-01-01T00:00:00"
+  },
+  "so better is it to perish in that howling infinite, than be ingloriously dashed upon the lee": {
+    "emoji": "💫👍🆙🎯💀🔛🌪️🔚, ➖👎🏁🙈🔨⚓",
+    "date": "2024-01-01T00:00:00"
+  },
+  "owing to the mystery of the spout—whether it be water or whether it be vapour—no absolute certainty can as yet be arrived at": {
+    "emoji": "📝➡️🔮🌀💦—🤔💦or🤔💨—❌💯🔒👍🕰️📍🤷‍♀️🎯",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the sun is breaking through; the clouds are rolling off—serenest azure is at hand.": {
+    "emoji": "☀️💥👉🌫️🌀🔚- ✨💙🤝",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Long exile from Christendom and civilization inevitably restores a man to that condition in which God placed him, i.e. what is called savagery.": {
+    "emoji": "🕰️🏝️🛐🌍🌐➡️💪🔄👨➡️🌱🙏🎁📍🚹, ➡️🧩🗣️🐾🏞️.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I know not all that may be coming, but be it what it will, I’ll go to it laughing.": {
+    "emoji": "👁️🧠❌🔮🌐, 🔮🎁⬅️🔜, 😇🔮🎁👍✔️, 👁️🚶‍♂️➡️😂.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Here, then, was this grey-headed, ungodly old man, chasing with curses a Job’s whale round the world, at the head of a crew, too, chiefly made up of mongrel renegades, and castaways, and cannibals": {
+    "emoji": "👇, 👴, 👿, 🏃‍♂️🗯️🐋🌍, 🔝👥, 🌍🔄, 👥➕, 🌍🔀, 🚣‍♂️, ‍🌊🗑️, 🥩👤.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "But the awful lonesomeness is intolerable.": {
+    "emoji": "🍑🔍👎👤😞📵⛔😱",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I’ve known some ships made of dead trees outlast the lives of men made of the most vital stuff of vital fathers.": {
+    "emoji": "👁️🌄👥🚢🪵💀🎵📏🎵⏳👨👥🌬️💪💫👨‍👧‍👦👴💫🌟",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the whaling voyage was welcome": {
+    "emoji": "🐋⛵️👍🤗",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Hast thou seen the White Whale?": {
+    "emoji": "👀🤔👈🐋⚪❓",
+    "date": "2024-01-01T00:00:00"
+  },
+  "more than suspects that the joke is at nobody’s expense but his own": {
+    "emoji": "👥➕➡️🤔💭🃏😂🚫💸👥💔👉🚶‍♂️💔👈",
+    "date": "2024-01-01T00:00:00"
+  },
+  "“Sail ho!” cried a triumphant voice from the main-mast-head.": {
+    "emoji": "\"⛵️📢!\" 😮 a 🏆🗣️ from the 🏴‍☠️🔝.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Be it known that, waiving all argument, I take the good old fashioned ground that the whale is a fish, and call upon holy Jonah to back me.": {
+    "emoji": "🔈✍️, 🙅‍♂️🗯️, 👉🏽👍🏼🕰️🌿📜🐋🐠, 🙏🏽🛐💫👨🏽🏴‍☠️⬅️👍🏽.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Out of the bottomless profundities the gigantic tail seems spasmodically snatching at the highest heaven.": {
+    "emoji": "⬆️🔽🌀🌊🐋🙌😵🏞️🏔️☁️🌠🌌🔝😇⛅",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Come in thy lowest form of love, and I will kneel and kiss thee": {
+    "emoji": "🚶‍♂️➡️👇💗, ➕👤🛐💋👈",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I could not help staring at this gallows with a vague misgiving.": {
+    "emoji": "👁️❌🆘👀↗️🗼🔱🌫️💭🤔",
+    "date": "2024-01-01T00:00:00"
+  },
+  "to the surprise of all, the announcement was made": {
+    "emoji": "😲👥📢📜🔈",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I have seldom seen such brawn in a man.": {
+    "emoji": "👁️💪🙌😯🔍👨‍💼",
+    "date": "2024-01-01T00:00:00"
+  },
+  "let Ahab beware of Ahab; beware of thyself, old man": {
+    "emoji": "⚠️🅰️🚫👀⚠️🅰️🚫; ⚠️👀👴⚠️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "if on that day I shall again raise him, then, ten times its sum shall be divided among all of ye!": {
+    "emoji": "🔁↪️📅👁️🔜🙌⬆️👨‍❤️‍👨,🔟❎💰➗👫🌍👈🙌‼️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "That is all.": {
+    "emoji": "👈✅🔚",
+    "date": "2024-01-01T00:00:00"
+  },
+  "don’t be in such a devil of a hurry to sink!": {
+    "emoji": "🚫🏃‍♂️💨😈⏩🚢⬇️!",
+    "date": "2024-01-01T00:00:00"
+  },
+  "all the things that God would have us do are hard for us to do": {
+    "emoji": "👥🌍📚👀🔐💪⛪️🛐🔜🎯🤔💢",
+    "date": "2024-01-01T00:00:00"
+  },
+  "let it continue hanging there a while till we can get a chance to attend to it": {
+    "emoji": "👉🔜🔁🕐🖼️🔛🔨⌛🔜⏰🔎🅰️🎰🤝➕👥🙏👈",
+    "date": "2024-01-01T00:00:00"
+  },
+  "In no living thing are the lines of beauty more exquisitely defined than in the crescentic borders of these flukes.": {
+    "emoji": "🚫❌🌱💐🐾🐇🦚☀️➖📈💅✨🌈🎀➕🌹💖💠➖🌜🌙🔽◀️🌺🐬⭐🎉",
+    "date": "2024-01-01T00:00:00"
+  },
+  "sundry mystifications too tedious to detail": {
+    "emoji": "🌤️🔮🤷‍♂️🙄📝📑🔍",
+    "date": "2024-01-01T00:00:00"
+  },
+  "to the last gasp of my earthquake life will dispute its unconditional, unintegral mastery in me": {
+    "emoji": "🔜🔚💨🌍⚡🎊💔, ✅💬🌐👎➕⭕🏅👍⛔✍🏻👨‍🦱",
+    "date": "2024-01-01T00:00:00"
+  },
+  "The devil fetch that harpooneer, thought I": {
+    "emoji": "😈🔍🐋🔱💭🙂",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Tell me, does the magnetic virtue of the needles of the compasses of all those ships attract them thither?": {
+    "emoji": "🗣️👂, 🧲💫📍🧭⛵🚢⛴️🎯👉?",
+    "date": "2024-01-01T00:00:00"
+  },
+  "The sudden exclamations of the crew must have alarmed the whale": {
+    "emoji": "😱💬⚡️⛵️👥🔊🐋👂‼️🚨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Lord, think of having half an acre of stomach-ache!": {
+    "emoji": "🙏, 💭 of 🎚️ half an 🪴 of 🤢!",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Bone is rather dusty, sir.": {
+    "emoji": "💀☠️🦴💨♠️🌀↕️🧑‍💼🎩🕴️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "you must first get fast to a whale, before any pitchpoling comes into play": {
+    "emoji": "👉🏾⏩🏃‍♂️🥇🐋⏰⏱️🔽🎳🎮⬅️🔄",
+    "date": "2024-01-01T00:00:00"
+  },
+  "By heaven, man, we are turned round and round in this world, like yonder windlass, and Fate is the handspike.": {
+    "emoji": "☁️🙏, 👨, 🔄🔄🌍, 🔄🔧, 💫👋⏳.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "So fare thee well, poor devil of a Sub-Sub, whose commentator I am.": {
+    "emoji": "👋👍🙁😈👉⬇️⬇️, 👤👈🗣️🥇🕵️‍♀️🙋‍♂️.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the blood imparts to the blood its vivifying principle": {
+    "emoji": "💉🔄💉🌱💡",
+    "date": "2024-01-01T00:00:00"
+  },
+  "no doubt the first man that ever murdered an ox was regarded as a murderer": {
+    "emoji": "🚫🤔🥇👨‍🦱🔪🐂👀🕵️‍♂️🔪👨‍🔬",
+    "date": "2024-01-01T00:00:00"
+  },
+  "He now has to drop and secure his oar, turn round on his centre half way, seize his harpoon from the crotch, and with what little strength may remain, he essays to pitch it somehow into the whale.": {
+    "emoji": "👨‍🦱➡️🔄🛶🔽🔐🚣‍♂️, ↩️➡️🔄🎯↩️1/2️⃣, 🤲🎯🔱⬅️🍑, 🤝🔍💪🔠🧩, 👨‍🦱💡📝🔽🐳.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Now hands are wanted here, and then again hands are wanted there.": {
+    "emoji": "🕒👋👤📍🔍, ➕🔀🕒👋👤📍🔍.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "What’s the mighty difference between holding a mast’s lightning-rod in the storm, and standing close by a mast that hasn’t got any": {
+    "emoji": "❓⚡💪🎭🔄🤲⚓🗼🌩️🌩️🔎, 🆚🕴️👣🚶‍♂️🔍⚓🗼🚫🎈🤷‍♂️🈚",
+    "date": "2024-01-01T00:00:00"
+  },
+  "there lay the tomahawk sleeping by the savage’s side, as if it were a hatchet-faced baby": {
+    "emoji": "👇🛌⚒️😴🔀👹🔛👥, ➖👼😠👶🗡️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I cannot tell, can only hint, the things that darted through me then.": {
+    "emoji": "❌🗣️, 🤷‍♂️💬🔎, ⬅️➡️💨💭🕰️.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "every one present must take good heed to dodge it when it swings, else it may box his ears and pitch him headlong overboard": {
+    "emoji": "👥➡️👀🔎🎯🔃👈, ❌⚠️👊👂📦🔄⤵️🌊🚢",
+    "date": "2024-01-01T00:00:00"
+  },
+  "and the great shroud of the sea rolled on as it rolled five thousand years ago": {
+    "emoji": "🔀, 🌟🌊⚰️ 🌊🔄🚀 ,🔄💫5️⃣0️⃣0️⃣0️⃣📆🔙",
+    "date": "2024-01-01T00:00:00"
+  },
+  "ain’t there too many heads in the world?": {
+    "emoji": "❌👥🌍➕➕❓",
+    "date": "2024-01-01T00:00:00"
+  },
+  "For this is one of those disheartening instances where truth requires full as much bolstering as error.": {
+    "emoji": "🔍👀, 👇📖1️⃣🔨💔🔬👥📚, 📖⚖️💯🏋️‍♀️🔩🔐🔅💡💢🎭⚖️💯🏋️‍♀️💔✖️.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Will I have eyes at the bottom of the sea, supposing I descend those endless stairs?": {
+    "emoji": "❓👁️🌊👇🌀🤔⬇️🔚🥾💭",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Not a chip of the boat was harmed, nor a hair of any oarsman’s head; but the mate for ever sank.": {
+    "emoji": "🚫🍟🚢🐚❌, 🚫💇‍♂️🚣‍♂️👤💆‍♂️; 😔👥⏭️🔽🌊.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "It is not down in any map; true places never are.": {
+    "emoji": "❌⬇️🌐📍🗺️; 🏞️🔎➡️🔝💯.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Reality outran apprehension; Captain Ahab stood upon his quarter-deck.": {
+    "emoji": "🌐🏃‍♂️👀; 👨‍✈️ Ahab 🕴️🪜🛳️🃏🪑.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "and thus stabs us from behind with the thought of annihilation": {
+    "emoji": "➕➡️🔪👥🔙💭💥🚫💭",
+    "date": "2024-01-01T00:00:00"
+  },
+  "on that shivering winter’s night, the Pequod thrust her vindictive bows into the cold malicious waves": {
+    "emoji": "🔛❄️🌬️🌃, ⛵️Pequod🗡️😠🏹➡️🥶🌊👿",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Oh! many are the Fin-Backs, and many are the Dericks, my friend.": {
+    "emoji": "😮! 🌊🐋🐋🐋, 🔨🔨🔨, 👥👫👬!",
+    "date": "2024-01-01T00:00:00"
+  },
+  "This whole book is but a draught—nay, but the draught of a draught. Oh, Time, Strength, Cash, and Patience!": {
+    "emoji": "📚➡️🍺, ❌, 🍺🍺. ⏰💪💰😇!",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Loftiest trucks were made for wildest winds, and this brain-truck of mine now sails amid the cloud-scud.": {
+    "emoji": "🗻🚚🔨🥇🌬️🌀, ➕🧠🚚👤🕗⛵🕹️☁️🌫️.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the monster horribly wallowed in his blood, overwrapped himself in impenetrable, mad, boiling spray": {
+    "emoji": "👹😱🛀💉, ➰👤🔐🔒🌀🤪🌊🔥💦",
+    "date": "2024-01-01T00:00:00"
+  },
+  "half-articulated wailings of the ghosts of all Herod’s murdered Innocents": {
+    "emoji": "🕰️🗣️👻👶🗡️🤴🏻🔪🎭🕊️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I wonder what the old man wants with this lump of foul lard": {
+    "emoji": "🤔❓👴🏻🤷‍♀️🔄👉🙌🧈💩",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Wet, drenched through, and shivering cold, despairing of ship or boat, we lifted up our eyes as the dawn came on.": {
+    "emoji": "💦,😓💧, and 🥶❄️, 😞 of 🚢 or 🚣‍♂️, we 👀🆙 as the 🌅 arrived.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Whales are scarce as hen’s teeth whenever thou art up here.": {
+    "emoji": "🐋➡️🔍🐓🦷🕑👤👆📍🌁",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Look ye, for yourselves, if Ahab be not lord of the level loadstone! The sun is East, and that compass swears it!": {
+    "emoji": "👀👥, 👉👥, 🧐 Ahab ➡️👑 ⚖️🧲! ☀️➡️🧭, 🤞🧭🤬👏!",
+    "date": "2024-01-01T00:00:00"
+  },
+  "all these things, I say, had awakened much interest and curiosity at the time": {
+    "emoji": "👀👇👨‍👩‍👧‍👦🔬👂🗓️, 👁️🗣️, 🌅📈🔍🧠💡⏳",
+    "date": "2024-01-01T00:00:00"
+  },
+  "What I’ve dared, I’ve willed; and what I’ve willed, I’ll do!": {
+    "emoji": "❓💭🏃‍♂️, 🏃‍♂️💪; ➕💭🏃‍♂️💪, 🙋‍♂️🔜💼!",
+    "date": "2024-01-01T00:00:00"
+  },
+  "man, though idiotic, and knowing not what he does, yet full of the sweet things of love and gratitude": {
+    "emoji": "👨‍🦳,🎭,❌💡🤔,🔄, 😍🍫🍬 ❤️🙏💌",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Who would think, then, that such fine ladies and gentlemen should regale themselves with an essence found in the inglorious bowels of a sick whale!": {
+    "emoji": "❓🤔💭, 🕰️, 👩‍🦰💅✨👨‍🦳🎩🍹🎉👄🍶💫💖🐳🤢⚓️❗",
+    "date": "2024-01-01T00:00:00"
+  },
+  "The whale was now going head out, and sending his spout before him in a continual tormented jet": {
+    "emoji": "🐋 ➡️ 🔄 🗺️ 🚀, ➕ 📤 💦💨 👉🏻 🙋‍♂️ ➡️ 💫🚀⏳🛠️💦🚿",
+    "date": "2024-01-01T00:00:00"
+  },
+  "previous to that connexion, the short-warp goes through sundry mystifications too tedious to detail": {
+    "emoji": "↩️🔗,⏮🔀 🛸🔮👻🛑📑💫🗂️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I cannot tell why it was exactly": {
+    "emoji": "❌🗣️🤷‍♀️🔎💭🤔💬👈",
+    "date": "2024-01-01T00:00:00"
+  },
+  "The burning ship drove on, as if remorselessly commissioned to some vengeful deed.": {
+    "emoji": "🔥🚢🚀⏩, 🤔💭🤷‍♂️🚫🛑💔, 📜✍️👉🅰️🙅‍♂️😡💼🕹️.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "these were the strong, troubled, murderous thinkings of the masculine sea": {
+    "emoji": "👉💪😟🗡️💭🔥🌊♂️⏪",
+    "date": "2024-01-01T00:00:00"
+  },
+  "ye gods!": {
+    "emoji": "😱🙌🛐",
+    "date": "2024-01-01T00:00:00"
+  },
+  "that famous lexicographer’s uncommon personal bulk more fitted him to compile a lexicon to be used by a whale author like me": {
+    "emoji": "👉🌟📖🔍🕴️🌟💼🍔🍔🍔🍔🍔💪⤵️👤🛠️📘📙🏺🐋✍️👨‍🎨👍👤",
+    "date": "2024-01-01T00:00:00"
+  },
+  "never mind if they lie side by side and touch each other": {
+    "emoji": "🚫💭🤷‍♂️🤥🛏️🤝👫",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the spine of even the hugest of living things tapers off at last into simple child’s play": {
+    "emoji": "🦴➡️💪🐋🦕🦍➡️🔚↘️🟢🧒🎮🤹‍♂️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "a man who rides a horse is called a horseman": {
+    "emoji": "👨🏼➡️🏇🏼➡️📞🐴👨🏼‍🌾",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Yea, foolish mortals, Noah’s flood is not yet subsided; two thirds of the fair world it yet covers.": {
+    "emoji": "👍, 💀🧍‍♂️🧍‍♀️, 🚢🌧️🌊(Noah's flood) 🚫❌⏭️; 2️⃣/3️⃣🌎🌍🌏 (fair world) 🌊🔄🔮.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "What things real are there, but imponderable thoughts?": {
+    "emoji": "❓💭💡🌐👉, ➡️💡⚖️💭❓",
+    "date": "2024-01-01T00:00:00"
+  },
+  "do you not find a strange analogy to something in yourself?": {
+    "emoji": "❓👤❌🔍🧩👥🤔🔄⚖️❓",
+    "date": "2024-01-01T00:00:00"
+  },
+  "down in the whirling heart of such a masterless commotion that he scarce heeds the moment when he drops seething into the yawning jaws": {
+    "emoji": "⬇️➡️🌀❤️👥💫🎭🚫💂‍♂️🙈🕒⏳🕹️🌊➡️🔥👄🕳️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Toes are scarce among veteran blubber-room men.": {
+    "emoji": "👣 📉 🕴️👴💼🧑🚹, 🐋🏠 ♂️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "One and all, they were harpooned and dragged up hither from the bottom of the sea.": {
+    "emoji": "1️⃣➕👥, 👥🔱➕🔝⬆️📍🌊⬇️🔚.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "there reigned, too, a sense of peculiar dread at this flitting apparition, as if it were treacherously beckoning us on and on, in order that the monster might turn round upon us, and rend us at last in the remotest and most savage seas": {
+    "emoji": "👑🔮😱💨👻, 🤔💭🎭 🏳️👥👉👉, 🐲🔄👥, 💥👥⏭️🌊🌊🏞️🏞️➡️🌎.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "move your foot or hand an inch; slip your hold at all; and your identity comes back in horror": {
+    "emoji": "👉👣🤚↔️1️⃣📏; 👋🛑💪💼🔛; 😱🔙〰️🆔🔜",
+    "date": "2024-01-01T00:00:00"
+  },
+  "In thought, a fine human brow is like the East when troubled with the morning.": {
+    "emoji": "💭, 👌🧑🤔💡➡️👍☀️🌄🔀😟☀️🌞🌅",
+    "date": "2024-01-01T00:00:00"
+  },
+  "though thou launchest navies of full-freighted worlds, there’s that in here that still remains indifferent": {
+    "emoji": "🤔💭⛵⛓️🌐🌐🌐🛳️,💡🔛🔒🤷‍♂️🏞️🔛🚶➕❄️🔛🔄",
+    "date": "2024-01-01T00:00:00"
+  },
+  "through numberless perils to the very point whence we started, where those that we left behind secure, were all the time before us": {
+    "emoji": "🔄🔢⚠️⬆️📍📍↪️🚶‍♂️🚶‍♀️👥🔙🔐🕒🔛🔝👀👈",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Why is almost every robust healthy boy with a robust healthy soul in him, at some time or other crazy to go to sea?": {
+    "emoji": "❓🤷‍♂️🕰️👦🌳💪😇💪🔄🤪🌊🚢🤔❓",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Look your last, now": {
+    "emoji": "👀👉🔚🕐, ⏱️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the Leviathan that but few supposed to be at this particular time lurking anywhere near": {
+    "emoji": "🐉🔮👥↩️🕰️🕵️⏭️👀📍",
+    "date": "2024-01-01T00:00:00"
+  },
+  "You would have thought we were offering up ten thousand red oxen to the sea gods.": {
+    "emoji": "👉🤔💭👥👈📊🆙🔟K🔴🐂🌊🛐🌊👼",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Well, sir, I want to see what whaling is. I want to see the world.": {
+    "emoji": "👌,🤵, 🙋‍♂️👀🐳🔎. 🙋‍♂️👀🌍.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "this mere painstaking burrower and grub-worm of a poor devil of a Sub-Sub": {
+    "emoji": "👉⛏🕳️🐛😈🔗🔍🔍👿👇👇",
+    "date": "2024-01-01T00:00:00"
+  },
+  "accept the first hint of the hitching tiller; believe not the artificial fire, when its redness makes all things look ghastly": {
+    "emoji": "👍🥇💡⚓🚜; 🙅‍♀️🔮🔥, 🔥🔴👀👻💀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "What then remained?": {
+    "emoji": "❓➡️🔜🔙❓",
+    "date": "2024-01-01T00:00:00"
+  },
+  "To sailors, oaths are household words; they will swear in the trance of the calm, and in the teeth of the tempest": {
+    "emoji": "⛵️👨‍🚀️, 🤞🤬🏠🗣️; 🤞🤬🟢✌️😌, 🌬️🦷️ ⛈️✌️😡",
+    "date": "2024-01-01T00:00:00"
+  },
+  "what’s made in fire must properly belong to fire; and so hell’s probable.": {
+    "emoji": "❓🏭🔥⚖️🤝🔥; ⏩🔥👹🔮🤷‍♂️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Upon the opening of that fatal cork, forth flew the fiend, and shrivelled up his home.": {
+    "emoji": "🔛🔓🍾, 👹💨🚀, 🏚️🔥📉.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "suddenly going down in a maelstrom, within three rods of the planks, he wholly disappeared from view": {
+    "emoji": "😱⤵️🌀, 📏📏📏👉🪵, 🙈⬛👀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "to and fro in the deeps, far down in the bottomless blue, rushed mighty leviathans, sword-fish, and sharks": {
+    "emoji": "↔️🔽🌊, ⬇️⬇️🔵🕳️, 🏃‍♂️💪🐋, 🗡️🐠, 🦈",
+    "date": "2024-01-01T00:00:00"
+  },
+  "life for the most part was a telling pantomime of action, and not a tame chapter of sounds": {
+    "emoji": "🌍➡️🔝⏳🎭🎬, 🚫🐢🔊📚",
+    "date": "2024-01-01T00:00:00"
+  },
+  "when you come to sit down before a meat-pie nearly one hundred feet long, it takes away your appetite": {
+    "emoji": "🕒👉🚶‍♂️👈💺⤵️🥧🍖🔛💯👣📏, 😮🚫🍴🤢",
+    "date": "2024-01-01T00:00:00"
+  },
+  "pull down and pulverize that subaltern’s tower, and make a little heap of dust of it": {
+    "emoji": "👇⬇️💪🏰🔨‼️🔜👈🔽🗼, ➕💫🔨🔨➡️🎇🏜️🔜⏩🔝👈♻️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "this whale carries the everlasting mail!": {
+    "emoji": "🐋➡️📨⏳💌",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Thou art as unprincipled as the gods, and as much of a jack-of-all-trades.": {
+    "emoji": "👉🎭🏛️🚫💖👦, 💡🔀🃏🎭🌐👨‍🔧👦.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "he sent him below for his ivory stool, and also his pipe.": {
+    "emoji": "👨‍💼➡️👇🚶‍♂️🔍🐘💺, 🔀🔍🚬",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Virtue, if a pauper, is stopped at all frontiers.": {
+    "emoji": "🎖️, if 👨‍🌾, is 🚫 at all 🗺️🚧.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "We must now retrace our way a little.": {
+    "emoji": "👥🔙🔜🔄👣↩️🛣️🔍🕰️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Like desperadoes they tugged and they strained, till the welcome cry was heard": {
+    "emoji": "👍🤠🧑‍🤝‍🧑🤏🏋️‍♀️💦, ⏳📣👂🎊🔊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "boggy, soggy, squitchy picture truly, enough to drive a nervous man distracted": {
+    "emoji": "🌫️🌧️💧🖼️😳💯🚘🧠😵‍💫♨️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Circumambulate the city of a dreamy Sabbath afternoon.": {
+    "emoji": "🔄🌃💭💤🕰️🌞",
+    "date": "2024-01-01T00:00:00"
+  },
+  "There was an infinity of firmest fortitude, a determinate, unsurrenderable wilfulness, in the fixed and fearless, forward dedication of that glance.": {
+    "emoji": "🔮↪️🌌💪🏼💪🏼, 🔍💯, 🚫🔁💪🏼💼, 🔒😏👊🔛👉, 👁️‍🗨️💫👊🔄.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "this leviathan seems the banished and unconquerable Cain of his race": {
+    "emoji": "🐋😱🚫🔓👤🔱🏁🚫🚩🚶‍♂️🔱🏁",
+    "date": "2024-01-01T00:00:00"
+  },
+  "The dark ocean and swelling waters were nothing": {
+    "emoji": "🌑🌊💦🚫🔛💁‍♂️🔚",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the skeleton of the whale furnishes but little clue to the shape of his fully invested body": {
+    "emoji": "💀🐋🛠️🔍🔎➡️🔍🔎👥🔄💡🔍🔎🟥💪🔍🔎💼👔👖🐋",
+    "date": "2024-01-01T00:00:00"
+  },
+  "thy spirit ebbs away to whence it came": {
+    "emoji": "👉👻⏮️🔙👉🏞️👈",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Nothing was done, and nothing seemed capable of being done": {
+    "emoji": "❌🚫🔨✅, ❌🚫💪💡🔨✅",
+    "date": "2024-01-01T00:00:00"
+  },
+  "All your oaths to hunt the White Whale are as binding as mine": {
+    "emoji": "👨‍👩‍👧‍👦🤝🏹🐋⚪🔗➕🔒💁‍♂️🤝",
+    "date": "2024-01-01T00:00:00"
+  },
+  "far over from the deep green convent valleys of the Manilla isles, the Spanish land-breeze, wantonly turned sailor, had gone to sea": {
+    "emoji": "🔭📏➡️🏞️🌳🌴🕍➡️🇵🇭, 🇪🇸🌬️🔄👨‍✈️, 🏴‍☠️🛳️🌊🌍",
+    "date": "2024-01-01T00:00:00"
+  },
+  "what all this gibberish of yours is about, I don’t know, and I don’t much care": {
+    "emoji": "❓🤷‍♀️🧐📝💬⁉️👈😕❓, 🙅‍♀️🤷‍♀️🧠❓, 👎🤷‍♀️💁‍♀️🤷‍♂️💤🤷‍♂️.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "every true whaleman sleeps with his harpoon": {
+    "emoji": "🌐✔️🐋👨‍🔧💤🛌🔱",
+    "date": "2024-01-01T00:00:00"
+  },
+  "God keep me from ever completing anything.": {
+    "emoji": "🙏🙌🚫🛑⛔🎯🔚💯🙅‍♂️🔄💬📝✅",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Moby Dick seemed combinedly possessed by all the angels that fell from heaven.": {
+    "emoji": "🐳 Moby Dick ⛓️👥💫☁️😇🔽🔀🌌👹🏰🙏👀👉🔥👼",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Such is the subtle elasticity of the organ I treat of, that whether wielded in sport, or in earnest, or in anger, whatever be the mood it be in, its flexions are invariably marked by exceeding grace.": {
+    "emoji": "👉🔍🌺🔬🎯🥏🧠, 👈⚖️😹🤹, 💼💼, 😡, 🔝💞🎭, 👈👋💃👀✔️🌺🌹🎊🎉.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "It does seem to me, that herein we see the rare virtue of a strong individual vitality": {
+    "emoji": "🤔💡👀👉, 🌍💗🕵️‍♂️🔮🌟🌷⚡💪🌐💼🕺💫💯",
+    "date": "2024-01-01T00:00:00"
+  },
+  "pay attention": {
+    "emoji": "💰👀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Death and devils! men, it is Moby Dick ye have seen—Moby Dick—Moby Dick!": {
+    "emoji": "💀😈! 👨‍👨‍👦‍👦, 🐋 Moby Dick 👀👥- Moby Dick- Moby Dick!",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I account it high time to get to sea as soon as I can.": {
+    "emoji": "📝💼🕰️⬆️🕒🌊🚀🔜⏩👍💨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the harpooneers of this world must start to their feet from out of idleness, and not from out of toil": {
+    "emoji": "🌐🔱🕴️🚶‍♂️🆙💤🚫💼",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Frighted Jonah trembles, and summoning all his boldness to his face, only looks so much the more a coward.": {
+    "emoji": "😱 Jonah 😨, and 📞 all his 💪 to his 🎭, only looks 👀 so much the more 🐓.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "As for the men, though some of them lowly rumbled, their fear of Ahab was greater than their fear of Fate.": {
+    "emoji": "👥👤👤➡️, 🙍‍♂️🙍‍♂️⬇️🗣️⚡, 👨‍👨‍👦‍👦👓😨🐳🎩🔝👀😨🔮🔁.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "exceeding slipperiness": {
+    "emoji": "📈🧼👣",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I will wreak that hate upon him.": {
+    "emoji": "👁️👉💥🔨😡🔛👨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "But here I’ll stay, though this stern strikes rocks; and they bulge through; and oysters come to join me.": {
+    "emoji": "🍑📍👇🏽🛑💁‍♂️, ↩️👇👊⛰️; ➕👥💪💫; ➕🐚🚶‍♂️🔄🤝👥.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Oh! spite of million villains, this makes me a bigot in the fadeless fidelity of man!": {
+    "emoji": "😮! 👎👎👎👎👎💰💰💰💰💰, 🚫😈😈😈😈😈😈😈, 🌠 🔽🙋‍♂️➡️💂‍♂️ 🔽🔕🔗💖👨!",
+    "date": "2024-01-01T00:00:00"
+  },
+  "You and I must understand one another, and that too without delay.": {
+    "emoji": "👥💡🤝, ⏩⏰🚫.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "mate, flushed with conquest, betrayed": {
+    "emoji": "🧑‍🦰, 🥵🎉🥇, 😵🔪🔄",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the least tangle or kink in the coiling would, in running out, infallibly take somebody’s arm, leg, or entire body off": {
+    "emoji": "👎➰🔀➿, 🏃‍♂️🔛, 🔒💯🤜🦾, 🦵, 🤷‍♂️🔪",
+    "date": "2024-01-01T00:00:00"
+  },
+  "sink to rise no more": {
+    "emoji": "🚰↘️🔝🚫🔂",
+    "date": "2024-01-01T00:00:00"
+  },
+  "and what is more, the Sperm Whale has done it": {
+    "emoji": "'➕, 🤔❓➕, 🐋💡👍🏽🎯'",
+    "date": "2024-01-01T00:00:00"
+  },
+  "yet all were vain": {
+    "emoji": "🔍👥👥👥👥👥🙅‍♂️👎🔮",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Ecclesiastes is the fine hammered steel of woe.": {
+    "emoji": "📖⛪ 😥🔨🔩🔧🚬",
+    "date": "2024-01-01T00:00:00"
+  },
+  "you involuntarily took an oath with yourself to find out what that marvellous painting meant": {
+    "emoji": "👉🤚👤💬🤝🤳🔍👀🤔🖼️✨📝🤷‍♂️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Leviathan maketh a path to shine after him; One would think the deep to be hoary": {
+    "emoji": "🐉🛣️✨🔙👥💭🌊👴🤔",
+    "date": "2024-01-01T00:00:00"
+  },
+  "refuse resurrections to the beings who have placelessly perished without a grave": {
+    "emoji": "🚫💀➡️👥😵🌐❌⚰️🚫🪦",
+    "date": "2024-01-01T00:00:00"
+  },
+  "methinks that white-lead chapter about whiteness is but a white flag hung out from a craven soul": {
+    "emoji": "💭🤔⚪📖➡️⚪⬜🏳️🎏➡️🏳️👋🔆🐔➕👻💭",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the wonderful comparative smallness of his brain proper is more than compensated by the wonderful comparative magnitude of his spinal cord": {
+    "emoji": "🌟😲📏🧠👨‍🦱➕🆚💰✅🌟😲📏🔎🦴➕🆚💰✅",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Horrible old man!": {
+    "emoji": "😱👴‼️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "And yet, ’tis a noble and heroic thing, the wind! who ever conquered it?": {
+    "emoji": "'👥🔛⏭️, '👥⏩🅰️🕴️🦸🔱🔮, 🌬️! 👥👎🏆🚩'",
+    "date": "2024-01-01T00:00:00"
+  },
+  "veritable gospel cetology": {
+    "emoji": "📖✅🐋🔬",
+    "date": "2024-01-01T00:00:00"
+  },
+  "But war is pain, and hate is woe.": {
+    "emoji": "🍑🔛💣🔛💔, 🍁🔛😡🔛😭",
+    "date": "2024-01-01T00:00:00"
+  },
+  "when our smoke was over, he pressed his forehead against mine, clasped me round the waist, and said that henceforth we were married": {
+    "emoji": "🕰🚬🔚, 👨‍⚖️🤲💆‍♂️🤝💆, 👐🤗👫💍🗣️👰‍♀️🤵‍♂️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "hard, remorseless service the soles of my boots were in a most miserable plight": {
+    "emoji": "💪😔🔧🔨⚙️👢👢🔚😱🙍‍♂️🔻",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the wild and distant seas where he rolled his island bulk": {
+    "emoji": "🏞️🌪️🌀🌊📍🌊🏝️🌬️🔄↩️🏝️🏞️🍔⛰️🌄",
+    "date": "2024-01-01T00:00:00"
+  },
+  "So go thy ways, and I will mine.": {
+    "emoji": "👉➡️💃🚶‍♂️, ➕👁️➡️⛏️🔨⛏️.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "it is by no means uncommon to see the needles in the compasses, at intervals, go round and round": {
+    "emoji": "➡️🙅‍♂️❌🔮👀📌🔄🧭, ⏰⏳, 🔄🔄🔄",
+    "date": "2024-01-01T00:00:00"
+  },
+  "The sovereignest thing on earth is parmacetti for an inward bruise.": {
+    "emoji": "👑🌍🌟🐳💊🩹🤕🔮",
+    "date": "2024-01-01T00:00:00"
+  },
+  "out of sight of land": {
+    "emoji": "👀❌🏞️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Shall we keep chasing this murderous fish till he swamps the last man?": {
+    "emoji": "🤔🔄🏃‍♂️🐟🔪🆚🙍‍♂️🏞️❓",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Coming afoul of that old man has a sort of turned me wrong side out.": {
+    "emoji": "🚶‍♂️💥👴🔀😵💤💢↩️🙃",
+    "date": "2024-01-01T00:00:00"
+  },
+  "This ignorant, unconscious fearlessness of his made him a little waggish in the matter of whales": {
+    "emoji": "👉🤷‍♂️🙈😱⛔🎭🤭⚖️🐳\u000f",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Ahab’s harpoon had shed older blood than the Pharaoh’s. Methuselah seems a school-boy.": {
+    "emoji": "👨‍🦳🔱💉🩸👴🩸↪️🤴🇪🇬. 🧓👈🧑‍🎓.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "man is fitted to sit down on tomb-stones, and break the green damp mould with unfathomably wondrous Solomon": {
+    "emoji": "👨‍🦰👌🪑⬇️🪦🔨🟢🌱💦🍄🕳️🤯🧙‍♂️💫",
+    "date": "2024-01-01T00:00:00"
+  },
+  "It should not have been omitted that previous to completely stripping the body of the leviathan, he was beheaded.": {
+    "emoji": "🚫❗📘💡🗨️🔙👤💯👋🚫👕👖🦾🐋, 👤🔪💀.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the German soon evinced his complete ignorance of the White Whale": {
+    "emoji": "🇩🇪🔜🤷‍♂️💯❌🧠🔍⚪🐋",
+    "date": "2024-01-01T00:00:00"
+  },
+  "a man of a singular appearance, even in that wild whaling life where individual notabilities make up all totalities": {
+    "emoji": "👨‍🦰💫👀, ➡️🌀🐋🎣🌍🌚, 🧑🌟🎬🆙👥🌐🌐",
+    "date": "2024-01-01T00:00:00"
+  },
+  "For a few minutes the struggle was intensely critical; for while they still slacked out the tightened line in one direction, and still plied their oars in another, the contending strain threatened to take them under.": {
+    "emoji": "⏳⌛🤼‍♂️🔥💯; ⏩🔀, 🤜🤛🎣🔒➰🏞️, 🤜🤛🚣‍♂️🔄🕹️, 🤜🤛🤝💪⚠️💦👇🌊🆘.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "In all directions expanding in vast irregular circles, and aimlessly swimming hither and thither, by their short thick spoutings, they plainly betrayed their distraction of panic": {
+    "emoji": "🔄↗️↘️↖️↙️📈🔵🔵➖🔀🔀, 🏊‍♂️🔀🔀🐋, 👉💦💦, 😱😨😖🆘🚨🚨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the charmed, churned circle of the hunted sperm whale": {
+    "emoji": "✨🌀⭕️🎯🐋",
+    "date": "2024-01-01T00:00:00"
+  },
+  "O head! thou hast seen enough to split the planets and make an infidel of Abraham, and not one syllable is thine!": {
+    "emoji": "💡🗣️! 👀👍🌎💥⚡️👤✝️🕌🕍☪️🕉️💔, 🚫1️⃣📝🔊🤐!",
+    "date": "2024-01-01T00:00:00"
+  },
+  "we found ourselves launched into this tormented sea, where guilty beings transformed into those fowls and these fish, seemed condemned to swim on everlastingly without any haven in store, or beat that black air without any horizon": {
+    "emoji": "👥🔍👥 🚀🔛🌊🌀, 👥😈🔄🐦🐠, 😭🐔🏊‍♂️⏩💔🚫⚓️, 🥁⚫️🌫️🚫🌅.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "There’s a sermon now, writ in high heaven, and the sun goes through it every year, and yet comes out of it all alive and hearty.": {
+    "emoji": "📖➡️🙏💬⬆️🌈, ☀️🔄📆📅, ➡️😊💪🌞👍.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Come; let us squeeze hands all round; nay, let us all squeeze ourselves into each other": {
+    "emoji": "💬👉🤝💫✋🔄✨👫💞👥🔄👉👥💖",
+    "date": "2024-01-01T00:00:00"
+  },
+  "during the violence of the gale, he had only steered according to its vicissitudes": {
+    "emoji": "🕒🌪️💥🌬️, 👨‍⚓️🔎🚀⏭️🔄🎭🌪️📈📉",
+    "date": "2024-01-01T00:00:00"
+  },
+  "But none of us are in heaven yet.": {
+    "emoji": "🚫❌👥👤👆🙂👈☁️🏰⏭️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "They must get just as nigh the water as they possibly can without falling in.": {
+    "emoji": "👥👉🔭➡️🌊⏭️🚫💧⬇️😱❗✅🚷",
+    "date": "2024-01-01T00:00:00"
+  },
+  "True enough, but then whalemen themselves are poor devils; they have no good blood in their veins.": {
+    "emoji": "👍✅, ➡️🔱🐋👨‍🔬🤷‍♂️👎😈; 🚫❤️💉😊🔴👉💉😕.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Nor is this the end. Desecrated as the body is, a vengeful ghost survives and hovers over it to scare.": {
+    "emoji": "🚫➡️🔚. 🔨👤💀, 👻💢🔛✊🌬️👆😱.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "He is, without doubt, the largest inhabitant of the globe; the most formidable of all whales to encounter": {
+    "emoji": "👨‍💼🚫❔, 👉🌍🌎🌏, 🐋➡️👌🏆, 😱🐋🤝🆘",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I’ll chase him round Good Hope, and round the Horn, and round the Norway Maelstrom, and round perdition’s flames before I give him up.": {
+    "emoji": "🏃‍♂️🔁👨‍🌾🇿🇦,🔁📯,🔁🌀🇳🇴,🔁🔥😈🔥 ⏭️🤲🔁👨‍🌾.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "rather than wander further about a strange town on so bitter a night, I would put up with the half of any decent man’s blanket": {
+    "emoji": "🔀 ➡️ 🚶‍♂️🔍🏙️ ➕ 💂‍♂️🌙, 🙋‍♂️🤷‍♂️ 👍 ➗1️⃣👨‍🦳🛌🔥",
+    "date": "2024-01-01T00:00:00"
+  },
+  "if he is going to live for ever, what good will it do to pitch him overboard": {
+    "emoji": "🤔➡️👨‍⚕️🔜🤷‍♀️💘🔁💀👍➡️🧩👋🌊🌊🛳️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "there is considerable glory in that": {
+    "emoji": "👉✨🏆👈⬆️💫🌟💯",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Like most sea-terms, this one is very happy and significant.": {
+    "emoji": "👍🌊🔠, 📖☝️😀💪🔣",
+    "date": "2024-01-01T00:00:00"
+  },
+  "How, then, with me, writing of this Leviathan?": {
+    "emoji": "❓, ➡️, 👥, ✍️, 🔛, 🐳?",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Over unsounded gorges, through the rifled hearts of mountains, under torrents’ beds, unerringly I rush!": {
+    "emoji": "🔝🔈🏞️, 🔫💖⛰️, ⬇️💦🛏️, 🎯💨❗",
+    "date": "2024-01-01T00:00:00"
+  },
+  "at last he loses his identity; takes the mystic ocean at his feet for the visible image of that deep, blue, bottomless soul": {
+    "emoji": "⏱️💔🕵️‍♂️; 🎈🌊👣🖼️🌊💙, ⬇️⛓️🌌🌊🌀➡️👤💙",
+    "date": "2024-01-01T00:00:00"
+  },
+  "The heavers forward now resume their song": {
+    "emoji": "💪🚶‍♂️🔜🎵📖🔁",
+    "date": "2024-01-01T00:00:00"
+  },
+  "though a sworn foe to human bloodshed, yet had he in his straight-bodied coat, spilled tuns upon tuns of leviathan gore": {
+    "emoji": "🤔😡🔪👫💉, ➡️👨👔, ✅😱🐋💔⛔🛢️🛢️🩸",
+    "date": "2024-01-01T00:00:00"
+  },
+  "What he thought of death itself, there is no telling.": {
+    "emoji": "❓👨💭💀⚰️, 🚫🗣️🔮",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Human madness is oftentimes a cunning and most feline thing. When you think it fled, it may have but become transfigured into some still subtler form.": {
+    "emoji": "👥🤪🕰️🦊🐱🌟. 🤔💭🏃‍♀️🔙, 🤷‍♂️🔄💼📘➡️👻🙃.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "sway me to my wish": {
+    "emoji": "💃🔄🙏🌠",
+    "date": "2024-01-01T00:00:00"
+  },
+  "From this last vent no blood yet came, because no vital part of him had thus far been struck.": {
+    "emoji": "🔀🚫💉⏭🕳️ , 👎🔴💖🦾🔨🎯 🕰️👈😕.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "What do you see?": {
+    "emoji": "❓👀👉🌐",
+    "date": "2024-01-01T00:00:00"
+  },
+  "there is an æsthetics in all things": {
+    "emoji": "👀✨🎨🌍🌸🌹🌀🏞️🎭🎶🌌📚👠🍲🖼️🏛️🎡🌠🕹️🎁💡🔬#️⃣⚽🍃💎📘🛍️🎈🌈💖🔍💫🌌💮⚖️🏯🏰🗼⌛⏳🕰️🌁🌌🌆🌇🌉🌠✨🌃⛺🏞️🛣️🏜️🌅🌄⏲️⏰💣💡🕯️🎑🖥️💻📱⌚️📷🎥📺🎼🎹🎷🎸🎻🎚️🎛️🔈🔉🔊🎶🎵",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Yes, as every one knows, meditation and water are wedded for ever.": {
+    "emoji": "👍, 🌍💡, 🧘‍♂️🤝💧🔗4️⃣👰‍♂️🤵‍♀️.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the rumor of a knocking in a tomb will terrify a whole city": {
+    "emoji": "🗣️👂💬👊➡️⚰️⬛🏙️😱🌐",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the room seeming almost supernaturally quiet after these orgies, I began to congratulate myself": {
+    "emoji": "🏠🔮🤫🔇➡️🥳🎉, 🙋‍♂️👏🎊🤲👈💭",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Other poets have warbled the praises of the soft eye of the antelope, and the lovely plumage of the bird that never alights; less celestial, I celebrate a tail.": {
+    "emoji": "👥📝🎶👍👀🦌, 🕊️💖🕊️🎶; 🖤💫, 🎉🐾🎊.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I see in him outrageous strength, with an inscrutable malice sinewing it.": {
+    "emoji": "👁️👀➡️👨💪😲, 😈🚫🔍😠💪 it.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "And with what quill did the Secretary of the Society for the Suppression of Cruelty to Ganders formally indite his circulars?": {
+    "emoji": "'🔀🖋️💼🤔❓️👨‍💼📚📜🚫🐦👊🌐✍️📨📏'",
+    "date": "2024-01-01T00:00:00"
+  },
+  "others were set down for magnificent parts in high tragedies, and short and easy parts in genteel comedies, and jolly parts in farces": {
+    "emoji": "👥👥➡️📍⬇️🎭🎭⬇️🔱🎭📉🎭, 🔝🎭, 📏🔜⏩🎭⬇️👌🎭, 😂🎭⬇️🎉🎭.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "young whales, in the highest health, and swelling with noble aspirations, prematurely cut off in the warm flush and May of life, with all their panting lard about them; even these brawny, buoyant heroes do sometimes sink": {
+    "emoji": "👶🐳👶🐳, 🔝💊🏥, 👀🚀👑🙏, ⏰✂️📴🔥😊🌼🕑, 👀🍗🥓⤴️; 🌚💪🏋️‍♂️💦🦸‍♂️🦸‍♀️ 🏊‍♂️⏬😫💔.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "what god made him shark": {
+    "emoji": "❓🙏👼🔨👨🦈",
+    "date": "2024-01-01T00:00:00"
+  },
+  "in the foamy confusion of their mixed and struggling hosts, the marksmen could not always hit their mark": {
+    "emoji": "🌊💭🤯🔀🤼‍♂️🐙🦑, 🎯👨‍🏫🚫🎯✔️✅🕰️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "it is only when caught in the swift, sudden turn of death, that mortals realize the silent, subtle, ever-present perils of life": {
+    "emoji": "🕰️🔹💭🕳️🔄💀, 🔍👥⚡️🧐🤫, 🧠🌌, ⏰🐍🚧🌍🌟",
+    "date": "2024-01-01T00:00:00"
+  },
+  "But there is no Champollion to decipher the Egypt of every man’s and every being’s face.": {
+    "emoji": "🚫🕊️📚🏛️🔍🇪🇬👨👩👽🙂🌍",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Stand up, and give it to him!": {
+    "emoji": "🚶‍♂️⬆️, ➕🎁👉👨‍!",
+    "date": "2024-01-01T00:00:00"
+  },
+  "all deep, earnest thinking is but the intrepid effort of the soul to keep the open independence of her sea": {
+    "emoji": "🌰💭💡🙏💪🏻😇, ⛵️🌊💡🤔⏩🚶‍♂️💁😇🆓🚀💡⬆️💡🌊.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "whaling may well be regarded as that Egyptian mother, who bore offspring themselves pregnant from her womb": {
+    "emoji": "🐋🐋🐋 ➡️🔎💭👍👤🔜 🇪🇬👩‍👧‍👧, 👩‍👧‍👧💭🚼💭👩‍👧🤰⬅️👩‍🦽",
+    "date": "2024-01-01T00:00:00"
+  },
+  "There is one God that is Lord over the earth, and one Captain that is lord over the Pequod.": {
+    "emoji": "☝️✝️🌍🔱, ☝️👮🔱🛳️.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "murderous din": {
+    "emoji": "🔪🔊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "he toiled away, as if toil were life itself, and the heavy beating of his hammer the heavy beating of his heart": {
+    "emoji": "👨‍🔧💪⏱️, 🔄💼🔲🔒🌍🌻, ➕ 🏋️‍♂️🔨🎵🏋️‍♂️🔨💓🎵",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Thus, then, in our hearts’ honeymoon, lay I and Queequeg—a cosy, loving pair.": {
+    "emoji": "\"👉, 🔙, ❤️🎉, 🛌👥👨‍❤️‍👨 - 😊, ❤️ 👫\"",
+    "date": "2024-01-01T00:00:00"
+  },
+  "it has the savor of analogical probability": {
+    "emoji": "📚👉🥩🍯📊🎲🤔",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I shall hereafter detail to you all the specialities and concentrations of potency everywhere lurking in this expansive monster": {
+    "emoji": "🙋‍♂️🔜📝👉👥🔍🌽➕💪🌍🎯🔎👁‍🗨🌌👹",
+    "date": "2024-01-01T00:00:00"
+  },
+  "The Killer is never hunted.": {
+    "emoji": "🔪💀🚫🔍⏭️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "To produce a mighty book, you must choose a mighty theme.": {
+    "emoji": "📚➡️💪📘, 📝👉🔍🚀⭐💡💭",
+    "date": "2024-01-01T00:00:00"
+  },
+  "But still you see his power in his play.": {
+    "emoji": "🍑⏩👀👇💪🎮🎭",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Nantucketer, out of sight of land, furls his sails, and lays him to his rest, while under his very pillow rush herds of walruses and whales": {
+    "emoji": "👤🏞️👀🚫, ⛵️⬇️, 🛌💤, 🐳🐋💨👇🛏️🤯.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "But what does he want of them?": {
+    "emoji": "❓🤔👀👨‍🦱📨👈🤷‍♀️👥🤷‍♂️👥🎁🤷‍♀️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the scaramouch in question had gained a wonderful ascendency over almost everybody": {
+    "emoji": "🎭❓📈🌟💪🔝👫👬👭👥",
+    "date": "2024-01-01T00:00:00"
+  },
+  "He is both ponderous and profound.": {
+    "emoji": "👨⬅️💭🧮🔄💡🕳️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "millions of mixed shades and shadows, drowned dreams, somnambulisms, reveries": {
+    "emoji": "💰💰💰🎨🔀🌫️🌓🌚,🌊💭🛌💤, 💤🚶🌙, 🌥️🤔💭",
+    "date": "2024-01-01T00:00:00"
+  },
+  "vexed with rapacious flights of screaming fowls, whose beaks are like so many insulting poniards": {
+    "emoji": "😤🔄 🦅💨🗣️🐦🐦, 👄👍💥🤬🔪🔪",
+    "date": "2024-01-01T00:00:00"
+  },
+  "some idea may hence be had of the enormousness of that animated mass, a mere part of whose mere integument yields such a lake of liquid as that": {
+    "emoji": "💡🤔 ➡️👍🏿🤷‍♂️🎩🐋🐋, ⚪🔮 ➕↩️📦💡🌊💧🌊💧👍🏿",
+    "date": "2024-01-01T00:00:00"
+  },
+  "What could be more full of meaning?": {
+    "emoji": "❓🤔💭➕📚💟🤷‍♂️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I thought I would sail about a little and see the watery part of the world.": {
+    "emoji": "💭🤔⛵️🔄🌊🌍",
+    "date": "2024-01-01T00:00:00"
+  },
+  "there was another thought, or rather vague, nameless horror concerning him, which at times by its intensity completely overpowered all the rest": {
+    "emoji": "🤔❗️➕1️⃣💭,🔍💤👥👻😱👉🏻👤,⏰⏰🔥⚡️💯❗️⛔️🔄🌐🔕👥🔄.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "so the graceful repose of the line, as it silently serpentines about the oarsmen before being brought into actual play—this is a thing which carries more of true terror than any other aspect of this dangerous affair": {
+    "emoji": "😌🕺💃➰🐍↔️🚣‍♂️🚣‍♂️🤫🔜🎭🎲➡️😱🔝😱⚠️🔥💼",
+    "date": "2024-01-01T00:00:00"
+  },
+  "What was America in 1492 but a Loose-Fish": {
+    "emoji": "❓🤷‍♂️🇺🇸⏪1492🐟🔓",
+    "date": "2024-01-01T00:00:00"
+  },
+  "more a demon than a man!": {
+    "emoji": "👹➕😈➖👨‍💼❗️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I have heard it said, and I do not much doubt it": {
+    "emoji": "👂🗣️, ➕ 🙅‍♂️🤔💭🤷‍♂️🤔",
+    "date": "2024-01-01T00:00:00"
+  },
+  "after having repeatedly smelt the sea as a merchant sailor, I should now take it into my head to go on a whaling voyage": {
+    "emoji": "🔁👃🌊🛳️👨‍✈️, 🤔⛵🐋🗺️🎯",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the silent ship, as if manned by painted sailors in wax, day after day tore on through all the swift madness and gladness of the demoniac waves": {
+    "emoji": "🔇🛳️, 🎨⛵👨‍👨‍👦‍👦👬🕯️,🌞🔄📆 🚀💨💫🌊🌊😈🎭🌊🌊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "far beneath the fantastic towers of man’s upper earth, his root of grandeur, his whole awful essence sits in bearded state; an antique buried beneath antiquities, and throned on torsoes!": {
+    "emoji": "↘️👇⬇️🗼🏰🏢🌍👨👑🎉, 👨‍🦳👑🌳⭐🕰️, 👨⬜⬜⬛👨👑💼🗻; 🏺💼⬇️🔱🏺🏺, 🛋️💺🗿💼!",
+    "date": "2024-01-01T00:00:00"
+  },
+  "all these passing things": {
+    "emoji": "👥👉🕛🔄🔀🌐",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Thou saw’st the locked lovers when leaping from their flaming ship": {
+    "emoji": "👀🔒💑⬇️🔥🚢",
+    "date": "2024-01-01T00:00:00"
+  },
+  "what are the comprehensible terrors of man compared with the interlinked terrors and wonders of God!": {
+    "emoji": "❓✅🧑‍🤝‍🧑👻⚖️😱🤔💫🔗😱❗️🎊🔄🙏🌌🎆✝️❗️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the many noses on the Pequod’s deck proved more vigilant discoverers than the three pairs of eyes": {
+    "emoji": "🔢👃🛳️🌃➕🔍🔭🕵️‍♀️👁️👁️👁️👁️👁️👁️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Unhinge the lower jaw": {
+    "emoji": "🔓👇🦷👄",
+    "date": "2024-01-01T00:00:00"
+  },
+  "What are the sinews and souls of Russian serfs and Republican slaves but Fast-Fish": {
+    "emoji": "❓🤔💪🏽👥🇷🇺🔗🕊️💔🇺🇸🔗⛓️🐟💨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Thou canst consume; but I can then be ashes.": {
+    "emoji": "👉🙏🍽️, 💡🔥👁️👉🏽🌫️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "prepare for what follows": {
+    "emoji": "🔍👀🔜🔮💫",
+    "date": "2024-01-01T00:00:00"
+  },
+  "your whales must be seen before they can be killed": {
+    "emoji": "👉🐋🐋 ➡️👀🔍🅱️4️⃣ ⚔️💀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "So be it, then. Born in throes, ’tis fit that man should live in pains and die in pangs! So be it, then!": {
+    "emoji": "👌, 🔁. 👶🎯, '🎭🤝🕺➡️💓💔💀😖! 👌, 🔁!'",
+    "date": "2024-01-01T00:00:00"
+  },
+  "break your backbones, my boys": {
+    "emoji": "💔💪🦴, 👦👦",
+    "date": "2024-01-01T00:00:00"
+  },
+  "it’s a wicked world in all meridians": {
+    "emoji": "😈🌍↔️📐🔀🌐",
+    "date": "2024-01-01T00:00:00"
+  },
+  "For all his tattooings he was on the whole a clean, comely looking cannibal.": {
+    "emoji": "👤💉🎨, ➡️🧼👀😋👹",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Future things swim before me, as in empty outlines and skeletons; all the past is somehow grown dim.": {
+    "emoji": "🔮🏊‍♀️🔛🔝↪️👤, 🔄🔲👤▶️💀; 🔅🌅🔦↩️🌌🌁🌑🤎.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the thousand concurring accidents of such an audacious enterprise": {
+    "emoji": "💯0⭐🔀💥🚧✨🔝🛠🏗️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "With a philosophical flourish Cato throws himself upon his sword; I quietly take to the ship.": {
+    "emoji": "📚🧐🌀 Cato 🚶‍♂️💨🗡️; 🤫 I 🚶‍♂️🚢",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Almost invariably it is all over obliquely crossed and re-crossed with numberless straight marks in thick array": {
+    "emoji": "⏳➡️🔄↗️↙️✖️🔀🔄➕🔁➡️🔢💯💯✔️➖🔛🔝🔛🔝2️⃣5️⃣➡️🏞️📶🔝",
+    "date": "2024-01-01T00:00:00"
+  },
+  "there is a certain mathematical symmetry in the Sperm Whale’s which the Right Whale’s sadly lacks": {
+    "emoji": "🔍➡️➕🔣🔄🌀🔀🐋🔍↔️🐋🔍😢🚫➖",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Well, well, what’s signed, is signed; and what’s to be, will be; and then again, perhaps it won’t be, after all.": {
+    "emoji": "🤔🤔,✍️✅,✍️✅; ➡️🤷‍♀️, 🌈 ; ➡️🔄, ❓🤷‍♀️❌, ⏭️🙅‍♀️.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "But my whole clock’s run down; my heart the all-controlling weight, I have no key to lift again.": {
+    "emoji": "🔍🕰️⏱️🏃‍♂️⤵️; ❤️⚖️🌐🎛️,🗝️🚫🔝🔄❓",
+    "date": "2024-01-01T00:00:00"
+  },
+  "there is no earthly way of finding out precisely what the whale really looks like": {
+    "emoji": "❌🌍💡🔍🎯🐋👀💯",
+    "date": "2024-01-01T00:00:00"
+  },
+  "all evil, to crazy Ahab, were visibly personified, and made practically assailable in Moby Dick": {
+    "emoji": "👥😈👉🤪Ahab, 👁️👤, ➕🛠🤝👊👉🐋Moby Dick.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "have I been but forging my own branding-iron, then?": {
+    "emoji": "❓👁️🔨🔥💭🔧⛏️🔥🏭🔄🤔",
+    "date": "2024-01-01T00:00:00"
+  },
+  "for ever and for ever, to the crack of doom, the sea will insult and murder him, and pulverize the stateliest, stiffest frigate he can make": {
+    "emoji": "🔁⏳🔁⏳, 🔄⚡💥🌋, 🌊👉🤬🔪🙎‍♂️, 🔄⚙️💣🏛️, 🕴️⬛⛵👉👍💪🛠️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Chowder for breakfast, and chowder for dinner, and chowder for supper, till you began to look for fish-bones coming through your clothes.": {
+    "emoji": "🥣🍲🥐 for 🍳, and 🥣🍲🥐 for 🍽️, and 🥣🍲🥐 for 🌙🍽️, till you 😳 to 🔍 for 🐟🦴 coming through your 👕👖.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "a poor pegging lubber": {
+    "emoji": "🤲💸🔨⚓",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the eyes themselves seem clear, eternal, tideless mountain lakes": {
+    "emoji": "👁️👁️🔛🏞️💦🔄💎🌅🕐🕕🕚🌊🏔️🏞️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Take almost any path you please, and ten to one it carries you down in a dale, and leaves you there by a pool in the stream.": {
+    "emoji": "👉🔀🚶‍♂️🛤️➡️🎰, ➕🔟➡️1️⃣, 🚛👇⤵️🌄, ➕🔚👈🌊🏞️.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "They are fighting Quakers; they are Quakers with a vengeance.": {
+    "emoji": "👥🥊⚔️👻🕊️; 👥👻🕊️😡🔥⚡💥",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Old age is always wakeful": {
+    "emoji": "👴👵⏰🌙🌙🌙⚠️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "The universe is finished; the copestone is on, and the chips were carted off a million years ago.": {
+    "emoji": "🌌✅; 🔝🏗️🔛, 🍟🚚💨🚀🕰️🔙⏭️1️⃣Ⓜ️📆🔚.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Hand in hand, ship and breeze blew on": {
+    "emoji": "🤝🚢💨🔛",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the perilous depth to which he had sunk": {
+    "emoji": "⚠️🕳️⬇️👇🤷‍♂️🔚👇",
+    "date": "2024-01-01T00:00:00"
+  },
+  "That mortal man should feed upon the creature that feeds his lamp": {
+    "emoji": "☠️🧍‍♂️🍽️➡️🐐🐄🐖➡️🍽️⛽🔥💡",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Here’s food for thought, had Ahab time to think; but Ahab never thinks; he only feels, feels, feels": {
+    "emoji": "📚💡🍔🧠, ⏳🤔 Ahab; ❌Ahab 🚫🤔; 👥🔲👀, 👀, 👀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "No town-bred dandy will compare with a country-bred one—I mean a downright bumpkin dandy": {
+    "emoji": "🚫🏙️🎩🧑‍🚀🔁🆚🏞️🎩🧑‍🌾—👈🏽🤔💯🌽🤵",
+    "date": "2024-01-01T00:00:00"
+  },
+  "in the deep shadows of his eyes floated some reminiscences that did not seem to give him much joy": {
+    "emoji": "🌑🎭👁️💭💡🔙😔📉🎈",
+    "date": "2024-01-01T00:00:00"
+  },
+  "a cannon-ball, missent, becomes a plough-share": {
+    "emoji": "🔵💣, ❌✉️, 🔄🚜🔧",
+    "date": "2024-01-01T00:00:00"
+  },
+  "﻿—oh, weariness! heaviness! Guinea-coast slavery of solitary command!": {
+    "emoji": "\"😫! 😩! 🌍🔗⛓🚶‍♂️💼!\"",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I own thy speechless, placeless power; but to the last gasp of my earthquake life will dispute its unconditional, unintegral mastery in me.": {
+    "emoji": "💬➡️🤐🚫🌍🏞️💥; ⏭️💨😵🌎🔥🤜🆚❎🚫📏🎖️🔗😤",
+    "date": "2024-01-01T00:00:00"
+  },
+  "is not Possession the whole of the law?": {
+    "emoji": "❓❌💼🔐🌍📜⚖️❓",
+    "date": "2024-01-01T00:00:00"
+  },
+  "For by how much the more pains ye take to please the world, by so much the more shall ye for ever go thankless!": {
+    "emoji": "💪🌍➡️😔↔️➡️💪🌍↔️➡️🙏🔁🙅‍♂️💫",
+    "date": "2024-01-01T00:00:00"
+  },
+  "and then turn to the green, gentle, and most docile earth; consider them both, the sea and the land": {
+    "emoji": "➡️🔄👉🟢🌎🕊️; 💭👥🌊🤝🏞️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Call me Ishmael.": {
+    "emoji": "☎️👤🐳",
+    "date": "2024-01-01T00:00:00"
+  },
+  "a rather good sort of god, who perhaps meant well enough upon the whole, but in all cases did not succeed in his benevolent designs": {
+    "emoji": "🅰️↗️👍🔮✝️, 👤⏭️💭💯🌍, ➡️🆚🅰️🔄 🌀❌🏆🏅🎁🤲🕊️🎨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "that unspeakable thing called his “flurry,” the monster": {
+    "emoji": "👉🚫🗣️🌬️👈👽👾🤭👹",
+    "date": "2024-01-01T00:00:00"
+  },
+  "a howling night": {
+    "emoji": "🅰️🌃🐺💨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "So be cheery, my lads, let your hearts never fail, While the bold harpooneer is striking the whale!": {
+    "emoji": "👉🎉😄, 👬, ❤️💪🚫❌, ⏳ 🔝💪🎣👨‍🦰👊🐋!",
+    "date": "2024-01-01T00:00:00"
+  },
+  "you are struck by the general contrast between these heads.": {
+    "emoji": "😮👥⚡️🎭🔁👤👤",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Cussed fellow-critters! Kick up de damndest row as ever you can; fill your dam’ bellies ’till dey bust—and den die.": {
+    "emoji": "😠🤬👥! 🦵⬆️👹💥😱🔊 as 🌟💫you 👉 can; 🍽️🍾👉🍔🍕🍗🍩 bellies 'till they💥—and then💀.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "much of a man’s character will be found betokened in his backbone": {
+    "emoji": "👤💪🔍📖💡🔑🔝🔙🦴",
+    "date": "2024-01-01T00:00:00"
+  },
+  "He desires to paint you the dreamiest, shadiest, quietest, most enchanting bit of romantic landscape": {
+    "emoji": "👨💭🎨👩🌅💤🌴🔇🔮📏💖🌄",
+    "date": "2024-01-01T00:00:00"
+  },
+  "it might yet in great part be buoyed up by its native element": {
+    "emoji": "🤔➡️⏭️🌟⬆️🅱️⛵🆙🔝🔁🌍🔘",
+    "date": "2024-01-01T00:00:00"
+  },
+  "never violate the Pythagorean maxim": {
+    "emoji": "🚫❌➗🔺📐🧮📚💡🀄🙏",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Oh, woe on woe! Oh, Death, why canst thou not sometimes be timely?": {
+    "emoji": "😮, 😭💔😭! 😮💀, ⁉️❓🕰️🕰️🕰️❓",
+    "date": "2024-01-01T00:00:00"
+  },
+  "it almost seemed that while he himself was marking out lines and courses on the wrinkled charts, some invisible pencil was also tracing lines and courses upon the deeply marked chart of his forehead": {
+    "emoji": "👤💭🔮, 🤔🏃🖍️📈🚏📍🗺️, 🤷👀✏️👻🤝🖍️📈🚏📍🏞️🤔🛤️🖼️👴👨‍🦳👍",
+    "date": "2024-01-01T00:00:00"
+  },
+  "everything was filled with sperm, except the captain’s pantaloons pockets": {
+    "emoji": "🌐👈🎯🈵🥛🍶, ❌👖👤🧥💰🚫👈⚓️👨‍✈️👖👛👈",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the weapon is instantly at hand to its hurler, who snatches it up as readily from its rest as a backwoodsman swings his rifle from the wall": {
+    "emoji": "🔫⏱️✋🔄🤾‍♂️, 👤💨🆙🚀↩️😴, 🌲🚶‍♂️🔄🕺🆕🔫🖼️💥",
+    "date": "2024-01-01T00:00:00"
+  },
+  "As for the sons and the daughters they beget, why, those sons and daughters must take care of themselves": {
+    "emoji": "🔍👦👧👨‍👩‍👧‍👦➡️❓, 👦👧⚠️🤝🤲👩‍👩‍👧‍👦👨‍👨‍👧‍👦👀🙏👈.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Madness! To be enraged with a dumb thing, Captain Ahab, seems blasphemous.": {
+    "emoji": "😱! 😡😤🆚🤐🤖, 🧑‍✈️🐳, 😇🙅‍♂️⛪️.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the line is running": {
+    "emoji": "🔲➖🔲🏃‍♂️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Consider the subtleness of the sea; how its most dreaded creatures glide under water, unapparent for the most part": {
+    "emoji": "🤔🌊🤏🐋👀💧⬇️🚫👀⏰➡️🤏🔍",
+    "date": "2024-01-01T00:00:00"
+  },
+  "hint nothing": {
+    "emoji": "💡❌",
+    "date": "2024-01-01T00:00:00"
+  },
+  "we are sown in dishonor, but raised in glory": {
+    "emoji": "👥🌱➡️👎🏻🔮, ↗️👫🎉➡️🌟✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "all collapsed, and the great shroud of the sea rolled on as it rolled five thousand years ago": {
+    "emoji": "💯📉, ➕ 🌊🚩🌊 🔄 ➡️ 🔁 5️⃣0️⃣0️⃣0️⃣📆 👈",
+    "date": "2024-01-01T00:00:00"
+  },
+  "speak, mighty head, and tell us the secret thing that is in thee": {
+    "emoji": "🗣️, 💪👤, 🤫🗣️☝️🤔🔐🎁👉🏻❤️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "what after all canst thou do, but tell the poor, pitiful point, where thou thyself happenest to be on this wide planet": {
+    "emoji": "❓➡️🔚❓❔👉📖💬💰👎😢📍🌍⬆️👉⚡💫🙋‍♂️🌎",
+    "date": "2024-01-01T00:00:00"
+  },
+  "how nobly it raises our conceit of the mighty, misty monster, to behold him solemnly sailing through a calm tropical sea; his vast, mild head overhung by a canopy of vapour": {
+    "emoji": "🤔🎩👏🚀👆🙄😤🧟‍♂️🌫️, 👀👉🕍🛳️🏞️🌴🌊; 👉🐋, 🕊️👤💦☁️🌫️🎪",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Your only salvation lies in eluding it": {
+    "emoji": "👉🕹️🔐💡⬇️💃🙅‍♂️🔮",
+    "date": "2024-01-01T00:00:00"
+  },
+  "that famous great tierce is mystically carved in front": {
+    "emoji": "✨👑🎵🎼🔮✍️👀🔝",
+    "date": "2024-01-01T00:00:00"
+  },
+  "our beset boat was like a ship mobbed by ice-isles in a tempest": {
+    "emoji": "👥🛳🏝️🥶🌪️💢",
+    "date": "2024-01-01T00:00:00"
+  },
+  "this one is very happy and significant": {
+    "emoji": "☝️😄💯🌟",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the undeliverable, nameless perils of the whale": {
+    "emoji": "🚫📨🔖🐋⚠️🆘",
+    "date": "2024-01-01T00:00:00"
+  },
+  "And I, you, and he; and we, ye, and they, are all bats; and I’m a crow": {
+    "emoji": "👤➕👁️, 👉👤, ➕👉🚹; ➕👥, 👉👥, ➕👉👥, 🔆🔆🦇; ➕👁️🔆🔆🦅🖤",
+    "date": "2024-01-01T00:00:00"
+  },
+  "What a really beautiful and chaste-looking mouth!": {
+    "emoji": "'😮❗️👌🌟👄✨👀💎💋'",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the eightieth or ninetieth bucket came suckingly up—my God!": {
+    "emoji": "8️⃣0️⃣🔄9️⃣0️⃣🪣⬆️👄⬆️➖😱🙏🙌",
+    "date": "2024-01-01T00:00:00"
+  },
+  "one most perilous and long voyage ended, only begins a second; and a second ended, only begins a third, and so on, for ever and for aye.": {
+    "emoji": "1️⃣⚠️⏳⛵️🔚, 🔜🔛🔄⏭️2️⃣; 2️⃣🔚, 🔜🔛🔄⏭️3️⃣, ➡️⏩, 4️⃣ever⏭️and 4️⃣ever➕.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "The path to my fixed purpose is laid with iron rails, whereon my soul is grooved to run.": {
+    "emoji": "🛤️➡️🎯💡🔩, 🚂💨🛤️, 💫🛤️🏁🏃‍♀️💨.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "far too rich to supply a substitute for butter": {
+    "emoji": "🔭💰💰➡️🔄🧈",
+    "date": "2024-01-01T00:00:00"
+  },
+  "skilfully steer clear of all adjacent, interdicted parts, and exactly divide the spine at a critical point": {
+    "emoji": "🎯👌🚫⬅️⬇️⬆️➡️🚫🔗🚫🧩, 🎯➗🦴💥📍",
+    "date": "2024-01-01T00:00:00"
+  },
+  "But what plays the mischief with this masterly code is the admirable brevity of it, which necessitates a vast volume of commentaries": {
+    "emoji": "🤔💭🎭🔮👨‍💼📜❓, 👌💯🔮🗣️🤏🔜📚💬😅📖💡.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "where your treasure is, there will your heart be also.": {
+    "emoji": "📍💰, ❤️🔜👈",
+    "date": "2024-01-01T00:00:00"
+  },
+  "for days and days we voyaged along, through seas so wearily, lonesomely mild, that all space, in repugnance to our vengeful errand, seemed vacating itself of life before our urn-like prow": {
+    "emoji": "📆📆🔄🚢, 🌊😩😔🌼, 🌌🔄👀🚫🐌, 👻🚫👤🤒🚶‍♀️🗿⛵️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "he is in a prodigious commotion, the water cascading all around him": {
+    "emoji": "👨‍🦰➡️🌀🌊💦🔄↩️👨‍🦰",
+    "date": "2024-01-01T00:00:00"
+  },
+  "not the most exhilarating conception of what the most exalted potency is": {
+    "emoji": "🚫🔝🤩💡🤔💭💪🔝🌟👊⚡",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Nor is the history of fanatics half so striking in respect to the measureless self-deception of the fanatic himself": {
+    "emoji": "🚫➡️📚🌀🤪1️⃣/2️⃣⚡🎯📏🤔🤥🌀🤪🙆‍♂️💭",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Are you a believer in ghosts, my friend? There are other ghosts than the Cock-Lane one, and far deeper men than Doctor Johnson who believe in them.": {
+    "emoji": "🤔❓👻👈👉, 👥🤝? 👻👈👉👥🎩 👻📖👉🛣️🇬🇧👻, 👉📚👤👨‍⚕️👤👉💭👥👈👉👻.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "as the swift monster drags you deeper and deeper into the frantic shoal, you bid adieu to circumspect life": {
+    "emoji": "🕐🦉🐉👋👥🔽🔽➡️🌀🐠🔽, 👤👋👋🔄💼🔍🔍🔍🌳🌳🌳🏞️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "make modern history a liar": {
+    "emoji": "🔨🔄📚🕰️🤥",
+    "date": "2024-01-01T00:00:00"
+  },
+  "strange subterranean commotions": {
+    "emoji": "👽🕳️🌎🔀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "this vast fleet of whales": {
+    "emoji": "👉🌊🐋🐋🐋",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Ahab is for ever Ahab, man. This whole act’s immutably decreed.": {
+    "emoji": "🅰️hab➡️🔂🅰️hab, 👨. 🎭➡️🔒📜💬.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "that pale phosphorescence, like a far away constellation of stars": {
+    "emoji": "✨🤍💫🌟🌌👀🌠🔭🌟🌌🌠⭐🌟🌌📍🔭🗺️🌠",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I like a good grip; I like to feel something in this slippery world that can hold, man.": {
+    "emoji": "👍💗👌💪😊; 👍💗👉👈👀🌎🌨️🚫👋,🧑‍🦱.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "so spent was he by loss of blood, that he helplessly rolled away from the wreck he had made": {
+    "emoji": "😫💉🩸➡️😵🔄⏩🚫🆘🚗💥🔨🚮",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Oh, horrible vultureism of earth! from which not the mightiest whale is free.": {
+    "emoji": "😱👎🦅🌍! ➡️🚫🐋🔝💪⛔🆓.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Science! Curse thee, thou vain toy; and cursed be all the things that cast man’s eyes aloft to that heaven": {
+    "emoji": "🔬❗️🤬👉, 👉🎭💡; 🤬👈🏻👀👨‍🔬, 🤬❗ 🍃🦜🚀👨‍🔬👀👆⬆️👉🙌🌌",
+    "date": "2024-01-01T00:00:00"
+  },
+  "tumultuous business": {
+    "emoji": "🌪️💼",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the invisible police officer of the Fates, who has the constant surveillance of me, and secretly dogs me": {
+    "emoji": "👻👮‍♂️➡️🧵🔮, 👁️‍🗨️👤🔄, 🕵️‍♂️🙊🐶👤",
+    "date": "2024-01-01T00:00:00"
+  },
+  "and like wilful travellers in Lapland, who refuse to wear coloured and colouring glasses upon their eyes, so the wretched infidel gazes himself blind at the monumental white shroud that wraps all the prospect around him": {
+    "emoji": "🔀👍🚶‍♀️🚶‍♂️🧳🧊🇫🇮, 🚫👓🌈👁️, 🙁🕋🙅‍♂️👀🔆😵⬜⚰️🌫️🔁👁️👀🎯👀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "with tornado brow, and eyes of red murder, and foam-glued lips, Ahab leaped after his prey": {
+    "emoji": "🌪️👁️, 🔴👁️🔪, 💦💋, Ahab 🏃‍♂️🏹🐳",
+    "date": "2024-01-01T00:00:00"
+  },
+  "stand just where you stood before, there, over against me, and pay particular attention": {
+    "emoji": "🕴️⏪📍👥👈🚶‍♀️🤔👉🫂👥💰💼🔎👁️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "their wondrous voracity can be at times considerably diminished, by vigorously stirring them up": {
+    "emoji": "👥🌈😲🦈🍴👉🕰️↕️💪📉, 🔄💪🔀🆙",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Humph! in my poor, insignificant opinion, I regard this as queer.": {
+    "emoji": "😤! 👉🏼😔👤💭, 👁️🤔👈🏼👥👍🏼🤨.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "And I’m thinking Moby Dick doesn’t bite so much as he swallows.": {
+    "emoji": "💭👥🤔🐋💭 Moby Dick 🚫🦷🍴👥💭👌🏾🥛🍶👥💭",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Drat the file, and drat the bone! That is hard which should be soft, and that is soft which should be hard.": {
+    "emoji": "😠💾, 😠🦴! 😫💢👉🏻🧱🔹🙄🍮, 😫🍮👉🏻💢🧱🔹🙄.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "amid the tornadoed Atlantic of my being, do I myself still for ever centrally disport in mute calm": {
+    "emoji": "🌪️🌊🔄🌐💖, 🤔👤🤐✌️⏰🌀🤫☮️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "little hears he or heeds he the far rush of the mighty whale, which even now with open mouth is cleaving the seas after him": {
+    "emoji": "👦👂❌👀👂❌➡️🔭🌊🐋, 🔄🕒👄🔓🔪🌊🏃‍♂️🚨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "However curious it may seem for an oil-ship to be borrowing oil on the whale-ground, and however much it may invertedly contradict the old proverb about carrying coals to Newcastle, yet sometimes such a thing really happens": {
+    "emoji": "🤔❓🔍🛢️⛴️🔄⏲️🐳🌊🥇🛢️🚫🔄🥈🔥🍖🔄🏰🚶‍♂️🇬🇧⏳🔄🎲🍀💯🔃🤷‍♂️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "The sea was as a crucible of molten gold, that bubblingly leaps with light and heat.": {
+    "emoji": "🌊➡️🔥🔥🥇🏺, 🌋🔆💡💥🔥🔥🔥",
+    "date": "2024-01-01T00:00:00"
+  },
+  "attending to a whale": {
+    "emoji": "👥👉🐋",
+    "date": "2024-01-01T00:00:00"
+  },
+  "It’s the first foul wind I ever knew to blow from astern": {
+    "emoji": "☝️🥇🌬️👎😷🌬️💨🔄⬅️🚤",
+    "date": "2024-01-01T00:00:00"
+  },
+  "by no means prevent all communications": {
+    "emoji": "🚫✋🚫⛔️🔁💌📞📡📢💬",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the universal thump is passed round": {
+    "emoji": "🌍👊🔄🔁",
+    "date": "2024-01-01T00:00:00"
+  },
+  "a night, a day, and still another night": {
+    "emoji": "🌃, 🌅, 🌃",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Posted like silent sentinels all around the town, stand thousands upon thousands of mortal men fixed in ocean reveries.": {
+    "emoji": "📌🤫👥🔄🏘️, ⏫🕴️🕴️🕴️💭🌊🌊🌊.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "showers of gore": {
+    "emoji": "🚿💧🩸😱",
+    "date": "2024-01-01T00:00:00"
+  },
+  "all thy strange mummeries not unmeaningly blended with the black tragedy of the melancholy ship, and mocked it": {
+    "emoji": "👥🎭🔮❌🔄😑🎭🔲🎭😔⛵😅🤡",
+    "date": "2024-01-01T00:00:00"
+  },
+  "even in his lowest swoop the mountain eagle is still higher than other birds upon the plain, even though they soar": {
+    "emoji": "🔽🦅🏔️➡️🔝🐦🌾🌌🆙🐦⛰️🔝🌀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "when you are close enough to a whale to get a close view of his spout, he is in a prodigious commotion, the water cascading all around him": {
+    "emoji": "🕐👉🤏📏🐋👁️🔍🚰💨, 🐋🌀🌊🌪️💦⤵️⭕🐋",
+    "date": "2024-01-01T00:00:00"
+  },
+  "She was Rachel, weeping for her children, because they were not.": {
+    "emoji": "👩‍🦰🔜👵(Rachel)😢😭👩‍👧‍👦👶,👉❌.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "how vast, then, the burden of a whale, bearing on his back a column of two hundred fathoms of ocean!": {
+    "emoji": "🤔🌌🤔, 👉⏱️, 🐋's 📦🔛🔙, 🏋️‍♂️🏛️🔝2️⃣0️⃣0️⃣ ⛲🌊!",
+    "date": "2024-01-01T00:00:00"
+  },
+  "eat him by his own light": {
+    "emoji": "🍽️👨🕯️💡",
+    "date": "2024-01-01T00:00:00"
+  },
+  "And for this I thank God; for all have doubts; many deny; but doubts or denials, few along with them, have intuitions.": {
+    "emoji": "👥➕👉🙏🙌☝️; 👥👀❓; 😮🙅‍♂️; ❓🚫, 👥🤏➕⬅️🧠💡.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "No roses, no violets, no Cologne-water in the sea.": {
+    "emoji": "🚫🌹, 🚫💜, 🚫🍾💦🌊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "In the title-page of the original edition of the “Advancement of Learning” you will find some curious whales.": {
+    "emoji": "📖💡🔍📚➡️\"Advancement of Learning\"👀🔍➡️👀🐋🐋🐋🤔💡",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Take away the tied tendons that all over seem bursting from the marble in the carved Hercules, and its charm would be gone.": {
+    "emoji": "👉🚫➰💪🏼🔀🌍💥🗿🔍🕵️‍♂️🎭🛑🔮🌌🌈👋🔮🔚🔱🚦⚖️🏞️🌌🏛️🎭",
+    "date": "2024-01-01T00:00:00"
+  },
+  "slide bravely": {
+    "emoji": "🛷💪",
+    "date": "2024-01-01T00:00:00"
+  },
+  "grease the bottom": {
+    "emoji": "🧈⬇️🍑",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Come, why don’t some of ye burst a blood-vessel?": {
+    "emoji": "👉🤷‍♀️, 🤔 ❓don't🚫 some👥 of you👈💥 burst💢 a blood-vessel🅱️💉?",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the luckless mate, so full of furious life, was smitten bodily into the air, and making a long arc in his descent, fell into the sea": {
+    "emoji": "🍀❌👫, 😡💥💯💓, 💥✈️➡️🌬️, 🏹🌈🌀🔻, 🌊🎯🏊‍♂️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "throbbing and heaving just below the surface of the sea": {
+    "emoji": "💓🌊💪👇⬇️🌊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Away, and bring us napkins!": {
+    "emoji": "🏃‍♂️💨, 🔄🔜🔽🧻!",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Do you not marvel, then": {
+    "emoji": "❓😮🚫🤔✨🌟👈",
+    "date": "2024-01-01T00:00:00"
+  },
+  "In fact take my body who will, take it I say, it is not me.": {
+    "emoji": "📖⬇️👥📥🤲👉🧍‍♂️🤷‍♂️,📥🗣️,🚫🙋‍♂️🙆‍♂️.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Wish, by gor! whale eat him, ’stead of him eat whale. I’m bressed if he ain’t more of shark dan Massa Shark hisself": {
+    "emoji": "🌠, ⚓! 🐳➡️🍽️ him, ↩️ of him 🍽️🐳.  😄 🌟 if he ain't 🔝 of 🦈 than 👱🦈 himself",
+    "date": "2024-01-01T00:00:00"
+  },
+  "It is still colossal.": {
+    "emoji": "💡⏳🔍🗻",
+    "date": "2024-01-01T00:00:00"
+  },
+  "So on I went.": {
+    "emoji": "👉🚶‍♂️🔛",
+    "date": "2024-01-01T00:00:00"
+  },
+  "He is the great prize ox of the sea, too fat to be delicately good.": {
+    "emoji": "👨‍🦰🏆🐂🌊, ⬆️🍔🤏👌🍴.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I now know thee, thou clear spirit, and I now know that thy right worship is defiance.": {
+    "emoji": "💡👁️👉✨👻⚡, 👁️💡🔥🙏➡️👉✊🆗.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I stand alone here upon an open sea, with two oceans and a whole continent between me and law.": {
+    "emoji": "👤🕴️🚶‍♂️👤🌊🌊🌎🌍🌏🏞️🏝️🗽🏛️⚖️🔗🔒⚔️🛡️🛄🛅🚧🚯🚷🚳⛔📛🔞🔚🔙🛑🛇🛈⚠️⛔‼️📵🚫🧳👯‍♀️🔖📝📩📨📧💌📥📤📦📫📪📬🔒📑💼🌊🌍.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Your hat, however, is the most convenient.": {
+    "emoji": "👉🎩, ➡️, 🏆🥇🏆, 🙌⏱️👍🆒.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "you cannot sit motionless in the heart of these perils, because the boat is rocking like a cradle, and you are pitched one way and the other, without the slightest warning": {
+    "emoji": "❌🚫💺🚶‍♂️➡️❤️💔🌋⚠️, 🚣‍♂️🔄👶🛌, 🚀↔️🔄, 🚫⚠️⏰🔔",
+    "date": "2024-01-01T00:00:00"
+  },
+  "amid the chips of chewed boats, and the sinking limbs of torn comrades, they swam out of the white curds of the whale’s direful wrath into the serene, exasperating sunlight": {
+    "emoji": "🌊🛥️🕳️, 🤔💭🚣‍♂️🚫🔪👥, 🏊‍♂️⬅️⚪🍦🐋's 😱😡➡️🌞😌🥵🕶️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "even these brawny, buoyant heroes do sometimes sink.": {
+    "emoji": "💪😎🦸‍♂️🦸‍♀️✨🌊⬇️😔",
+    "date": "2024-01-01T00:00:00"
+  },
+  "The urbane activity with which a man receives money is really marvellous": {
+    "emoji": "🏙️🏃‍♂️🔁👨💰💫🤯",
+    "date": "2024-01-01T00:00:00"
+  },
+  "by those clanking links, the vast corpse itself, not the ship, is to be moored": {
+    "emoji": "👉🔗🔗, 🗺️💀😱, 🚫⛵, 🔒⚓📌",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Such dreary streets! blocks of blackness, not houses, on either hand, and here and there a candle, like a candle moving about in a tomb.": {
+    "emoji": "😩🌧️🛣️! ⬛⬛⬛, 🚫🏠, 👐👐, 📍🕯️, 🧈🕯️🚶‍♂️🔄⚰️.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "man has lost that sense of the full awfulness of the sea which aboriginally belongs to it": {
+    "emoji": "👨‍🦳🔍🤷‍♂️👀👉🌊😱➡️💯🤚🪨👈",
+    "date": "2024-01-01T00:00:00"
+  },
+  "For truly, the Right Whale’s mouth would accommodate a couple of whist-tables, and comfortably seat all the players.": {
+    "emoji": "☑️💯, 🐋👄➡️🎯🪑🪑🃏🃏, 🤗💺🪑🙆‍♀️🙆‍♂️🙆‍♀️🙆‍♂️🕹️.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "But why should the King have the head, and the Queen the tail?": {
+    "emoji": "❓👑💭🤴🎁👤💡👩‍🦲, 👸🎁👤🐍👈?",
+    "date": "2024-01-01T00:00:00"
+  },
+  "my body is but the lees of my better being": {
+    "emoji": "💭➡️👤, 👥💪🙇‍♂️➡️⏳🆚 🚀💫💘☀️👤🔝😇🌟",
+    "date": "2024-01-01T00:00:00"
+  },
+  "these scraps are called “fritters”; which, indeed, they greatly resemble, being brown and crisp, and smelling something like old Amsterdam housewives’ dough-nuts": {
+    "emoji": "👉🗑️🔎🍘 \"fritters\" 👈, 🏞️, 🍘🔍, 🟤🥐🔥, 👃 🍩👵🏠🇳🇱🍩",
+    "date": "2024-01-01T00:00:00"
+  },
+  "There are some enterprises in which a careful disorderliness is the true method.": {
+    "emoji": "👥🔍💼⚠️🌐, 🔄📈🧩🔍🙌🆗⚖️👍",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the spermaceti itself, how bland and creamy that is": {
+    "emoji": "🐳💦➡️👈,🤔🍦🍨😋",
+    "date": "2024-01-01T00:00:00"
+  },
+  "all the attending marvels of a thousand Patagonian sights and sounds": {
+    "emoji": "👀👂🌍✨🌈💫💥⚡️🏞️🌅🌌💯🔱🇦🇷📷🎶🎵🎧",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Nothing will content them but the extremest limit of the land": {
+    "emoji": "🚫🤲🆒👥🔝🔚🌍🌄",
+    "date": "2024-01-01T00:00:00"
+  },
+  "For hours and hours from the almost stationary ship that hideous sight is seen.": {
+    "emoji": "⏳⏳⏳🚢🔛🔝⏹️😱👀➡️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I here saw but a few disordered joints; and in place of the weighty and majestic, but boneless flukes, an utter blank!": {
+    "emoji": "👁️📍👀🔍👇🪢🪢🩹; ➕🔄📍⚖️👑😌, 🔮🍖💀🐋👏, ❗💬❌🤷‍♂️❗",
+    "date": "2024-01-01T00:00:00"
+  },
+  "The weaver-god, he weaves; and by that weaving is he deafened, that he hears no mortal voice": {
+    "emoji": "🕸️👨‍🌾👼, 👨‍🌾🧶; ➕🧶🤫👂, 👂🙅‍♂️🔊🙎‍♂️🗣️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "This is a nasty night, lad.": {
+    "emoji": "👉🤬🌚🧑‍🦰",
+    "date": "2024-01-01T00:00:00"
+  },
+  "prolonged and exhausting": {
+    "emoji": "🔄🕰️😫",
+    "date": "2024-01-01T00:00:00"
+  },
+  "With oars apeak, and paddles down, the sheets of their sails adrift, the three boats now stilly floated, awaiting Moby Dick’s reappearance.": {
+    "emoji": "🚣🆙, 🚣⬇️, ⛵️📄🔀, 🛶🛶🛶🔇⛵️, ⏱️🐳🔄.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "while other ships may have gone to China from New York, and back again, touching at a score of ports, the whale-ship, in all that interval, may not have sighted one grain of soil": {
+    "emoji": "🕰️⛴️👥🚀➡️🇨🇳🗽↩️, ➕🔙⤵️🔥, 🖐️🔢🚢⚓, 🐋⛴️, 🔁🕦, ❌👁️🌽🧪🌱🏞️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "“Sing out for him!” was the impulsive rejoinder from a score of clubbed voices.": {
+    "emoji": "\"🎵📢👨‍🎤!\" 😮🎬↩️🗣️🔢➕🔢🗣️🏏📢🗣️.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "hell is an idea first born on an undigested apple-dumpling": {
+    "emoji": "🔥😈💡🥇🐣🤔🍏🥟",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Say you are in the country; in some high land of lakes.": {
+    "emoji": "🗣️👉🏻👥📍🌳🏞️; 📍🏔️🌊🌊.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Time itself now held long breaths with keen suspense.": {
+    "emoji": "⏳⏸️🕰️🔒🔵😤⏱️🔪🕵️‍♂️👀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "as if its vast tides were a conscience": {
+    "emoji": "🤔💭🌊🌊🌊🔛🔄🔄🔄💡📜❤️🔄🔄",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Human or animal, the mystical brow is as that great golden seal affixed by the German emperors to their decrees.": {
+    "emoji": "👨👩🐶🐱, the 🔮✨⭐️👁️ is like the 🏵️🔱🔆📜✅ by the 🇩🇪👑👸 to their 👑📜❗️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Ere this, you must have plainly seen the truth of what I started with": {
+    "emoji": "'👁️👈, you 👥 must 📌 have 👍🔎 seen 👀 the truth 🏳️ of what 🤷 I 🙋‍♂️ started 🏁 with ⏭️'",
+    "date": "2024-01-01T00:00:00"
+  },
+  "But let us to the story.": {
+    "emoji": "🍑, 📖↪️👥🔛📖.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "At last his spout grew thick, and with a frightful roll and vomit, he turned upon his back a corpse": {
+    "emoji": "💫🕒, 🐳💦🍔📈, 😱🌀🤮, 🔄🔙💀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "That ghastly whiteness it is which imparts such an abhorrent mildness, even more loathsome than terrific, to the dumb gloating": {
+    "emoji": "👻🤍👈😲, 😖🍦😷, ➕😖🤮😱, 🤐😏🔇.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Mixed with these were rusty old whaling lances and harpoons all broken and deformed. Some were storied weapons.": {
+    "emoji": "🔀👥👉🗝️🏚️🐳🔱🎣👺💔💢⚠️. ⚔️📜🔫😮.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Art thou a silk-worm? Dost thou spin thy own shroud out of thyself?": {
+    "emoji": "🎨🤔🐛? 🌀🧵💀⬆️👉👤?",
+    "date": "2024-01-01T00:00:00"
+  },
+  "human infants while suckling will calmly and fixedly gaze away from the breast, as if leading two different lives at the time": {
+    "emoji": "👶🍼😌👀🔄➡️🚫👀🍼, ⏳➡️🏞️🔄 2️⃣🔀🌍's⌛",
+    "date": "2024-01-01T00:00:00"
+  },
+  "with the mad secret of his unabated rage bolted up and keyed in him, Ahab had purposely sailed upon the present voyage with the one only and all-engrossing object of hunting the White Whale": {
+    "emoji": "😡🔐🤫🤬💢, Ahab ⛵️🌊🔛🐳🔎☑️🎯🐋⚪️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "your noble conceptions of him are never insulted": {
+    "emoji": "👉👑💭👤🚫👎💔",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Oh, ye foolish! throw all these thunder-heads overboard, and then you will float light and right.": {
+    "emoji": "😮,🙄🤦‍♂️! 🤲🔽🌩🗑️⬆️, ↪️🔜🛶💡✅.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "this velvet paw but conceals a remorseless fang": {
+    "emoji": "👉🧶🐾🙈🤐😈🦷",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Ahab is lord over the level loadstone yet.": {
+    "emoji": "🅰️🎩⤴️👑📏🔮🧲⏩.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "It is a way I have of driving off the spleen and regulating the circulation.": {
+    "emoji": "👉🚗💨1️⃣➡️😤💭🗺️🔜❌🤬🩸⏭️💓🔄🔃🔄",
+    "date": "2024-01-01T00:00:00"
+  },
+  "ye grim, phantom futures! Stand by me, hold me, bind me": {
+    "emoji": "☠️👻🔮🔮! 🤝🙏🔗🙋‍♂️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Such is the endlessness, yea, the intolerableness of all earthly effort.": {
+    "emoji": "🔄🔁🌍💪😫🚫⛔😖",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Where, in the bottomless deeps, could he find the torn limbs of his brother?": {
+    "emoji": "📍,🔽⬇️🕳️,🤔💭,🕵️‍♂️🔍💔💪👬👥⁉️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "The phantoms, for so they then seemed, were flitting on the other side of the deck, and, with a noiseless celerity, were casting loose the tackles and bands of the boat which swung there.": {
+    "emoji": "👻👥, 👥,👤🕰️💭, ➡️💨↗️🚢🔛🔝, 🔇🏃‍♂️💨, 🔓⚓🛶🔄🔗👇.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "for a moment or two the prodigious blood-dripping mass sways to and fro as if let down from the sky": {
+    "emoji": "⏳🔄🕰️, 🤯🔴💉🧱⚖️⬅️➡️, 🤔👇🌌🌤️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "one serene and moonlight night, when all the waves rolled by like scrolls of silver; and, by their soft, suffusing seethings, made what seemed a silvery silence, not a solitude; on such a silent night a silvery jet was seen": {
+    "emoji": "1️⃣🌌🌕🌃, 🌊🌊🌊📜🥈; ➕, 🌊🤫🥈, 👀🤫🥈, ❌🤫; 🌌🌌🤫🥈✈️👀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Yes, a mighty change had come over the fish.": {
+    "emoji": "👍, 💪🔀🔄🔛🐠.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Then the whole world was the whale’s; and, king of creation, he left his wake along the present lines of the Andes and the Himmalehs.": {
+    "emoji": "🔜, 🌍 ➡️ 🐋; 👑🌿, 🐋🛣️ ➡️ 🏞️ 🔄📍🗻🗻 (Andes) ➕ 🏔️🏔️ (Himalayas).",
+    "date": "2024-01-01T00:00:00"
+  },
+  "we were now in that enchanted calm which they say lurks at the heart of every commotion": {
+    "emoji": "👥🕰️🔄🔛🎆✨🏞️➡️👥🗣️👀⚠️💖💠🌪️🌪️🌪️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "a white man standing before him seemed a white flag come to beg truce of a fortress": {
+    "emoji": "👨🏻‍🦳🕴️🔛🔝👥👀🏳️🙏🤝🏰",
+    "date": "2024-01-01T00:00:00"
+  },
+  "He lives on the sea, as prairie cocks in the prairie; he hides among the waves, he climbs them as chamois hunters climb the Alps.": {
+    "emoji": "👨‍🦱🏠🌊, 🐓🌾🌾; 👨‍🦱🙈🌊, 👨‍🦱🏔️🧗‍♂️🐐🏹🏔️🏞️🇨🇭.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "It was unsafe to meddle with the corpses and ghosts of these creatures.": {
+    "emoji": "☠️⚠️🚫👉🔀💀👻👾",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Stealing unawares upon the whale in the fancied security of the middle of solitary seas, you find him unbent from the vast corpulence of his dignity, and kitten-like, he plays on the ocean as if it were a hearth.": {
+    "emoji": "🕵️‍♂️🤫🐳✨🛡️🌊↔️, 🔍🐳💪🔄🏋️‍♂️🌌👑, 😺🐾🌊💭🔥🏠.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "ice and icebergs all astern": {
+    "emoji": "❄️ and 🧊🏔️ all ⬅️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "this ivory leg had at sea been fashioned from the polished bone of the sperm whale’s jaw": {
+    "emoji": "👉🐘🦵🌊🛠️🔮🦴🐳👄",
+    "date": "2024-01-01T00:00:00"
+  },
+  "If ye see a white one, split your lungs for him!": {
+    "emoji": "👀🔎⚪👈, ➗💔😱👏👦!",
+    "date": "2024-01-01T00:00:00"
+  },
+  "now then, go and preach to ’em!": {
+    "emoji": "🕑➡️, 🚶‍♂️💨, 🗣️📖👥!",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the proper time comes": {
+    "emoji": "🕰️👌⏰🔜",
+    "date": "2024-01-01T00:00:00"
+  },
+  "In the sea, under certain circumstances, seals have more than once been mistaken for men.": {
+    "emoji": "🌊, ➡️❓📝🕰️, 🦭🈶➕1️⃣🔁🤡👤🙈🤷‍♀️.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I did but half fancy being committed this way to so long a voyage": {
+    "emoji": "🙋‍♂️💁‍♂️🔨🌗🎨👬⚖️🔀👣🔚🏞️⛵ 🕰️📅🌊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I leave a white and turbid wake; pale waters, paler cheeks, where’er I sail. The envious billows sidelong swell to whelm my track; let them; but first I pass.": {
+    "emoji": "👋⬜💦💧; 🌫️💦, ⚪😳, 🌍⛵️. 😠🌊🌐↗️🌊🔜🔥👣; 👍👥; 👆⬅️↪️.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the shrouded phantom of the whitened waters is horrible to him as a real ghost": {
+    "emoji": "🌫️👻🌊⚪😱👨👻💀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "look at this matter in other lights; weigh it in all sorts of scales": {
+    "emoji": "👀🔛👉📝🔦💡💡; ⚖️🎚️👈📏🔄🎛️🎚️⚖️🔄",
+    "date": "2024-01-01T00:00:00"
+  },
+  "nigh to the man who was apt to doze over the grave always ready dug to the seaman’s hand": {
+    "emoji": "🌙👉👨‍💼😴💤💭⚰️🕳️⚓👋🔜🔃",
+    "date": "2024-01-01T00:00:00"
+  },
+  "there swims behind it all a mass of tremendous life": {
+    "emoji": "🐠🌊➡️🔙🌐💪🌳🌱🌍🌻🦋🐞🐳🌼🌲🌸🌿🐾🦜🐬🍃😮💫",
+    "date": "2024-01-01T00:00:00"
+  },
+  "for an hour or more, a thousand fathoms in the sea, he carries a surplus stock of vitality in him": {
+    "emoji": "⏰1️⃣⏳➕, 1️⃣0️⃣0️⃣0️⃣🌊👇🌊, 🧔🎒➕💪💡🔋👇👨‍⚕️.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Of the grand order of folio leviathans, the Sperm Whale and the Right Whale are by far the most noteworthy.": {
+    "emoji": "📚🐋🌐, 🐋💦👑🐳 & ➡️🐳👑💫🏆🎖️✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "The drama’s done. Why then here does any one step forth?—Because one did survive the wreck.": {
+    "emoji": "🎭✅. ❓👣👤➡️? —🤔1️⃣💪🚢💥.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "thousands on thousands of sharks, swarming round the dead leviathan, smackingly feasted on its fatness": {
+    "emoji": "🔢🦈🦈🦈🔄💀🐋, 👅😋🍴🎉🍖🧈",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Ginger-jub! you gingerly rascal!": {
+    "emoji": "🧡🎉! 👉🧡😺!",
+    "date": "2024-01-01T00:00:00"
+  },
+  "you might almost stand in it, and yet be undecided as to what it is precisely": {
+    "emoji": "👥🤔💭🔍🤷‍♂️📍📏❓🕵️‍♂️‍♂️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I account no living bone of mine one jot more me, than this dead one that’s lost.": {
+    "emoji": "💡✍️🚫🦴💀🔎➕1️⃣🙋‍♂️➡️🦴💀🤷‍♂️❌",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the seamen went below to their dinner": {
+    "emoji": "⛵👨‍🍳👇🍽️🍽️🥘",
+    "date": "2024-01-01T00:00:00"
+  },
+  "wilt thou not chase the white whale? art not game for Moby Dick?": {
+    "emoji": "🥀❓💨🚫🏃‍♂️🐳⬜❓🎨🚫🕹️🎣🐳 Moby Dick❓",
+    "date": "2024-01-01T00:00:00"
+  },
+  "unaccountable masses of shades and shadows": {
+    "emoji": "🤷‍♂️🌐🎭🌚⚫🌫️❗",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Thou belongest to that hopeless, sallow tribe which no wine of this world will ever warm": {
+    "emoji": "👉🖤🤷‍♂️🏳️🥀💔💑🍷🌎🔥🚫🔜🕰️⏳",
+    "date": "2024-01-01T00:00:00"
+  },
+  "that deep, blue, bottomless soul, pervading mankind and nature": {
+    "emoji": "😮🌟🔵⬇️🕳️🌌👥🌍⛰️🌳🌀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the stumps of harpoons are frequently found in the dead bodies of captured whales, with the flesh perfectly healed around them": {
+    "emoji": "🌳🪓🔝🔱🔍💀🐋🐳, 🥩💯💉💊🔄👥.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "From beneath his slouched hat Ahab dropped a tear into the sea; nor did all the Pacific contain such wealth as that one wee drop.": {
+    "emoji": "👇🎩👨Ahab💧😢➡️🌊; ↔️🚫📖🌊🌏🌐💎💰📖💧🌱🌻👌🎁🔍.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "The bearer looked nobler than the rider.": {
+    "emoji": "🚶‍♂️👑🔱👀🏇🤴📉",
+    "date": "2024-01-01T00:00:00"
+  },
+  "if you take the breath out of his body how can you expect to find it there when most wanted!": {
+    "emoji": "❗️👇🔁🌬️🔀🧍‍♂️, ➡️❓💭❔ 🔎📌🕰️💯🙏❗️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the whale-line folds the whole boat in its complicated coils, twisting and writhing around it in almost every direction": {
+    "emoji": "🐋➰🔄🚤🤏🧩🔄🌀⤵️↩️🔄🔄🔀🔁",
+    "date": "2024-01-01T00:00:00"
+  },
+  "What is the great globe itself but a Loose-Fish?": {
+    "emoji": "❓❓🌍🌍🌍😱➡️🐟🆓🧐❓",
+    "date": "2024-01-01T00:00:00"
+  },
+  "with a full grown leviathan this is impossible": {
+    "emoji": "👥🐋🎆❌🚫🆗",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the entire ship careens over on her side; every bolt in her starts like the nail-heads of an old house in frosty weather; she trembles, quivers, and nods her frighted mast-heads to the sky": {
+    "emoji": "🌐🚢⤵️↩️👩🤵‍♀️💃‍♀️; 🔩⚙️🔧🔨🏠🌬❄️☁️; 🥶🚢😖💢😱⚠️🌌🌌👆🌤🌞⛅️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "there is a higher horror in this whiteness of her woe": {
+    "emoji": "☝️🗻😱⬆️👉⬛️🕊️💔",
+    "date": "2024-01-01T00:00:00"
+  },
+  "a minute black spot was dimly discerned, falling from that vast height into the sea": {
+    "emoji": "⏱️⚫️👀🔍🌫️, ↘️🗼🔝↘️🌊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "that was freely": {
+    "emoji": "👈✨🆓🔁",
+    "date": "2024-01-01T00:00:00"
+  },
+  "you now saw through this wreck, as plainly as you see through the peeled, half-unhinged, and bleaching skeleton of a horse": {
+    "emoji": "👉👀🔎👀💥🌪️🕳️🏚️🔎👁️,🔆👍🕵️‍♂️🦴🔎🐴🍖.🚪🙆🔆😳👀(1️⃣/2️⃣) 🦴🍖⚪🐴.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "it is not customary for such venerable leviathans to be at all social": {
+    "emoji": "❌🔄👴🐋👥🚫⚖️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "if a man made up his mind to live, mere sickness could not kill him": {
+    "emoji": "🤔💭👨🔨🧠💡✌️🌈🛌😷🦠⛔💀🔫",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Be it distinctly recorded here, that the Nantucketers were the first among mankind to harpoon with civilized steel the great Sperm Whale": {
+    "emoji": "📝✅📍, 🐳🏞️(Nantucketers) 🥇👥🌍🔭🧐, 🔱🏛️🔩 🐋💪(Sperm Whale).",
+    "date": "2024-01-01T00:00:00"
+  },
+  "admire the magnanimity of the sea which will permit no records": {
+    "emoji": "👀🙏💗🌊⛔️📜",
+    "date": "2024-01-01T00:00:00"
+  },
+  "for days and weeks and months afterwards I lost myself in confounding attempts to explain the mystery": {
+    "emoji": "📆📆🔄📅🔄🌜🔜🌞🔩🔭🔮🔮👀🙈🔥❓⁉️🕵️‍♂️🕯️🔬🧩🔑💭🔮🌫️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "A hogshead of brandy, then, to the best man.": {
+    "emoji": "🐖🛢️🥃, 🔜, 👉🥇👨.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "all truth with malice in it": {
+    "emoji": "🌐💯↔️🧿👿📌",
+    "date": "2024-01-01T00:00:00"
+  },
+  "most young candidates for the pains and penalties of whaling stop at this same New Bedford": {
+    "emoji": "🌟👶🙋‍♂️🔜🔥😖🐋🛑〰️📍🆕🛏️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Thou sea-mark! thou high and mighty Pilot! thou tellest me truly where I am—but canst thou cast the least hint where I shall be?": {
+    "emoji": "🗣️⚓! 🗣️🏔️🚁! 🗣️👉👀💯🌐📌📍I am—🤔💭👉👀🔍🤷‍♂️💡🌐📌📍I shall be?",
+    "date": "2024-01-01T00:00:00"
+  },
+  "in general shape the noble Sperm Whale’s head may be compared to a Roman war-chariot": {
+    "emoji": "➡️👨‍⚖️📐, 🎩🐳🐋👤🔍🏺 ➡️🛡️ 🏛️🇮🇹⚔️🏎️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Nothing more happened on the passage worthy the mentioning": {
+    "emoji": "🚫➕🎭🔛🛤️🏆🗣️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "unspeakable horror": {
+    "emoji": "😱👹👻💀🔪🔞",
+    "date": "2024-01-01T00:00:00"
+  },
+  "let’s drink shame upon all cowards! I name no names. Shame upon them!": {
+    "emoji": "🥂🐔🙈😡🚫📛😡🔛👥❗",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Quoin is not a Euclidean term. It belongs to the pure nautical mathematics.": {
+    "emoji": "🔸🚫❌📐🔠. 🔸🔀🔵🛥️🔢🔠.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the mother dived down into the long church-yard grass": {
+    "emoji": "👩‍🦰⬇️🏊‍♀️🔽➡️🏞️⛪🌱",
+    "date": "2024-01-01T00:00:00"
+  },
+  "no wonder that to many ship owners, whaling is but a losing concern": {
+    "emoji": "🚫❓🌀👥🚢👑🐋🤷‍♂️💸🚫🏆",
+    "date": "2024-01-01T00:00:00"
+  },
+  "in the soul of man there lies one insular Tahiti, full of peace and joy, but encompassed by all the horrors of the half known life": {
+    "emoji": "➡️👨‍💼💭🕸️1️⃣🏝️🗺️, 😀😌🏝️, 📌⚡🌑😨🗃️🕹️🎭🌗💡🌊🎯🎢.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "a wondrous fearlessness and confidence": {
+    "emoji": "✨😱💪🦸‍♂️💼⚡🙌💫",
+    "date": "2024-01-01T00:00:00"
+  },
+  "damn your eyes, you mustn’t swear that way when you’re preaching": {
+    "emoji": "😠👉👀, 🚫⚠️🤬👈🗣️🙏",
+    "date": "2024-01-01T00:00:00"
+  },
+  "our vocation amounts to a butchering sort of business": {
+    "emoji": "👥💼➡️🔪💼",
+    "date": "2024-01-01T00:00:00"
+  },
+  "What bitter blanks in those black-bordered marbles which cover no ashes!": {
+    "emoji": "❓🍋❓⬜⬛🟩⚫🔄⬛🔳🟫🔝🔳🚬❗",
+    "date": "2024-01-01T00:00:00"
+  },
+  "And there’s a mighty difference between a living thump and a dead thump.": {
+    "emoji": "'🔀, 🤔💪👍🆚 🤝👤❤️👊 🆚 💀👊.'",
+    "date": "2024-01-01T00:00:00"
+  },
+  "You is sharks, sartin; but if you gobern de shark in you, why den you be angel; for all angel is not’ing more dan de shark well goberned.": {
+    "emoji": "👉🏽🦈, ✔️; ➡️⚖️🦈👉🏽, 🔜👉🏽👼; 👼⏩🚫🔥⏭️🦈👌⚖️.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the mightiest elephant is but a terrier to Leviathan": {
+    "emoji": "💪🐘 ➡️ 🐕 👉 🐋",
+    "date": "2024-01-01T00:00:00"
+  },
+  "hooped round by the gloom of the night they seemed the last men in a flooded world": {
+    "emoji": "🟤🔵🌌⚫🌚👥👀👈🔚👨‍👨‍👦‍👦🌎🌊🌐",
+    "date": "2024-01-01T00:00:00"
+  },
+  "into the hole itself you can hardly insert a quill, so wondrously minute is it": {
+    "emoji": "🕳️🤏📝⛔️🔬🤯👌🔍",
+    "date": "2024-01-01T00:00:00"
+  },
+  "heroes, saints, demigods, and prophets alone comprise the whole roll of our order": {
+    "emoji": "🦸‍♂️🦸‍♀️, 🙏👼, 👑⚡🌈, 🔮🗣️ ☝️⚖️ 🌐 🔁 📜📚 🛡️🔥",
+    "date": "2024-01-01T00:00:00"
+  },
+  "she was so far to windward, and shooting by, apparently making a passage to some other ground, the Pequod could not hope to reach her": {
+    "emoji": "👩‍🦰⬅️⛵🌬️🏹➡️☑️🚀🕳️↗️🌍🐋🚫🎯🤞💁‍♀️🔜",
+    "date": "2024-01-01T00:00:00"
+  },
+  "“Can’st not read it?” cried Ahab.": {
+    "emoji": "\"❓🚫📖❓\" 😱 Ahab.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "In a word, Frederick Cuvier’s Sperm Whale is not a Sperm Whale, but a squash.": {
+    "emoji": "📘👉, Frederick Cuvier's 🐋🍆❌🐋🍆, ➡️🎃.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "with two legs man is but a hobbling wight in all times of danger": {
+    "emoji": "🦵🦵🚶‍♂️👨⚠️⌛⏳🆘",
+    "date": "2024-01-01T00:00:00"
+  },
+  "continue hanging there a while": {
+    "emoji": "🔁🧗‍♂️⏰🔛",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Where is the foundling’s father hidden?": {
+    "emoji": "❓👶👨🔍❓",
+    "date": "2024-01-01T00:00:00"
+  },
+  "And there they stand—miles of them—leagues.": {
+    "emoji": "🧍‍♂️🧍‍♀️🧍‍♂️🧍‍♀️—📏📏📏—🌍",
+    "date": "2024-01-01T00:00:00"
+  },
+  "in the wild conceits that swayed me to my purpose, two and two there floated into my inmost soul, endless processions of the whale": {
+    "emoji": "🌿🤯👉🛤️, 2️⃣➕2️⃣🌀➡️💭💭🔄🐋",
+    "date": "2024-01-01T00:00:00"
+  },
+  "idolatrous dotings": {
+    "emoji": "😵‍💫❤️‍🔥✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the whale rushed round in a sudden maelstrom; seized the swimmer between his jaws; and rearing high up with him, plunged headlong again, and went down": {
+    "emoji": "🌀🐋💨🔄⚡👟👄; 🦷🦸‍♂️; 🏔️⬆️⬆️🆙🔄, 🌊🔁, ⬇️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "almost all the tapers, lamps, and candles that burn round the globe, burn, as before so many shrines, to our glory!": {
+    "emoji": "🌍🕯️💡🕯️🔥✨🕯️🌍, 🔥✨, 🌟🙏✨⛩️⛪💖!",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Ye are not other men, but my arms and my legs; and so obey me.": {
+    "emoji": "🙋‍♂️👥🚫👫, 🙏💪🦵; ➡️🙏📜🔛.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "investigate it now with the sole view of forming to yourself some unexaggerated, intelligent estimate of whatever battering-ram power may be lodged there": {
+    "emoji": "🔍 it 🕒 with the 🎯 of forming to yourself some 📉, 🧠 estimate of whatever 🏗️ power may be lodged there",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Man may, in effect, be said to look out on the world from a sentry-box with two joined sashes for his window.": {
+    "emoji": "👨➡️🌍👀📦🪟",
+    "date": "2024-01-01T00:00:00"
+  },
+  "you find some of these Nantucketers who have a genuine relish for that particular part of the Sperm Whale designated by Stubb; comprising the tapering extremity of the body": {
+    "emoji": "🫵 🛳️ some of these 🏝️🐋ers who have a 😋 for that part of the 🐳 designated by Stubb; 🏋️‍ close to the 🍑=\".",
+    "date": "2024-01-01T00:00:00"
+  },
+  "a hermit and a crucifix were within": {
+    "emoji": "🧘‍♂️✝️🪄",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Many are the men, small and great, old and new, landsmen and seamen, who have at large or in little, written of the whale.": {
+    "emoji": "👨➡️👥, 🐋📖✍️...",
+    "date": "2024-01-01T00:00:00"
+  },
+  "his stump as unquestionable a stump as any you will find in the western clearings": {
+    "emoji": "🦵🤚🤔🦵🤚🔍🦵🎄⬅️🇺🇸🌲",
+    "date": "2024-01-01T00:00:00"
+  },
+  "We work by the month, or by the job, or by the profit; not for us to ask the why and wherefore of our work": {
+    "emoji": "👷‍♂️👩‍💼 We work 📅 by the month, ✍️ or 🛠 by the job, 💵 or 📈 by the profit; 🚫 not for us to ask ❓ the why and wherefore 🤔 of our work 💼",
+    "date": "2024-01-01T00:00:00"
+  },
+  "But no more of this.": {
+    "emoji": "🙅‍♂️❌🗣️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "It was a humorously perilous business": {
+    "emoji": "😂⚠️💼",
+    "date": "2024-01-01T00:00:00"
+  },
+  "What is it, what nameless, inscrutable, unearthly thing is it": {
+    "emoji": "🤔🤷‍♂️🤔, 🤷‍♂️❓, 🤷‍♂️❓🤔👽✨🤔❓",
+    "date": "2024-01-01T00:00:00"
+  },
+  "a mighty pleasant zephyr": {
+    "emoji": "💪😊🌬️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "a thick curled bush of white mist": {
+    "emoji": "🌫️⬜️🌿🔄",
+    "date": "2024-01-01T00:00:00"
+  },
+  "It’s a ticklish business, but must be done, or else it’s no go.": {
+    "emoji": "🪶😄📈, ℹ️🍕🥇✈️🔜, 📉 it's 🚫🏃‍♂️.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Let him go. I know little more of him, nor does anybody else.": {
+    "emoji": "🫱🤚➡️🧔. 🤷‍♀️I know 🤏 more of 🧔, nor does anybody else.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "This Right Whale I take to have been a Stoic; the Sperm Whale, a Platonian, who might have taken up Spinoza in his latter years.": {
+    "emoji": "🐳➡️🧘‍♂️; 🐋➡️🏛️, 📜🌀🕰️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "we go the gait that leaves no dust behind": {
+    "emoji": "🚶‍♂️🚶‍♀️➡️👣🧹⬅️❌",
+    "date": "2024-01-01T00:00:00"
+  },
+  "at last I was continually squeezing their hands, and looking up into their eyes sentimentally": {
+    "emoji": "🙌❤️💑😢👀✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I’m demoniac, I am madness maddened!": {
+    "emoji": "😈😵‍💫🌀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "It’s only his outside; a man can be honest in any sort of skin.": {
+    "emoji": "👨🔄👥; 👨‍🦲🤝✔️🔜👔👗🧥.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "ponderous things": {
+    "emoji": "🤔📚🪨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Methuselah seems a school-boy.": {
+    "emoji": "📚👦 Methuselah seems a school-boy.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "concentric circles seized the lone boat itself, and all its crew, and each floating oar, and every lance-pole": {
+    "emoji": "🔵🔵🔵 ⛵️ ⚓️ 👤  🛶 🔄 ✋ 📏⚔",
+    "date": "2024-01-01T00:00:00"
+  },
+  "wandering from all mortal reason, man comes at last to that celestial thought": {
+    "emoji": "🚶🧍‍♂️🌏❓🤔➡️🕊️✨🌟",
+    "date": "2024-01-01T00:00:00"
+  },
+  "in his large, deep eyes, fiery black and bold, there seemed tokens of a spirit that would dare a thousand devils": {
+    "emoji": "👀🔥🖤😠👹💪🔟❗",
+    "date": "2024-01-01T00:00:00"
+  },
+  "God keep thee! Push not off from that isle, thou canst never return!": {
+    "emoji": "🙏😇! 🚫🏝🛑➡️, ⛔️↩️!",
+    "date": "2024-01-01T00:00:00"
+  },
+  "there stands the vast arched bone of the whale’s jaw, so wide, a coach might almost drive beneath it.": {
+    "emoji": "🐋👁️ 🔍 ➡️ 🚪 👉🏽 🦴 ➡️ 🐋's 😃 🚪, 🌌, 🚌 🔜 💭 🛣️⬇️ 🚍",
+    "date": "2024-01-01T00:00:00"
+  },
+  "This aspect is sublime.": {
+    "emoji": "✨🌟 This aspect is sublime. 🌟✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I now and then jerked the poor fellow from too close a vicinity to the maw of what seemed a peculiarly ferocious shark": {
+    "emoji": "🤔👦➡️🦈😱 (sometimes)➡️👋💦🚶😬",
+    "date": "2024-01-01T00:00:00"
+  },
+  "being laid upon the printed page, I have sometimes pleased myself with fancying it exerted a magnifying influence": {
+    "emoji": "👀📖✨, 😌💭🔍✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "It is a place also for profound mathematical meditation.": {
+    "emoji": "🔢🧘‍♂️🏞️🧠🧮",
+    "date": "2024-01-01T00:00:00"
+  },
+  "For the height of this sort of deliciousness is to have nothing but the blanket between you and your snugness": {
+    "emoji": "🛏️✨🥰📏🥇🧶🍫💤",
+    "date": "2024-01-01T00:00:00"
+  },
+  "according to Genesis, the angels indeed consorted with the daughters of men, the devils also, add the uncanonical Rabbins, indulged in mundane amours": {
+    "emoji": "🕊️📖 says 👼💑👩, 😈 too, add 📜 Rabbins, had 🌍❤️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Thou art too damned jolly. Sail on.": {
+    "emoji": "🫵😈😄⛵➡️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "in all seasons and all oceans declared everlasting war with the mightiest animated mass that has survived the flood": {
+    "emoji": "🌦️🌊✨🗣️⚔️🌍🎐👑💥🌊💪🌊⏳",
+    "date": "2024-01-01T00:00:00"
+  },
+  "In life, the visible surface of the Sperm Whale is not the least among the many marvels he presents.": {
+    "emoji": "🧬🌊, 👀🗺️ 🌊🐋 is ✨📚 🧩 🤯 🌈 🕵️‍♂️📚.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "sleights of hand and countless subtleties": {
+    "emoji": "🪄👐✨ and 🔢🔍",
+    "date": "2024-01-01T00:00:00"
+  },
+  "those entrails seemed swallowed over and over again by the same mouth, to be oppositely voided by the gaping wound": {
+    "emoji": "🤯✨🌀👄💫🌀➡️👄🩸😱",
+    "date": "2024-01-01T00:00:00"
+  },
+  "The ungracious and ungrateful dog!": {
+    "emoji": "😠🐕",
+    "date": "2024-01-01T00:00:00"
+  },
+  "in landscape gardening, a spire, cupola, monument, or tower of some sort, is deemed almost indispensable to the completion of the scene": {
+    "emoji": "🌳🏞️🏡, 🗼🏰🗿, ⛪️🌟🏢 🎯, ✅ 🛠️👀⚙️⬜️ 📸",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the stranger in question waved his hand": {
+    "emoji": "👋🤔 ",
+    "date": "2024-01-01T00:00:00"
+  },
+  "he profoundly saw a white living spot no bigger than a white weasel, with wonderful celerity uprising, and magnifying as it rose": {
+    "emoji": "🧒👀🔍⬜⬆️🐾❔⏳💨⬆️💥❤️‍🔥",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the sight of those bleak tablets sympathetically caused the old wounds to bleed afresh": {
+    "emoji": "🪦😔🩸",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Look here, Beelzebub, you don’t do it": {
+    "emoji": "👀➡️, 😈, ❌📛",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Where lies the final harbor, whence we unmoor no more?": {
+    "emoji": "🌅⚓❓",
+    "date": "2024-01-01T00:00:00"
+  },
+  "They asked him, then, whether to live or die was a matter of his own sovereign will and pleasure.": {
+    "emoji": "🗣️❓👤💭⚖️👑👌🔄👎💀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Had the trump of judgment blown, they could not have quivered more": {
+    "emoji": "📣🪦⚖️, 😨🙌🌀💀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "There’s a clue somewhere; wait a bit; hist—hark!": {
+    "emoji": "🕵️‍♂️🔍❔⏳🤫👂",
+    "date": "2024-01-01T00:00:00"
+  },
+  "a series of small whirlwinds": {
+    "emoji": "🌪️🌪️🌪️ (or you could use) 🍃🍃🍃",
+    "date": "2024-01-01T00:00:00"
+  },
+  "a somewhat similar circumstance that befell me; whether it was a reality or a dream, I never could entirely settle.": {
+    "emoji": "🧐🤔🌙✨🤷‍♂️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Remember what I say; be kicked by him; account his kicks honors; and on no account kick back": {
+    "emoji": "📝💭 \"Remember what I say; 👂 be kicked by him; 🦵 account his kicks honors; 🏅 and on no account kick back. 🚫\"",
+    "date": "2024-01-01T00:00:00"
+  },
+  "If you flatter yourself that you are all over comfortable, and have been so a long time, then you cannot be said to be comfortable any more.": {
+    "emoji": "🪞😌➡️😇⏳✨➡️❌😌",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Is it not curious, that so vast a being as the whale should see the world through so small an eye": {
+    "emoji": "🧐 🐋👁️ 🌍",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Never dream with thy hand on the helm! Turn not thy back to the compass": {
+    "emoji": "🛌🚫💤👋🛳️🛠️! 🔄🚫🔙🧭",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the practices of whalemen soon convinced him that even Christians could be both miserable and wicked": {
+    "emoji": "🛥️💼🐋⛴️🌊➡️🤔✨🙏🏻🛐🕊️➕😞💔🧥🙏🏻💭🙅‍♂️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "stunsail on stunsail": {
+    "emoji": "⛵️⛵️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "most seamen are beginning to learn, tar in general by no means adds to the rope’s durability or strength": {
+    "emoji": "🚢👨‍✈️⛴️ are beginning to 📖🧠, 🪝 in ⚓️ by 🛑 means ➕ to the 🪢’s 🕰️⏳ or 💪🦾",
+    "date": "2024-01-01T00:00:00"
+  },
+  "that white whale must be the same that some call Moby Dick": {
+    "emoji": "🐳⚪️ ➡️ 🐋 📛 \"Moby Dick\"",
+    "date": "2024-01-01T00:00:00"
+  },
+  "dive into this matter of whaling": {
+    "emoji": "🤿🐋📚",
+    "date": "2024-01-01T00:00:00"
+  },
+  "And what do you pick your teeth with, after devouring that fat goose? With a feather of the same fowl.": {
+    "emoji": "🦷➡️🤔🪶➡️🍽️🍗🪶🦢",
+    "date": "2024-01-01T00:00:00"
+  },
+  "he now depresses his head altogether beneath the surface, and anon swims with it high elevated out of the water": {
+    "emoji": "🌊⬇️🤕🛑↘️🌊, 🏊‍♂️⬆️😊🌊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "who ever heard that the devil was dead?": {
+    "emoji": "🗣️👂❓👿💀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I must be content with a hint.": {
+    "emoji": "👍😌💭",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Yet this is life.": {
+    "emoji": "🫤📈🙌",
+    "date": "2024-01-01T00:00:00"
+  },
+  "My soul is more than matched; she’s overmanned; and by a madman!": {
+    "emoji": "🫀😢 💪 ➕ 👸💁‍♀️ 👫 🚢💨 🌪🧔",
+    "date": "2024-01-01T00:00:00"
+  },
+  "And there is a Catskill eagle in some souls that can alike dive down into the blackest gorges, and soar out of them again": {
+    "emoji": "🦅😺⛰️🌌💫🧠🔄⚫️🌊,⬇️⬆️✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "a fine, boisterous something about everything": {
+    "emoji": "✨🙌🔆🌪️🔄✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Old age is always wakeful; as if, the longer linked with life, the less man has to do with aught that looks like death.": {
+    "emoji": "👴🌙 is always 👀; as if, the longer 🔗 with 🌍, the less 👨 has to do with aught that looks like 💀.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I made no more ado, but jumped out of my pantaloons and boots": {
+    "emoji": "🙅🏽‍♂️🤹🏼‍♂️👖🥾⬇️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "what but their smooth, flaky whiteness makes them the transcendent horrors they are?": {
+    "emoji": "🤔❓❄️✨😱⬜️❓💀🚀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "some hitherto unknown and unsuspected connexion": {
+    "emoji": "🔍🆕❓🤯🧩",
+    "date": "2024-01-01T00:00:00"
+  },
+  "they began capering about most obstreperously": {
+    "emoji": "🕺💃🎉🎊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Starbuck seemed prepared to endure for long ages to come, and to endure always": {
+    "emoji": "🌟🦌 seemed 🤔 prepared to 🌄🔜 for ⏳ ages to come, and to 🌄 always",
+    "date": "2024-01-01T00:00:00"
+  },
+  "true to each other, when heaven seemed false to them": {
+    "emoji": "🤝💖 , ☁️💔",
+    "date": "2024-01-01T00:00:00"
+  },
+  "AND I ONLY AM ESCAPED ALONE TO TELL THEE": {
+    "emoji": "🅰️🎵🌅🅾️🎵👢🍸 🅰️〽️ 📓📧💲🌜🅰️🅿️📧🌛 📧👢🌜🎐⚖️🎐🌜🗣️ 🅿️ 💣🚪✋ 📜📧👢👢 🌴🌞 🌴📧👢👢  🌴🍀📧📧",
+    "date": "2024-01-01T00:00:00"
+  },
+  "There now": {
+    "emoji": "🫴😊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "The dead, blind wall butts all inquiring heads at last.": {
+    "emoji": "💀😶‍🌫️🧱➡️🤔🤯🔚",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I know not": {
+    "emoji": "🤷‍♂️💭❓",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Now, mark.": {
+    "emoji": "🕰️✍️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "did you yourself feel such a mystical vibration, when first told that you and your ship were now out of sight of land?": {
+    "emoji": "🫵🌊🔮, 🗣️⛵➡️🌍?",
+    "date": "2024-01-01T00:00:00"
+  },
+  "several tubs had been filled with the fragrant sperm": {
+    "emoji": "🛁🛁🛁 ➡️ 🏠 🌺😌",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Let me try to explain them.": {
+    "emoji": "📝➡️🤔🗣️🔍📃",
+    "date": "2024-01-01T00:00:00"
+  },
+  "A nose to the whale would have been impertinent.": {
+    "emoji": "👃➡️🐋❗️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "something obscurely in reference to his incarcerated body and the whale’s gastric juices": {
+    "emoji": "🔍🧑‍⚖️🍂🐳🍲",
+    "date": "2024-01-01T00:00:00"
+  },
+  "it blew very fresh": {
+    "emoji": "💨🌬️😊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "by exceeding caution, you may possibly escape these and the multitudinous other evil chances of life": {
+    "emoji": "🚫⚠️😊🏃‍♂️💨📉🙅‍♂️🔀😈📉📉📉😥🌐",
+    "date": "2024-01-01T00:00:00"
+  },
+  "he was nothing but a humbug, trying to be a bugbear.": {
+    "emoji": "👨❌🧢🐞➡️👺",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the Right Whale’s head bears a rather inelegant resemblance to a gigantic galliot-toed shoe.": {
+    "emoji": "🐋➡️👟🔍💡",
+    "date": "2024-01-01T00:00:00"
+  },
+  "The permanent constitutional condition of the manufactured man, thought Ahab, is sordidness.": {
+    "emoji": "📝🤔 \"The permanent constitutional condition of the manufactured man, thought Ahab, is sordidness.\"",
+    "date": "2024-01-01T00:00:00"
+  },
+  "What business have I with this pipe?": {
+    "emoji": "🤔📯❓",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Haul in the chains! Let the carcase go astern!": {
+    "emoji": "⚓️🔗 Haul in the chains! 🐋⬇️ Let the carcase go astern! 🚢",
+    "date": "2024-01-01T00:00:00"
+  },
+  "to learn all about these recondite matters, your best way is at once to descend into the blubber-room, and have a long talk with its inmates": {
+    "emoji": "📚💡🤔⬇️🚪🛳️🔍🐋➡️🗣️🧑‍🏫💬📘",
+    "date": "2024-01-01T00:00:00"
+  },
+  "in that full front view, you feel the Deity and the dread powers more forcibly than in beholding any other object in living nature": {
+    "emoji": "🌅👁️😲🙏⚡️💪🏞️🧑‍🤝‍🧑",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I’ve studied signs, and know their marks": {
+    "emoji": "📚🔍✨ ➕ 🧐🖊️, 🧐➡️ 📌🔍🔖",
+    "date": "2024-01-01T00:00:00"
+  },
+  "it’s better to sail with a moody good captain than a laughing bad one": {
+    "emoji": "⛵️😤👨‍✈️> 😂👨‍✈️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "And heaved and heaved, still unrestingly heaved the black sea, as if its vast tides were a conscience; and the great mundane soul were in anguish and remorse for the long sin and suffering it had bred.": {
+    "emoji": "🌊➕🌊, 🏋️‍♂️🌊🌊, ➡️🚫🙇‍♀️🌊🔵🌊, ⚫️🌊, 🌫️⚖️✈️, ➕😦✨🪶🌊🌊, ➡️👁️⚡🌊🪞⚓👎✨😓🌫️⚖️➕😞🌊🛌🪦➕🪻🌊🛌💔💭।",
+    "date": "2024-01-01T00:00:00"
+  },
+  "and the last whale, like the last man, smoke his last pipe, and then himself evaporate in the final puff": {
+    "emoji": "🌀🐋, 🧔🚬, 💨↖️💨, 🌫️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "a long, limber, portentous, black mass of something": {
+    "emoji": "🖤🐍📏🌀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Thus, gentlemen, though an inlander, Steelkilt was wild-ocean born, and wild-ocean nurtured": {
+    "emoji": "🌊👨‍🚀, 👨‍⚖️🌐, 🌊🌿, 🌊🌊🌊🌊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Into this hole, the end of the second alternating great tackle is then hooked so as to retain a hold upon the blubber, in order to prepare for what follows.": {
+    "emoji": "🕳️➡️⚓️🐋🔄📌🔧📍🛠️🐳➡️🔜",
+    "date": "2024-01-01T00:00:00"
+  },
+  "embellished with all the gay flags of all the known nations of the world": {
+    "emoji": "🎉🏳️‍🌈🌍⛵✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "often possession is the whole of the law": {
+    "emoji": "🔁🔑➡️⚖️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I began to be sensible of strange feelings. I felt a melting in me.": {
+    "emoji": "🧠✨😳😶‍🌫️💧🫠",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I claim him for one of our clan.": {
+    "emoji": "🗣️🙋‍♂️👨‍👩‍👧‍👦➡️👨‍👨‍👦",
+    "date": "2024-01-01T00:00:00"
+  },
+  "To-morrow, in the natural sun, the skies will be bright": {
+    "emoji": "🌞✨, ☀️🏞️, 🌌🌤️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Let me make a clean breast of it here, and frankly admit that I kept but sorry guard.": {
+    "emoji": "🗣️💬 \"🫀✨➡️🤝😊🫣, 🤔🙈😔🛡️\"",
+    "date": "2024-01-01T00:00:00"
+  },
+  "so you suppose I’m afraid of the devil?": {
+    "emoji": "😅🤔💭 \"😈?\"",
+    "date": "2024-01-01T00:00:00"
+  },
+  "The jaw is afterwards sawn into slabs, and piled away like joists for building houses.": {
+    "emoji": "🦈✂️➡️🪚➡️📏➡️🏠",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Surely this was a touch of fine philosophy; though no doubt he had never heard there was such a thing as that.": {
+    "emoji": "👍🤔🧐📚🤔🙉🤷‍♂️🤔",
+    "date": "2024-01-01T00:00:00"
+  },
+  "methinks it rings most vast, but hollow": {
+    "emoji": "🤔🔔🌌❗️💭➡️🕳️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "He minds you somewhat of a juggler, balancing a long staff on his chin.": {
+    "emoji": "🧔‍♂️🤹‍♂️🎩🪄, 🤹‍♂️👨🦯🩻",
+    "date": "2024-01-01T00:00:00"
+  },
+  "spinning, animate and inanimate, all round and round in one vortex, carried the smallest chip of the Pequod out of sight": {
+    "emoji": "🌀, 🌀💃🚫 💃, 🚢➡️♾️, 🚢⛔, 🌊, 🌊🏞, 🚤➡️🔭",
+    "date": "2024-01-01T00:00:00"
+  },
+  "But as in landlessness alone resides highest truth, shoreless, indefinite as God": {
+    "emoji": "🌊🤔🔍⚓️📝🌟🚫🛤️🏝️➡️🌌🔝👌🌿🌫️🌍👓🙏",
+    "date": "2024-01-01T00:00:00"
+  },
+  "is his brain so much more comprehensive, combining, and subtle than man’s, that he can at the same moment of time attentively examine two distinct prospects, one on one side of him, and the other in an exactly opposite direction?": {
+    "emoji": "🤔🧠➕🔍🤨🤯👉👨‍🦱❓📊🕰️⏱️👀➡️1️⃣⭐🛤️✋🔄↔️⭐",
+    "date": "2024-01-01T00:00:00"
+  },
+  "a supernatural hand seemed placed in mine.": {
+    "emoji": "🖐✨👻🔮🖐",
+    "date": "2024-01-01T00:00:00"
+  },
+  "See how elastic our prejudices grow when once love comes to bend them.": {
+    "emoji": "👀➡️🌱📏🔄📈💬❓❤️➡️🧠⚡🌿",
+    "date": "2024-01-01T00:00:00"
+  },
+  "they drag out these teeth, as Michigan oxen drag stumps of old oaks out of wild wood lands": {
+    "emoji": "🔗🦷🚜🐂📏🌳🆚🌲🏞️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the one visible quality in the aspect of the dead which most appals the gazer, is the marble pallor lingering there": {
+    "emoji": "👁️👤🪦🧊😱",
+    "date": "2024-01-01T00:00:00"
+  },
+  "And lo! close under our lee, not forty fathoms off, a gigantic Sperm Whale lay rolling in the water like the capsized hull of a frigate": {
+    "emoji": "🐋🌊👀! 🔍⬇️🛳️🔜😮, 🌊🚢4️⃣0️⃣〰️🙅‍♂️🏊‍♂️, 🐋✨⚓️, 🛳️🔄🌊🎢⚓️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "it floats more and more away, the water round it torn and splashed by the insatiate sharks": {
+    "emoji": "🌊🚤⏩⏩➡️, 🦈💦🌊💢📈🦈\n",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Who ain’t a slave? Tell me that.": {
+    "emoji": "🙋‍♂️🙋‍♀️ ❓ 🛑 🔗 ❗️ 🗣️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "descend upon the monster’s back for the special purpose referred to": {
+    "emoji": "⬇️🦇🧌🔙for⭐🛠🫰",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Surely all this is not without meaning.": {
+    "emoji": "🔍🤔📖❓💭💬",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I, Ishmael, was one of that crew; my shouts had gone up with the rest; my oath had been welded with theirs; and stronger I shouted, and more did I hammer and clinch my oath, because of the dread in my soul.": {
+    "emoji": "🧔🤚🌊👥; 🔊📢⬆️👆; ✋🤝🔒🗣️; 💪📢, 🔨💬💪, 📝, 😱💀.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "For the present other matters press, and the best we can do now for the head, is to pray heaven the tackles may hold.": {
+    "emoji": "📚🤔⏳📝💼🔄📅🙇‍♂️🙏🌌📌🙏👏",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Come, Almanack!": {
+    "emoji": "🛎️📅",
+    "date": "2024-01-01T00:00:00"
+  },
+  "we are curing the wound, when whang come the arrows all round; Sagittarius, or the Archer, is amusing himself": {
+    "emoji": "🩹🏹➡️🎯 ♐😆",
+    "date": "2024-01-01T00:00:00"
+  },
+  "If the wind only held": {
+    "emoji": "🌬️🤞",
+    "date": "2024-01-01T00:00:00"
+  },
+  "because he could not grasp the tormenting, mild image he saw in the fountain, plunged into it and was drowned": {
+    "emoji": "📝😵‍💫🚫🤲😖🖼️🚰🤿🌊💀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I have ye": {
+    "emoji": "👁️➡️⛵",
+    "date": "2024-01-01T00:00:00"
+  },
+  "an unendurable length of time": {
+    "emoji": "⏳😫🕰️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Instantly I felt a shock running through all my frame; nothing was to be seen, and nothing was to be heard": {
+    "emoji": "⚡😱 Instantly I felt a shock running through all my frame; nothing was to be seen 👀 and nothing was to be heard 👂❌",
+    "date": "2024-01-01T00:00:00"
+  },
+  "The glittering mouth yawned beneath the boat like an open-doored marble tomb": {
+    "emoji": "✨👄🦷😮💎🚤⬇️📥🏛️⚰️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Do thou, too, remain warm among ice.": {
+    "emoji": "🫵❄️2️⃣😌🔥🌬️❄️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "whiteness is not so much a colour as the visible absence of colour": {
+    "emoji": "⚪️ is not so much a 🖍️ as the 👀 absence of 🖍️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the fear of this vast dumb brute of the sea, was chained up and enchanted in him; he had no voice": {
+    "emoji": "😨🌊🦈🔗✨🤐",
+    "date": "2024-01-01T00:00:00"
+  },
+  "beyond all hum of human weal or woe": {
+    "emoji": "🌌📣🚶‍♂️❌😂😭",
+    "date": "2024-01-01T00:00:00"
+  },
+  "a prayer so deeply devout that he seemed kneeling and praying at the bottom of the sea": {
+    "emoji": "🙏🌊🤲🌊\n\n",
+    "date": "2024-01-01T00:00:00"
+  },
+  "The gallant Perseus, a son of Jupiter, was the first whaleman": {
+    "emoji": "🗡️👑 Perseus, 👶🔱 son of Jupiter, 🛳️🗺️ was the 1️⃣st 🐋🧔",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the Evil One himself": {
+    "emoji": "😈➡️👤",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Usually the dead Sperm Whale floats with great buoyancy, with its side or belly considerably elevated above the surface.": {
+    "emoji": "🐋⚪️⛴️🔝\n",
+    "date": "2024-01-01T00:00:00"
+  },
+  "The ivory Pequod was turned into what seemed a shamble; every sailor a butcher.": {
+    "emoji": "🗡️⚓️🐳✨\n\nThe 🦦 ship 🛳️⚓️ was transformed 🌀 into what seemed like a mess 🩸; every 🧑‍✈️ a butcher 🔪.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "now that the creature was dead, some vague dissatisfaction, or impatience, or despair, seemed working in him": {
+    "emoji": "🐾💀😞🤔💭😣🕰️🚫📈💔",
+    "date": "2024-01-01T00:00:00"
+  },
+  "it needs a strong, nervous arm to strike the first iron into the fish": {
+    "emoji": "💪😬🤜🐟➡️⚒️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "he had but little learning except what he had picked up from the sun and the sea": {
+    "emoji": "👨🏾‍🏫📚🌞🌊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the vast body had at last been stripped of its fathom-deep enfoldings, and the bones become dust dry in the sun": {
+    "emoji": "🐋➡️🌞💀➡️🦴💨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "every moment whole tons of ponderosity seemed added to the sinking bulk, and the ship seemed on the point of going over": {
+    "emoji": "🌊⚓🚢⚖️😱⏳➡️📉⚖️⬆️⏳➡️⛔️🌊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Woe to him who would not be true, even though to be false were salvation!": {
+    "emoji": "😔➡️🤥❌❤️, 🚫🌈➡️⚰️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Top-heavy was the ship as a dinnerless student with all Aristotle in his head.": {
+    "emoji": "🚢💫🍽️📚💡👨‍🎓🤯🧠📖",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Look at his hump": {
+    "emoji": "👀➡️🐫",
+    "date": "2024-01-01T00:00:00"
+  },
+  "From that hour I clove to Queequeg like a barnacle; yea, till poor Queequeg took his last long dive.": {
+    "emoji": "🕰️😌🤝🦑➡️🦭🌊🔚",
+    "date": "2024-01-01T00:00:00"
+  },
+  "numerous nations of them had sworn solemn league and covenant for mutual assistance and protection": {
+    "emoji": "🌍⚔️🛡️🤝📜✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "hardly had the blinding vapor cleared away, when a naked figure with a boarding-sword in his hand, was for one swift moment seen hovering over the bulwarks": {
+    "emoji": "🧑‍🚀💨➡️👀👤🔪🌬️⚓",
+    "date": "2024-01-01T00:00:00"
+  },
+  "all hands were preparing to cast anchor in the deep; for heavy chains are being dragged along the deck, and thrust rattling out of the port-holes": {
+    "emoji": "👐⚓🔧🌊; ⛓️📉🛳️, 🎣🔊📤🚢",
+    "date": "2024-01-01T00:00:00"
+  },
+  "this corner-anchored old ark rocked so furiously": {
+    "emoji": "📐🏠🛳️📜🌀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the frenzy, the boiling blood and the smoking brow, with which, for a thousand lowerings old Ahab has furiously, foamingly chased his prey": {
+    "emoji": "🔥😡💉💦💀⛅️🤯😤🌊➡️1️⃣0️⃣0️⃣0️⃣📅⚓️🐋💨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Nor was this all. It was unsafe to meddle with the corpses and ghosts of these creatures.": {
+    "emoji": "👻🙅‍♂️💀📛🚫🪦",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Believe ye, men, in the things called omens? Then laugh aloud, and cry encore!": {
+    "emoji": "🤔🙋‍♂️, 👀 🪄📜📉? 😂🤣, & 🙏🔁!",
+    "date": "2024-01-01T00:00:00"
+  },
+  "with a lantern we might descend into the great Kentucky Mammoth Cave of his stomach": {
+    "emoji": "🪔➡️🕳️⬇️➡️🗺️🐘🕳️📍🐎🦇⛅",
+    "date": "2024-01-01T00:00:00"
+  },
+  "It was the devious-cruising Rachel, that in her retracing search after her missing children, only found another orphan.": {
+    "emoji": "🛳️👀 Rachel, in her search for her missing children, found another orphan. 💔",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Sometimes these tufts impart a rather brigandish expression to his otherwise solemn countenance.": {
+    "emoji": "🕴️🚶‍♂️🔍🔝🟰😐🔄🚵😠✨💥",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I feel deadly faint, bowed, and humped, as though I were Adam, staggering beneath the piled centuries since Paradise.": {
+    "emoji": "😵‍💫😩🔻🕳️, 🙇‍♂️, 🏋️, 😞👫, 🤯⏳🌿🕰️🤯",
+    "date": "2024-01-01T00:00:00"
+  },
+  "T’gallant sails!—stunsails! alow and aloft, and on both sides!": {
+    "emoji": "🫡⛵️🚩 Mainsails!—Studding sails! below and above, and on both sides!",
+    "date": "2024-01-01T00:00:00"
+  },
+  "It is an ineffably oozy, stringy affair, most frequently found in the tubs of sperm, after a prolonged squeezing, and subsequent decanting.": {
+    "emoji": "🔍👀↔️💦🧵🎭, 🧽🤷‍♂️🤔, 🛁🕵️‍♂️⚗️, 🕰️👐, 🛒🍷🧪.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "they themselves may have either seen or heard of some one’s falling into a cistern ashore": {
+    "emoji": "👥👂👁️➡️🤷‍♂️⬇️⬆️➡️💧🕳️🏝️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Yet is there hope. Time and tide flow wide.": {
+    "emoji": "🕰️🌊✨😌🙏 🌊🕒➡️🌍",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Oh, thou clear spirit, of thy fire thou madest me, and like a true child of fire, I breathe it back to thee.": {
+    "emoji": "😮, 🌟🌬️, 🔥👶, 🔥🌬️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "When that wicked king was slain, the dogs, did they not lick his blood?": {
+    "emoji": "👑🔪💀🐶🩸",
+    "date": "2024-01-01T00:00:00"
+  },
+  "In less than half a minute, this entire thing happened.": {
+    "emoji": "⏳🔜⬇️ 1/2⃣🕛, 🟰✨all🦸➡️🔚.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the monster perpendicularly flitted his tail forty feet into the air, and then sank out of sight like a tower swallowed up": {
+    "emoji": "👹⬆️40️⃣🦵➡️⬇️🏢🌀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "it is a damp, drizzly November in my soul": {
+    "emoji": "🌧️🍂😔",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Lit up by the moon, it looked celestial; seemed some plumed and glittering god uprising from the sea.": {
+    "emoji": "🌕✨🌌😇🌊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "What is yonder undetected villain’s marble mansion with a door-plate for a waif; what is that but a Fast-Fish?": {
+    "emoji": "🤔🏰👹🔍🏠🚪🔖👶➡️🐡🚤🎣",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the sea is his; he owns it, as Emperors own empires": {
+    "emoji": "🌊🐋👑; 🤴🌊, 🔱👑🌎",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Is the steward an apothecary, sir?": {
+    "emoji": "🧐👉🤵💊❓",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the full terror of the voyage must be kept withdrawn into the obscure background": {
+    "emoji": "😱🚢✨ must ➡️ be ↩️🔙📥 into the 🌑⬛️ background",
+    "date": "2024-01-01T00:00:00"
+  },
+  "then all this desolate vacuity of life went away": {
+    "emoji": "🕰️➡️🌌🤷‍♂️➡️😔🌀➡️👋",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Whole Atlantics and Pacifics seemed passed as they shot on their way, till at length the whale somewhat slackened his flight.": {
+    "emoji": "🌊🌊🌊🌊🌊🌊🐋⏩🛤️, 🛤️⏩📉💨🌊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "A thin joist of a spine never yet upheld a full and noble soul.": {
+    "emoji": "🪵➡️🤏🏾🧍‍♂️➡️🦴✨➡️👎➡️👏😇🕊️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "he would have been deified by their child-magian thoughts": {
+    "emoji": "🙇✨👼 🤔💭🚸=>🕴️🔮",
+    "date": "2024-01-01T00:00:00"
+  },
+  "millions of mixed shades and shadows, drowned dreams, somnambulisms, reveries; all that we call lives and souls, lie dreaming, dreaming": {
+    "emoji": "🌈🖤🌫💭💤🌙✨; 🌍😴🌀🌌, 👻💭; 🌜✨🌟💭💭",
+    "date": "2024-01-01T00:00:00"
+  },
+  "He loved to dust his old grammars; it somehow mildly reminded him of his mortality.": {
+    "emoji": "👨❤️➡️🧹📚📖; 👴🔙🧠➡️🕰️🪦",
+    "date": "2024-01-01T00:00:00"
+  },
+  "all whose creatures prey upon each other, carrying on eternal war since the world began": {
+    "emoji": "🦁🔄🐇🦅\n🌏🗡️\n⏳",
+    "date": "2024-01-01T00:00:00"
+  },
+  "many is the time the poor fellows, just buttoning the necks of their clean frocks, are startled by the cry of “There she blows!” and away they fly to fight another whale": {
+    "emoji": "🐋⌚😮‍💨👦😟👕✨🧥🔘😲📣👂✈️🐳⚔️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "in the ordinary swimming position of the Sperm Whale, the front of his head presents an almost wholly vertical plane to the water": {
+    "emoji": "🐋➡️🌊📏💧",
+    "date": "2024-01-01T00:00:00"
+  },
+  "For unless you own the whale, you are but a provincial and sentimentalist in Truth.": {
+    "emoji": "🌊🐋➡️❌👤🌍, 🫵=💔🏞️💭➡️🧐✒️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "keep cool, keep cool—cucumbers is the word": {
+    "emoji": "🆒🆒🥒🗣️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Right and left, the streets take you waterward.": {
+    "emoji": "➡️↔️⬅️ 🛣️ 🏙️🚶‍♂️🚶‍♀️🌊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "all these are but subtile deceits, not actually inherent in substances, but only laid on from without": {
+    "emoji": "🔍🌐🎭✨ not actually 📦🧬, but 🚫🔜🎨🖌️🌐",
+    "date": "2024-01-01T00:00:00"
+  },
+  "And that the great monster is indomitable, you will yet have reason to know.": {
+    "emoji": "🫢 🐉 🦖 ➡️ 😤, ⏳ 🙇‍♂️ 💡",
+    "date": "2024-01-01T00:00:00"
+  },
+  "With books the same. The truest of all men was the Man of Sorrows, and the truest of all books is Solomon’s": {
+    "emoji": "📚🤔 📚✨👤✨😢, ✨📚✨📖✨👑📝",
+    "date": "2024-01-01T00:00:00"
+  },
+  "any man unaccustomed to such sights, to have looked over her side that night, would have almost thought": {
+    "emoji": "🧍‍♂️❌👀👁️👀📅🌚,👀⬇️⬆️⛵🌃,👀💭🧠",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the stricken whale, without at all sounding, still continued his horizontal flight, with added fleetness": {
+    "emoji": "🐋💢, ⛔🔊, ➡️🔄↔️🛫, ➕⚡💨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Dash the nose from Phidias’s marble Jove, and what a sorry remainder!": {
+    "emoji": "🌀👃🗿Phidias’s🪨🧿, and 😢🔚!",
+    "date": "2024-01-01T00:00:00"
+  },
+  "these spiritual throes in him heaved his being up from its base, and a chasm seemed opening in him": {
+    "emoji": "🌌💫 these 🙏🔥 in him 🌪️ his 🌍🌟 up from its 🏞️🔽, and a 🌋 seemed ⛏️ in him",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Here Saturn’s grey chaos rolls over me, and I obtain dim, shuddering glimpses into those Polar eternities": {
+    "emoji": "🌌🪐🌫️ rolls over me, and I obtain 🌫️😱 glimpses into those 🌌❄️⌛",
+    "date": "2024-01-01T00:00:00"
+  },
+  "But neither great Washington, nor Napoleon, nor Nelson, will answer a single hail from below": {
+    "emoji": "🙅‍♂️🗣️🇺🇸🤵🪖🔱💬👂⬇️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "all the coopers in creation couldn’t show hoops enough to make oughts enough": {
+    "emoji": "🪵🔨🌍 🥽🤷‍♂️⬆️🔄💯🪅⭕➡️👌",
+    "date": "2024-01-01T00:00:00"
+  },
+  "they deemed our ship some drifting, uninhabited craft; a thing appointed to desolation": {
+    "emoji": "👥🔍🛳️➡️🌊🛠️➡️🏝️🚫🏠; 📜➡️💀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "athirst in the great American desert": {
+    "emoji": "🧑‍🤠💧🏜️🌵🇺🇸",
+    "date": "2024-01-01T00:00:00"
+  },
+  "when the second iron is thrown overboard, it becomes a dangling, sharp-edged terror, skittishly curvetting about both boat and whale": {
+    "emoji": "🔄🪓❗⚓️🛥🐋",
+    "date": "2024-01-01T00:00:00"
+  },
+  "these were words best omitted here; for you live under the blessed light of the evangelical land": {
+    "emoji": "💬❌🔤⬇️🗣️; 🌍🌞🙌📖✝️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "if thou could’st, blacksmith, glad enough would I lay my head upon thy anvil, and feel thy heaviest hammer between my eyes": {
+    "emoji": "🙇‍♂️🤲🛠️✨😌🔨💥👀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "if you have anything important to tell us, out with it; but if you are only trying to bamboozle us, you are mistaken in your game": {
+    "emoji": "🗣️💬❗️🤔🤫😇🛑🤥🃏🫢😏🎲",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the long tension of Ahab’s bodily strength did crack, and helplessly he yielded to his body’s doom": {
+    "emoji": "\n🧓💪💥💔😞👐➡️🪦",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Nantucket was her great original—the Tyre of this Carthage;—the place where the first dead American whale was stranded.": {
+    "emoji": "🏝️🕰️➡️🏴‍☠️📍🐋☠️🇺🇸⬅️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "they all disappeared far to leeward, still in bold, hopeful chase": {
+    "emoji": "👥✨🏃‍♂️🏃‍♀️💨🔙 ➡️🍃🐾💪💫",
+    "date": "2024-01-01T00:00:00"
+  },
+  "How it is, there is no telling": {
+    "emoji": "🤷‍♂️🤷‍♀️❓🔮",
+    "date": "2024-01-01T00:00:00"
+  },
+  "He became a nameless terror to the ship.": {
+    "emoji": "👤➡️😨⚓🚢",
+    "date": "2024-01-01T00:00:00"
+  },
+  "This vigilance was not long without reward.": {
+    "emoji": "🔍⏳➡️🏆",
+    "date": "2024-01-01T00:00:00"
+  },
+  "keep a bright look-out": {
+    "emoji": "👀✨🚶‍♂️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "his head was phrenologically an excellent one": {
+    "emoji": "🧑‍🦲🧠👍",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I thought I might as well go below and make a rough draft of my will.": {
+    "emoji": "🤔➡️👇📝📄🖋️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "like man, the whale has lungs and warm blood. Freeze his blood, and he dies.": {
+    "emoji": "👍👨, 🐳 🫁 🔥🩸. ❄️🩸, 💀.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "there were some boobies and bumpkins there, who, by their intense greenness, must have come from the heart and centre of all verdure": {
+    "emoji": "🦤👢🌿✨, 🌱🛤💚🔍➡️📝🌲✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "let us now have a good long look": {
+    "emoji": "👀📖😊🔍",
+    "date": "2024-01-01T00:00:00"
+  },
+  "It is as though the forehead of the Sperm Whale were paved with horses’ hoofs. I do not think that any sensation lurks in it.": {
+    "emoji": "🐋 ➡️ 🤔 💭 ➡️ 🤯 ⚒️ 🐎 🦶. ❌ 💬 🧠 ➡️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "treacherously hidden beneath the loveliest tints of azure": {
+    "emoji": "😈🔄🌿🍃🌸🔵",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I believe that much of a man’s character will be found betokened in his backbone.": {
+    "emoji": "🧠✨💭\n🙋‍♂️🌟👤🧐👍\n🙌📚🍃🦴✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "better answer": {
+    "emoji": "👍✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "how may unlettered Ishmael hope to read the awful Chaldee of the Sperm Whale’s brow?": {
+    "emoji": "🤔📖❓🟢🕵️‍♂️🌊🐋📝👀😱",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Still, we can hypothesize, even if we cannot prove and establish.": {
+    "emoji": "🤔💭🔍, we can 🧩, even if we cannot ✅📜.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Of all divers, thou hast dived the deepest.": {
+    "emoji": "🌊🤿 Of all divers, thou hast dived the deepest. 🌊🦈",
+    "date": "2024-01-01T00:00:00"
+  },
+  "what has been promiscuously said, thought, fancied, and sung of Leviathan": {
+    "emoji": "🔊🤔💭🎶🐋",
+    "date": "2024-01-01T00:00:00"
+  },
+  "he still hugged me tightly, as though naught but death should part us twain": {
+    "emoji": "👫💔🤗💀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "diving under the ultimate glassy barriers and walls there, come up among icy fields and floes": {
+    "emoji": "🤿⬇️ 🌊🪟⛔️🧱➕🧱 🧱↔️🏔️❄️🏔️ 👉 ⬆️ 🌨️❄️🏔️ ❄️🧊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "where, I should like to know, will you obtain a better chance to study practical cetology than here?": {
+    "emoji": "🌍❓🤔➡️📚🐋💡🔎🏫👉🏾⌛",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Some unknown conduits from the unknown worlds must empty into thee!": {
+    "emoji": "🌌❓🌐🌌❓➔💧👉🫵",
+    "date": "2024-01-01T00:00:00"
+  },
+  "odds and ends of strange nations come up from the unknown nooks and ash-holes of the earth to man these floating outlaws of whalers": {
+    "emoji": "🧩🌍❓👳‍♂️🦘🌑🕳️🛳️🐋",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Yet what depths of the soul does Jonah’s deep sealine sound!": {
+    "emoji": "🌀😱🌊🐋🤿🕳️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "this consciousness at last glided away from me": {
+    "emoji": "🧠➡️😌⏳🚶‍♂️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "'Tis July's immortal Fourth; all fountains must run wine today!": {
+    "emoji": "🎇🍷🌟 'Tis July's immortal Fourth; all fountains must run wine today! 🌟🍷🎇",
+    "date": "2024-01-01T00:00:00"
+  },
+  "In truth, a mature man who uses hair-oil, unless medicinally, that man has probably got a quoggy spot in him somewhere.": {
+    "emoji": "🔍🤔👨‍🦳🦹‍♂️🧴🛢️, ❌💊, 🧔➡️🤯💭🟤👤😬🔎",
+    "date": "2024-01-01T00:00:00"
+  },
+  "embracing one half of the level horizon, a continuous chain of whale-jets were up-playing and sparkling in the noon-day air": {
+    "emoji": "🫂 ➗ 🌆 = 🤯📈 a continuous chain of 🐋💦 were 🌊✨ in the 🌞-day 🌬️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "are you the man to snap your spine": {
+    "emoji": "👨❓🫵👨‍🦲👉📸🦴",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Gabriel, ascending to the main-royal mast-head, was tossing one arm in frantic gestures, and hurling forth prophecies of speedy doom to the sacrilegious assailants of his divinity.": {
+    "emoji": "👨‍🦱⬆️⛵️🌟💨🙋‍♂️😱⚡️📢🏴‍☠️💣👀⛔️🛐",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Yet this is nothing": {
+    "emoji": "🟡➕🟡🔜🔙➡️🅾️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "spouting all over the sea, and sprinkling and mistifying the gardens of the deep": {
+    "emoji": "🐳💦🌊, 🌬️💧🌸🏝️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "We try to reach Virtue, when lo! comes Cancer the Crab, and drags us back": {
+    "emoji": "🔜✨↖️🌟, 😲🦀⏪",
+    "date": "2024-01-01T00:00:00"
+  },
+  "lo! a broad white shadow rose from the sea; by its quick, fanning motion, temporarily taking the breath out of the bodies of the oarsmen": {
+    "emoji": "🌊❗👐🌌👻⬆️🌅;🌬️⚡🚣‍♂️📴",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Gabriel once more started to his feet, glaring upon the old man, and vehemently exclaimed, with downward pointed finger—“Think, think of the blasphemer—dead, and down there!—beware of the blasphemer’s end!”": {
+    "emoji": "😤🧔‍♂️➡️🏃‍♂️⬆️👀👴💢☝️👇💬 \"🤔🤔😈☠️⬇️!⚠️😈's🔚!\"",
+    "date": "2024-01-01T00:00:00"
+  },
+  "An intense copper calm, like a universal yellow lotus, was more and more unfolding its noiseless measureless leaves upon the sea.": {
+    "emoji": "🌅💛🌼🌊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "away with child’s play; no more gaffs and pikes to-day": {
+    "emoji": "🚫🎭; 🚫🪓🎣📅",
+    "date": "2024-01-01T00:00:00"
+  },
+  "he too lives like a Czar in an ice palace made of frozen sighs": {
+    "emoji": "👑❄️🏰🏔️💨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "these queer proceedings increased my uncomfortableness": {
+    "emoji": "😰👀 these 🏳️‍🌈🤔 proceedings 📈 increased ➕ my 😣 uncomfortableness",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Consider the subtleness of the sea": {
+    "emoji": "🌊✨🤔",
+    "date": "2024-01-01T00:00:00"
+  },
+  "washed by waves, and cooled by breezes": {
+    "emoji": "🌊🌀 🌬️🍃",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Days, weeks passed, and under easy sail, the ivory Pequod had slowly swept across four several cruising-grounds": {
+    "emoji": "🗓️➡️🗓️📅⏳, 🌊⛵, 🐘⚓🚢 🐳💨 🐢🌐🗺️4⃣ 🛳️🐳",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Yet Dives himself, he too lives like a Czar in an ice palace made of frozen sighs": {
+    "emoji": "🤑❄️👑🏰😢",
+    "date": "2024-01-01T00:00:00"
+  },
+  "this were as vain a thing as to attempt weighing a Dutch barn in jewellers’ scales": {
+    "emoji": "🔄⚖️🛖💎⚖️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "“Aye? Well, now, that’s cheering,” cried Ahab, suddenly erecting himself, while whole thunder-clouds swept aside from his brow.": {
+    "emoji": "\"🗣️? Well, now, that’s 😀,\" cried 🧔‍♂️, suddenly 🚶‍♂️, while whole 🌩️ swept aside from his brow.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "almost squared by the enormous superincumbent mass of the junk and sperm": {
+    "emoji": "🟧❓ by the 🏔️🟩 ⬛️ of the 🗑️🧊 and 🦖🦴",
+    "date": "2024-01-01T00:00:00"
+  },
+  "It makes a stranger stare.": {
+    "emoji": "😲👀👤",
+    "date": "2024-01-01T00:00:00"
+  },
+  "The white whale is their demigorgon.": {
+    "emoji": "🦈👻\n**\n**The white whale is their demigorgon.**\nNote: In this conversion, 🦈 represents \"whale,\" and 👻 represents \"demigorgon.\" This translation captures the essence of the phrase but may not convey the exact literary reference.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "surrounded by five dusky phantoms that seemed fresh formed out of air": {
+    "emoji": "🌫️🧟‍♂️🧟🧟‍♀️🧟‍♂️🧟‍♀️ 🌫️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "and beyond, a black Angel of Doom was beating a book in a pulpit.": {
+    "emoji": "📖✨, 😈👼 🌑 ⏳ 📖 🌩️📖 😇",
+    "date": "2024-01-01T00:00:00"
+  },
+  "he may be deemed a sort of involuntary whaleman; at any rate the whale caught him, if he did not the whale": {
+    "emoji": "👤🤷‍♂️🐋→👨‍✈️; 🐋🎣👦, 🧍‍♂️🚫🎣🐋",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Interweaving in its proper place this darker thread with the story as publicly narrated on the ship, the whole of this strange affair I now proceed to put on lasting record.": {
+    "emoji": "🧵🖤🛳️📖✨🔍✍️📜",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the boat was still booming through the mist, the waves curling and hissing around us like the erected crests of enraged serpents": {
+    "emoji": "🚤🌫️🌊🔊🌬️🐍💢",
+    "date": "2024-01-01T00:00:00"
+  },
+  "In short, he is what the fishermen technically call a “grey-headed whale.”": {
+    "emoji": "📝🚶🐟🔍👨‍🦳🐋",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I have the satisfaction of knowing that it is all right; that everybody else is one way or other served in much the same way": {
+    "emoji": "😊🤔👍😌; 🧑‍🤝‍🧑👩‍🤝‍👨👨‍👩‍👦‍👦➡️👈➡️🙌✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "In life but few of them would have helped the whale, I ween, if peradventure he had needed it; but upon the banquet of his funeral they most piously do pounce.": {
+    "emoji": "🌊👤💭🐋❓🚫🆘🙅‍♂️💭🍽️⚰️🙇‍♂️🍴",
+    "date": "2024-01-01T00:00:00"
+  },
+  "The Nut.": {
+    "emoji": "🥜",
+    "date": "2024-01-01T00:00:00"
+  },
+  "be a philosopher": {
+    "emoji": "🤔📚",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Close to our bows, strange forms in the water darted hither and thither before us; while thick in our rear flew the inscrutable sea-ravens.": {
+    "emoji": "🛶🌊🤔👽🐟💦➡️⬅️🔙👁️‍🗨️🕊️🌊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I once saw a large herd of whales in the east, all heading towards the sun, and for a moment vibrating in concert with peaked flukes.": {
+    "emoji": "🐋🏞️➡️🌅, 🎶✨👀👉🎵🎶🔝🐋",
+    "date": "2024-01-01T00:00:00"
+  },
+  "The Nantucketer, he alone resides and riots on the sea": {
+    "emoji": "🧔⚓️, 🌊🏝️, 🏠🔹 🎉🔹 ⛵️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "your bill of fare is immutable": {
+    "emoji": "🍽️📜🔒",
+    "date": "2024-01-01T00:00:00"
+  },
+  "And God created great whales.": {
+    "emoji": "🌌🙏🌊🐋",
+    "date": "2024-01-01T00:00:00"
+  },
+  "All thy unnamable imminglings float beneath me here": {
+    "emoji": "🔮 All thy unnamable 🌫️ imminglings float beneath me here 🌊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Like the great dome of St. Peter’s, and like the great whale, retain, O man! in all seasons a temperature of thine own.": {
+    "emoji": "👍🏛🕊, 🐋, 🧊🌡😊🕰💪👨!",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I now prophesy that I will dismember my dismemberer.": {
+    "emoji": "🔮➡️🤺✂️↔️🪓",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Over this lip, as over a slippery threshold, we now slide into the mouth.": {
+    "emoji": "👄⬆️👈➡️🪜🚪🛤️➡️😊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "so the wretched infidel gazes himself blind at the monumental white shroud that wraps all the prospect around him": {
+    "emoji": "🧔‍♂️➡️👀❌📜🏳️🏔🗺",
+    "date": "2024-01-01T00:00:00"
+  },
+  "“I will have no man in my boat,” said Starbuck, “who is not afraid of a whale.”": {
+    "emoji": "🗣️🚫👨‍✈️🚣‍♂️, 🗣️⭐🦌, 🗣️🗣️, \"🛑⚓️🐋\".",
+    "date": "2024-01-01T00:00:00"
+  },
+  "If man will strike, strike through the mask!": {
+    "emoji": "👨⚡🎭",
+    "date": "2024-01-01T00:00:00"
+  },
+  "With a frigate’s anchors for my bridle-bitts and fasces of harpoons for spurs, would I could mount that whale and leap the topmost skies": {
+    "emoji": "⚓🐋🌌",
+    "date": "2024-01-01T00:00:00"
+  },
+  "So with stun-sail piled on stun-sail, we sailed along, driving these leviathans before us": {
+    "emoji": "📜🛳️➡️🛳️🌬️➡️➡️🦈⬆️➡️➡️🌊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the great floodgates of the wonder-world swung open": {
+    "emoji": "🌊🚪✨🌍 opened",
+    "date": "2024-01-01T00:00:00"
+  },
+  "he followed these fish for the fun of it; and a three years’ voyage round Cape Horn was only a jolly joke that lasted that length of time": {
+    "emoji": "🧔➡️🐟🎣😂; ⛵🌎🌊🌍⚓3️⃣📅🤣🕰️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I remember the first albatross I ever saw.": {
+    "emoji": "😊💭🕰️1️⃣🦤👀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Curses throttle thee!": {
+    "emoji": "🤬🤯🗣️🌀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "go down to the fiery pit itself, in order to keep out this frost": {
+    "emoji": "⬇️🔥🕳️➡️❄️🚫",
+    "date": "2024-01-01T00:00:00"
+  },
+  "seize hold of the nearest oarsman’s hair, and hold on there like grim death": {
+    "emoji": "💪🛶👤👋🦱⛓️💀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "What of it, if some old hunks of a sea-captain orders me to get a broom and sweep down the decks?": {
+    "emoji": "🤔 🌊 ⛵️🧹✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "all ye nations before my prow, I bring the sun to ye": {
+    "emoji": "🌍🌐🚢⛴️📢🔆➡️🌞🫵",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I have sometimes pleased myself": {
+    "emoji": "🙋‍♂️😊👌😌",
+    "date": "2024-01-01T00:00:00"
+  },
+  "The sailors, mostly poor devils, cringed, and some of them fawned before him; in obedience to his instructions, sometimes rendering him personal homage, as to a god.": {
+    "emoji": "👨‍✈️🧔‍♂️🚢, 😟👿👥, 😖, 😧🛐👨‍✈️; 👇📜🧔‍♂️🌟, 🔄🙇‍♂️🏛️, 🛐🆘🌟, 🙏🔱.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "into this noiselessness came Ahab alone": {
+    "emoji": "🌌🦶👨‍🦳⛵",
+    "date": "2024-01-01T00:00:00"
+  },
+  "playing upon this crimson pond in the sea": {
+    "emoji": "🎭 🌊 🔴 🌅 🐟",
+    "date": "2024-01-01T00:00:00"
+  },
+  "For what are the comprehensible terrors of man compared with the interlinked terrors and wonders of God!": {
+    "emoji": "🌍🤔➡️😱🤷‍♂️vs🔗😨✨🙏👀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "“the tall pale man” of the Hartz forests, whose changeless pallor unrustlingly glides through the green of the groves—why is this phantom more terrible than all the whooping imps of the Blocksburg?": {
+    "emoji": "🌲👤\"the tall pale man\" of the 🌳Hartz forests, whose 🏳️changeless pallor unrustlingly glides through the 🌿green of the groves—❓why is this 👻phantom more 😨terrible than all the 🏔️whooping imps of the 🏞️Blocksburg?",
+    "date": "2024-01-01T00:00:00"
+  },
+  "full of barbaric spirit and suggestiveness, as the prints of that fine old Dutch savage, Albert Durer": {
+    "emoji": "🦁✨ 🏰⚔️ 🌍🧭 🎨🖼️ 🇳🇱🧔‍🎨 🔥📜\n\n(Note: Albert Durer is presumably referring to Albrecht Dürer, a renowned German artist, often mistakenly identified as Dutch in some contexts. For accuracy, you might adjust the flag to 🇩🇪. The reference has been adapted in emojis to reflect an old-world, artistic, and somewhat fierce spirit.)",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the most exhilarating conception of what the most exalted potency is": {
+    "emoji": "🌟🤩💡🤔🧠🌌💪✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "a tone so strangely compounded of fun and fury, and the fury seemed so calculated merely as a spice to the fun": {
+    "emoji": "🎶😆💥😆, 💥📏🌶️🎉",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the certainty of this criterion is far from demonstrable": {
+    "emoji": "🔍❓📏 🔄🛤️ 📉 👎🔬",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Oh! my friends, but this is man-killing! Yet this is life.": {
+    "emoji": "😮! 🙋‍♂️🙋‍♀️, 👍this is 🚶‍♂️💀! Yet 🌱.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the reason why the grave-digger made music must have been because there was none in his spade": {
+    "emoji": "💭🔎⚰️🔨🎶🤔➕❌👻🔄🛠️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "no wonder that so many hapless harpooneers are madly cursed": {
+    "emoji": "🙅‍♂️🌟🤔🤷‍♂️🎯🔝😥🛶💔🗣😡👎",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Thou shalt see my back parts, my tail, he seems to say, but my face shall not be seen.": {
+    "emoji": "🐳💨🐋, 🐳🎐🤭, 👤⁉️😶🚫👀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "for forty years has Ahab forsaken the peaceful land, for forty years to make war on the horrors of the deep!": {
+    "emoji": "⛵️🌊🔱 For 40 years, Ahab abandoned the 🏞️ peaceful land, for 40 years to wage war ⚔️ on the horrors of the deep! 🌊🦈",
+    "date": "2024-01-01T00:00:00"
+  },
+  "But these are all landsmen; of week days pent up in lath and plaster—tied to counters, nailed to benches, clinched to desks.": {
+    "emoji": "👨‍💼🔒🏢➡️🏘️🏢📆🛠️🔨🪑📎💼🔩✏️💻",
+    "date": "2024-01-01T00:00:00"
+  },
+  "To begin: there’s Aries, or the Ram—lecherous dog, he begets us; then, Taurus, or the Bull—he bumps us the first thing": {
+    "emoji": "🔜: 🐏♈️—🐶❤️, he 👶 us; then, 🐂♉️—he 🤕 us 1️⃣st thing",
+    "date": "2024-01-01T00:00:00"
+  },
+  "they might scout at Moby Dick as a monstrous fable, or still worse and more detestable, a hideous and intolerable allegory": {
+    "emoji": "👥🤔🧐🐳📖🤯👹😳👉📕🚫👎🤢🤬👺🧩",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Look at your knife-handle, there, my civilized and enlightened gourmand dining off that roast beef, what is that handle made of?—what but the bones of the brother of the very ox you are eating?": {
+    "emoji": "👀🔪➡️🙌, 🧑‍🎓🍽️✨🥩, 🦴➡️🐂🍽️🌿?",
+    "date": "2024-01-01T00:00:00"
+  },
+  "while ponderous planets of unwaning woe revolve round me, deep down and deep inland there I still bathe me in eternal mildness of joy": {
+    "emoji": "🌌🌍💫😔🔄🔁😫🔄🔄⚫️, 🌊⬇️🔍⬇️🏞️🏝️🏔️🌿😌🛀🌞😇✨😊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "its profounder and more subtle meanings": {
+    "emoji": "🔍📚✨🎭↩️🤔🧠💡",
+    "date": "2024-01-01T00:00:00"
+  },
+  "When in the Southern Fishery, a captured Sperm Whale, after long and weary toil, is brought alongside late at night, it is not, as a general thing at least, customary to proceed at once to the business of cutting him in.": {
+    "emoji": "🐳🌌💪⏳🌊🙅‍♂️🔪⏰🕒✂️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Death to Moby Dick! God hunt us all, if we do not hunt Moby Dick to his death!": {
+    "emoji": "☠️🔪🐋! 🙏🕵️‍♂️👁️🧑‍✈️⛵️, 🔥❌🚫🔍🐋☠️!",
+    "date": "2024-01-01T00:00:00"
+  },
+  "However, a good laugh is a mighty good thing, and rather too scarce a good thing; the more’s the pity.": {
+    "emoji": "😂➡️😄💪🔝👍, ➕🤏😟🦄🔝👍; ➕😭😔.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Already you know what his blubber is.": {
+    "emoji": "🤔🧐 ❓ 🐋➕😄🔍📖",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Whether he had lost that fin in battle, or had been born without it, it were hard to say.": {
+    "emoji": "🤔🦈❓⚔️🤕🤷‍♂️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "last night’s thunder turned our compasses": {
+    "emoji": "🌩️⏰🌙 🔄🧭",
+    "date": "2024-01-01T00:00:00"
+  },
+  "no longer will I guide my earthly way by thee": {
+    "emoji": "🚫⏳🚶‍♀️🌏➡️🗺️🔍👉✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the villanous green goggling glasses deceitfully tapered downwards to a cheating bottom": {
+    "emoji": "😈🟢👓🔍📉🔽➡️🔚🃏",
+    "date": "2024-01-01T00:00:00"
+  },
+  "But, perhaps, to be true philosophers, we mortals should not be conscious of so living or so striving.": {
+    "emoji": "🤔🧠💭➡️👥🧑‍🎓👩‍🎓👉😇🙈💪🔥❌🏆🙌",
+    "date": "2024-01-01T00:00:00"
+  },
+  "her companions swim around her with every token of concern, sometimes lingering so near her and so long, as themselves to fall a prey": {
+    "emoji": "👥 🐠 🏊‍♀️ 🤔 ❤️ 😟, 🕰️ 🌀 🤗 ↔️ ⏳, 😰 🕰️ ⌛️, 🐠 🎣",
+    "date": "2024-01-01T00:00:00"
+  },
+  "his great genius is declared in his doing nothing particular to prove it": {
+    "emoji": "👨‍🎨✨🤔 ➡️ 👌❌📜🧠✔️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "And thus the work proceeds; the two tackles hoisting and lowering simultaneously; both whale and windlass heaving, the heavers singing, the blubber-room gentlemen coiling, the mates scarfing, the ship straining, and all hands swearing occasionally": {
+    "emoji": "🐳⛓️↕️🎶🔧💪🎵🎶📦⚓🤬",
+    "date": "2024-01-01T00:00:00"
+  },
+  "is this Moby Dick?": {
+    "emoji": "🐋❓",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Who can tell how appalling to the wounded whale must have been such huge phantoms flitting over his head!": {
+    "emoji": "🧐💭🐋😨🤕💭👻🛸🤯🐋⬆️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Ever and anon a bright, but, alas, deceptive idea would dart you through.": {
+    "emoji": "⏰🌟💭➡️😔💡➡️⚡️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "if all the blood in a man could be aerated with one breath, he might then seal up his nostrils and not fetch another for a considerable time": {
+    "emoji": "👨‍🦳💨❤️➕👃🛑⏳",
+    "date": "2024-01-01T00:00:00"
+  },
+  "from the unmarred dead body of the whale, you may scrape off with your hand an infinitely thin, transparent substance, somewhat resembling the thinnest shreds of isinglass, only it is almost as flexible and soft as satin": {
+    "emoji": "🐋➡️👐🆓🧊🌊🎛️✨🔍🔎🫙🪞🧵🪞👗",
+    "date": "2024-01-01T00:00:00"
+  },
+  "a sudden stop was put to further discoveries": {
+    "emoji": "🚫⏹️🕵️‍♂️🔍☝️⛔✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "wondrous": {
+    "emoji": "✨🌟🙌",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Book! you lie there; the fact is, you books must know your places.": {
+    "emoji": "📚! You lie there; the fact is, you 📚 must know your places.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "while the wildest winds of heaven and earth conspire to cast her on the treacherous, slavish shore?": {
+    "emoji": "🌪️🌬️🤝🌍🔄🌊➡️🏝️❓",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Like noiseless nautilus shells, their light prows sped through the sea; but only slowly they neared the foe.": {
+    "emoji": "🐚🚤🌊🐢➡️⚔️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "you must not, in every case at least, take the higgledy-piggledy whale statements, however authentic, in these extracts, for veritable gospel cetology.": {
+    "emoji": "🔍❌🐋📜🔀💯📖⚓🦷",
+    "date": "2024-01-01T00:00:00"
+  },
+  "From his mighty bulk the whale affords a most congenial theme whereon to enlarge, amplify, and generally expatiate.": {
+    "emoji": "🐋➡️📚✨ The whale's impressive size offers a perfect topic to expand, amplify, and discuss. 💬🗣️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "beneath the effulgent Antarctic skies I have boarded the Argo-Navis, and joined the chase against the starry Cetus": {
+    "emoji": "☀️🌌❄️🧑‍✈️🚢🌟➡️🐋✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "we undressed and went to bed, at peace with our own consciences and all the world": {
+    "emoji": "👗➡️🛏️, ☮️🧠🌍",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Wrapped, for that interval, in darkness myself, I but the better saw the redness, the madness, the ghastliness of others.": {
+    "emoji": "🖤🌑🔒, 🌌🕒, 🖤🌑🔁, 🌚👀📈, 🌈🔴, 🤪, 🧟‍♂️😱😨👥.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the slippered waves whispered together as they softly ran on": {
+    "emoji": "🌊👂🤫🤝💨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Signs and wonders, eh? Pity if there is nothing wonderful in signs, and significant in wonders!": {
+    "emoji": "🔮✨🤔🤷‍♂️🙁❓🌟❌🔤✨, 🔄📌🔍👏🔮",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I cherish the greatest respect towards everybody’s religious obligations, never mind how comical": {
+    "emoji": "❤️⛪️🙏👳‍♂️😂🤝",
+    "date": "2024-01-01T00:00:00"
+  },
+  "with one half-throttled shriek you drop through that transparent air into the summer sea, no more to rise for ever": {
+    "emoji": "😱✈️🌊☀️⛵️💫✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Look you, Doubloon, your zodiac here is the life of man in one round chapter": {
+    "emoji": "🔍🤔, 💰, ♒🌌, 👤➡️📖🔄",
+    "date": "2024-01-01T00:00:00"
+  },
+  "But strangest of all is the circumstance, that in more instances than one, when the body has been recovered, not a single mark of violence is discernible; the man being stark dead.": {
+    "emoji": "🤔🤯🤔💀 ➡️ 💼, 🕵️‍♂️, 😮😮😮😮, ➡️ 🤔🧐, 🧍‍♂️💀 ⏩ 🕵️‍♂️🔍, ❌🔍🔍🔍❗️ 🚶‍♂️ = 😵💀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "he can never see an object which is exactly ahead, no more than he can one exactly astern": {
+    "emoji": "🚫👁️‍🗨️➡️🔍🔵,🔄🚫👁️‍🗨️⬅️🔍🔙",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Out of the trunk, the branches grow; out of them, the twigs. So, in productive subjects, grow the chapters.": {
+    "emoji": "🌳➡️🌿➡️🌱 (🌿➡️🌱) 📚➡️📖✍️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Ecclesiastes is the fine hammered steel of woe. “All is vanity.” ALL.": {
+    "emoji": "📜🔨😔 \"All is vanity.\" 🪞🔄 ALL.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "with a great swash the ship rolls upwards and backwards from the whale, and the triumphant tackle rises into sight dragging after it the disengaged semicircular end of the first strip of blubber": {
+    "emoji": "🚢🌊⬆️⬅️🐋, 🎉⚙️👁️‍🗨️🪝🔛➡️🪓1️⃣🟦🛢️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "That’s no way to convert sinners, cook!": {
+    "emoji": "😮❌➡️😇, 👨‍🍳!",
+    "date": "2024-01-01T00:00:00"
+  },
+  "A good laugh is a mighty good thing, and rather too scarce a good thing—mores the pity.": {
+    "emoji": "😂👍 is a mighty 👍 thing, and rather too ❌ a 👍 thing—😔",
+    "date": "2024-01-01T00:00:00"
+  },
+  "tell him to paint me a sign, with—“no suicides permitted here, and no smoking in the parlor;”": {
+    "emoji": "🗣️➡️🎨🖌️📜🖼️: \"🚫💀✅🚫🚬🏠💬\"",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Oh, man! admire and model thyself after the whale!": {
+    "emoji": "😮🧔! 👏 🐳 🕵️‍♂️ 🧍 ➡️ 🐋!",
+    "date": "2024-01-01T00:00:00"
+  },
+  "His tormented body rolled not in brine but in blood, which bubbled and seethed for furlongs behind in their wake.": {
+    "emoji": "🧍‍♂️💔🤯💦❌🔄🔴💧🔄🩸🌊🥵😤↔️🔙",
+    "date": "2024-01-01T00:00:00"
+  },
+  "out of fifty fair chances for a dart, not five are successful": {
+    "emoji": "🎯 Out of 50 🎲 fair chances for a 🎯, not 5 are ✅🎯",
+    "date": "2024-01-01T00:00:00"
+  },
+  "But lazily undulating in the trough of the sea, and ever and anon tranquilly spouting his vapory jet, the whale looked like a portly burgher smoking his pipe of a warm afternoon.": {
+    "emoji": "🐋🌊😌💨➡️🏙️👨‍🦳🚬☀️🍂",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Here ye strike but splintered hearts together—there, ye shall strike unsplinterable glasses!": {
+    "emoji": "👂⚔️❤️💔➡️🍷✊🍾💪",
+    "date": "2024-01-01T00:00:00"
+  },
+  "deformities floundering in seas of blood and blue paint": {
+    "emoji": "🐠🔄🌊🩸🔵🎨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "copied verbatim from my right arm, where I had them tattooed": {
+    "emoji": "📋➡️✍️💪🖋️🖋️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "For as this appalling ocean surrounds the verdant land, so in the soul of man there lies one insular Tahiti": {
+    "emoji": "🌊🌍➡️🌿🏝️, 😊👉🧠👤🔍🏝️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the thunderous concussion resounds for miles": {
+    "emoji": "🌩️💥🔊📏🏞️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the whale has no voice": {
+    "emoji": "🐋❌🔊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "to the eternal honor of our calling be it said, that the first whale attacked by our brotherhood was not killed with any sordid intent": {
+    "emoji": "🐋🏴‍☠️✨✋🗣️🗨️🤝👥📜, 🚫💀⚔️🎯💰💭",
+    "date": "2024-01-01T00:00:00"
+  },
+  "every gasping heave of the windlass is answered by a helping heave from the billows": {
+    "emoji": "🌬️⛓️⬆️➕🌊⬆️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "my mother dragged me by the legs out of the chimney and packed me off to bed": {
+    "emoji": "👩‍👦💪🦵🚪🏠➡️🛏️😴",
+    "date": "2024-01-01T00:00:00"
+  },
+  "a sound so strange, long drawn, and musically wild and unearthly, that the ball of free will dropped from my hand": {
+    "emoji": "🎵🔊😲🌌🎶🌀🎭👉🪦🤚🪩",
+    "date": "2024-01-01T00:00:00"
+  },
+  "It was a black and hooded head; and hanging there in the midst of so intense a calm, it seemed the Sphynx’s in the desert. “Speak, thou vast and venerable head,” muttered Ahab": {
+    "emoji": "🐋🌑👤🖤 🌌🦅➡️ 🏜️🤔🏜️. “🗣️📣, 🤯👴🔮🗿,” 🗣️🧔‍🦱",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Let not the modern paintings of this scene mislead us": {
+    "emoji": "🖼️🚫🖌️🆕🎨⚠️👀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "so mystical and well nigh ineffable was it, that I almost despair of putting it in a comprehensible form": {
+    "emoji": "🌌🧙‍♂️✨ & 🔮😶‍🌫️📜 was it, that I almost 😩🤔 of 📝💡 it in a 🤓🗣️ form",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I went to my little room in the third floor, undressed myself as slowly as possible so as to kill time, and with a bitter sigh got between the sheets.": {
+    "emoji": "🏠➡️🛌3️⃣rd⬆️⬆️, 🚶‍♂️😌, 🧥🐢⌛➖➖😓👉🛏️💭😫",
+    "date": "2024-01-01T00:00:00"
+  },
+  "what just before might have seemed to him a thing most momentous, now seems but a part of the general joke": {
+    "emoji": "🤔➡️🤯➡️😂 Now feels like *just* part of the joke!",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I am game for his crooked jaw, and for the jaws of Death too, Captain Ahab": {
+    "emoji": "😃🎮👤👉👨‍✈️😮👄🔥💀📌🐋",
+    "date": "2024-01-01T00:00:00"
+  },
+  "by three such thin threads the great Leviathan was suspended like the big weight to an eight day clock": {
+    "emoji": "🕰️🔗🔗🔗🐋⚖️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the madness, the frenzy, the boiling blood and the smoking brow": {
+    "emoji": "😜🤪🔥💉😤💢",
+    "date": "2024-01-01T00:00:00"
+  },
+  "if I wake thee not to death, old man, who can tell to what unsounded deeps Starbuck’s body this day week may sink, with all the crew": {
+    "emoji": "👴🌄❌💀, 👴❓➡️🌊❔⭐🦌👨‍✈️💪🏽🕰️🔜📅🍂⬇️🚢❓",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Physiognomically regarded, the Sperm Whale is an anomalous creature.": {
+    "emoji": "🐋👀❓🤔, 🐳👉🤷‍♂️🔍✨.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "under his very pillow rush herds of walruses and whales": {
+    "emoji": "🛏️➡️🥶🐘🐋",
+    "date": "2024-01-01T00:00:00"
+  },
+  "by its indefiniteness it shadows forth the heartless voids and immensities of the universe, and thus stabs us from behind with the thought of annihilation": {
+    "emoji": "🌌❓💔🌌🚫🤯🌌, 🗡️➡️💭💫🌌",
+    "date": "2024-01-01T00:00:00"
+  },
+  "tar in general by no means adds to the rope’s durability or strength, however much it may give it compactness and gloss": {
+    "emoji": "🪢🏺 ❌➕ ⏩ 🪢💪🛡️, 🤔 ➕✨ & 💎",
+    "date": "2024-01-01T00:00:00"
+  },
+  "we occasionally hear of English and American vessels, which, in those waters, have been remorselessly boarded and pillaged": {
+    "emoji": "⛵️👂🔄🇬🇧🚢🇺🇸, 🌊, 💔🗡️🛳️💰",
+    "date": "2024-01-01T00:00:00"
+  },
+  "as the blubber envelopes the whale precisely as the rind does an orange, so is it stripped off from the body precisely as an orange is sometimes stripped by spiralizing it": {
+    "emoji": "🐋➡️🍊⛑️➡️🔪🍊🔄",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Now that the incorruption of this most fragrant ambergris should be found in the heart of such decay; is this nothing?": {
+    "emoji": "\n🙉 ➡️ 🕰️ ➕ ⚖️ ➡️ 🌸 🌺 💨 👃🏼 🌅 🧠 🧩 💔 🦴 😕 👀 🌌 🔍 😕 🤔❗",
+    "date": "2024-01-01T00:00:00"
+  },
+  "But the mingled, mingling threads of life are woven by warp and woof": {
+    "emoji": "🧶 But the intertwined, mixing threads of life are woven by warp and woof ⚡️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "In much the same way do the commonalty lead their leaders in many other things, at the same time that the leaders little suspect it.": {
+    "emoji": "👥➡️👨‍🏫👩‍🏫🔄📚🤔🤷‍♂️👥",
+    "date": "2024-01-01T00:00:00"
+  },
+  "no face can be physiognomically in keeping without the elevated open-work belfry of the nose": {
+    "emoji": "🚫🙂 ➡️ 👃➡️ 🏰⛪️🌬️🔔",
+    "date": "2024-01-01T00:00:00"
+  },
+  "To accomplish his object Ahab must use tools; and of all tools used in the shadow of the moon, men are most apt to get out of order.": {
+    "emoji": "🔨🌒➡️⚓️👨‍✈️💡🛠️❗️👨👨‍🦱👨‍🦰🔧⚠️🚫☀️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "you at last come to the conclusion that such an idea, however wild, might not be altogether unwarranted": {
+    "emoji": "👤🤔➡️🤷‍♂️💭🤔💡😜, ❓😯, 💭💭💭🔍🚫🛑",
+    "date": "2024-01-01T00:00:00"
+  },
+  "The great Leviathan that maketh the seas to seethe like boiling pan.": {
+    "emoji": "🐋🔥🌊 The great Leviathan that maketh the seas to seethe like boiling pan 🌊🔥🐋",
+    "date": "2024-01-01T00:00:00"
+  },
+  "a herd of remorseless wild pirates and inhuman atheistical devils were infernally cheering him on with their curses": {
+    "emoji": "🧔‍☠️🐑😈🦹‍♂️🏴‍☠️👏👹😈🔊💀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "other fish are found exceedingly brisk in those Hyperborean waters; but these, be it observed, are your cold-blooded, lungless fish": {
+    "emoji": "🐟❄️🐠💨🌊🌌; 🐟⛄️🤔💬🐟🥶🩸, 🚫🫁🐟",
+    "date": "2024-01-01T00:00:00"
+  },
+  "this is one of those disheartening instances where truth requires full as much bolstering as error": {
+    "emoji": "🔹😞📖 ➡️ 💯💔 📍🔍🔍 ⚖️🤔 ➕🆙📈💡❌",
+    "date": "2024-01-01T00:00:00"
+  },
+  "all at once a queer accident happened": {
+    "emoji": "🔄🤔💥🤯➡️🚨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Physiognomy, like every other human science, is but a passing fable.": {
+    "emoji": "🔍🙂📖➕👨‍🔬🔬➡️⏳📚➡️🗨️🚶‍♂️📜",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Ah, mortal! then, be heedful; for so, in all this din of the great world’s loom, thy subtlest thinkings may be overheard afar.": {
+    "emoji": "⚠️😱🌍🧠🔍👂🌌",
+    "date": "2024-01-01T00:00:00"
+  },
+  "most appalling beauty": {
+    "emoji": "🤯🧑‍🎤✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Glimpses do ye seem to see of that mortally intolerable truth": {
+    "emoji": "👀✨ do you 🧚‍♀️ seem to 👀 of that ☠️ unbearably 🎭 truth",
+    "date": "2024-01-01T00:00:00"
+  },
+  "with a rapid, nameless impulse, in a superb lofty arch the bright steel spans the foaming distance, and quivers in the life spot of the whale": {
+    "emoji": "🏃‍♂️💥🔎🌈🏹🌊🐋💫❤️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "who against the proud gods and commodores of this earth, ever stands forth his own inexorable self.": {
+    "emoji": "🧍‍♂️🤜🦚🗿🌍🌊🧔‍♂️💪⛓️🌟",
+    "date": "2024-01-01T00:00:00"
+  },
+  "How many barrels will thy vengeance yield thee even if thou gettest it, Captain Ahab?": {
+    "emoji": "🧐⚓️➡️🥃❓🤔😠📈➡️👨‍✈️🦵🏴‍☠️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "By Jove, I have it!": {
+    "emoji": "🌟😲✨ I've got it!",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the precise origin of ambergris remained, like amber itself, a problem to the learned": {
+    "emoji": "🧐❓💭🐋🌊🏺🎨, 🕵️‍♂️💡🤔🐚, ⚙️❔📚🧠",
+    "date": "2024-01-01T00:00:00"
+  },
+  "The whale has no famous author, and whaling no famous chronicler": {
+    "emoji": "🐋❌📚🔝✍️, 🐳❌📖🔝📜",
+    "date": "2024-01-01T00:00:00"
+  },
+  "No perceptible face or front did it have; no conceivable token of either sensation or instinct": {
+    "emoji": "🚫👀😐🔄🔍🤖🚫🧠💡",
+    "date": "2024-01-01T00:00:00"
+  },
+  "“Ah! poor fellow! he’ll have to die now,” ejaculated the Long Island sailor.": {
+    "emoji": "\"Ah! 😢👨‍✈️💔💀\" exclaimed the 🏝️👨‍✈️.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "All professions have their own little peculiarities of detail; so has the whale fishery.": {
+    "emoji": "🧑‍💼👨‍🚀👨‍🍳👩‍⚕️📚🔍🔍🔍; 🐋🐳⚓🎣",
+    "date": "2024-01-01T00:00:00"
+  },
+  "his ship, which, like Satan, would not sink to hell till she had dragged a living part of heaven along with her": {
+    "emoji": "🚢😈⬇️🏴‍☠️➡️🔥🌊👼☁️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "He tasks me; he heaps me": {
+    "emoji": "🔨😠; 🔼🧱⬆️⚖️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "till he spouts black blood and rolls fin out": {
+    "emoji": "🐳🤕🔪🩸➡️⚫🌊🐟🔚",
+    "date": "2024-01-01T00:00:00"
+  },
+  "there is all the difference in the world between paying and being paid": {
+    "emoji": "💸⬅️🌍🔄💰➡️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Had any one of his old acquaintances on shore but half dreamed of what was lurking in him then, how soon would their aghast and righteous souls have wrenched the ship from such a fiendish man!": {
+    "emoji": "🧔⛵️❓🌊🤔😴💭👀🙀😇🛡️💪🚢💨😈👨‍✈️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Let us fly, let us fly! Old Nick take me if it is not Leviathan described by the noble prophet Moses in the life of patient Job.": {
+    "emoji": "✈️🕊️✨ Let's fly, let's fly! 🌊🐉😈 Take me if it isn't Leviathan as described by 👴📜 Moses in Job's life.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "How it was that they so aboundingly responded to the old man’s ire—by what evil magic their souls were possessed, that at times his hate seemed almost theirs": {
+    "emoji": "🤔❓👴😡➡️👥💥➡️🧙‍♂️🧠🤯🤔❤️➕😠⚡➡️🙃",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I sang out, I could not help it now; and giving a sudden grunt of astonishment he began feeling me.": {
+    "emoji": "🎤🎶😮🐷😲🤚👐",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Away! let us away!—this instant let me alter the course!": {
+    "emoji": "🏃‍♂️💨 Let's go! 🚀⏰ Change direction now!",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Oh God! that man should be a thing for immortal souls to sieve through!": {
+    "emoji": "😮🙏😱🙍‍♂️➡️✨👻💔🕳️🔎",
+    "date": "2024-01-01T00:00:00"
+  },
+  "But gulp down your tears and hie aloft to the royal-mast with your hearts": {
+    "emoji": "🤐😢➡️⏫👑⛵️❤️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "The French are the lads for painting action.": {
+    "emoji": "🇫🇷👨‍🎨🎨💥👨‍🎨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "But if I know not even the tail of this whale, how understand his head?": {
+    "emoji": "🤔➡️🐋❓⛔️🧠",
+    "date": "2024-01-01T00:00:00"
+  },
+  "heavy chains are being dragged along the deck": {
+    "emoji": "🔗⛓️➖🚢🛳️🛠️📦",
+    "date": "2024-01-01T00:00:00"
+  },
+  "There is his home; there lies his business, which a Noah’s flood would not interrupt, though it overwhelmed all the millions in China.": {
+    "emoji": "🏠➡️🏢🌊⛵️❌🛑, 🌏🌊💰🇨🇳",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Had these Leviathans been but a flock of simple sheep, pursued over the pasture by three fierce wolves": {
+    "emoji": "🐏🐏🐏 ➡️ 🐑🐑🐑, 🏃‍⬇️ 🌾🌿 ℹ️ 📍 3️⃣ 🐺🐺🐺",
+    "date": "2024-01-01T00:00:00"
+  },
+  "among the joyous, heartless, ever-juvenile eternities, Pip saw the multitudinous, God-omnipresent, coral insects": {
+    "emoji": "😊💃😐💔🌟🔄👶🌌, 🐳👀🦠🤲🙏🐚🐜",
+    "date": "2024-01-01T00:00:00"
+  },
+  "upon the banquet of his funeral they most piously do pounce": {
+    "emoji": "🪦🍽️🙏🦅❗",
+    "date": "2024-01-01T00:00:00"
+  },
+  "your friends who have gone before are clearing out the seven-storied heavens": {
+    "emoji": "🌟👯‍♂️👫✨🌈👼➡️🧹☁️7️⃣🏢⛅",
+    "date": "2024-01-01T00:00:00"
+  },
+  "how wonderful that he should be found at home, immersed to his lips for life in those Arctic waters!": {
+    "emoji": "🙌🏠❄️🧊🌊😲😄",
+    "date": "2024-01-01T00:00:00"
+  },
+  "A soul’s a sort of a fifth wheel to a wagon.": {
+    "emoji": "🧿🟠➕🔄🛞📦➡️🛺",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the calm is but the wrapper and envelope of the storm; and contains it in itself, as the seemingly harmless rifle holds the fatal powder": {
+    "emoji": "🧘‍♂️🌌 ➡️ 🎁🌫️⛈️; 📦🌪️🌌, 🎯🌫️🔫 ➡️🎯⚠️💥",
+    "date": "2024-01-01T00:00:00"
+  },
+  "man is a money-making animal, which propensity too often interferes with his benevolence": {
+    "emoji": "👨💰➡️🐒, 🤔⚠️🌀🚫❤️✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "all this to explain, would be to dive deeper than Ishmael can go": {
+    "emoji": "🐋📖➡️😮‍💨🔍⬇️👨‍🏫🌊📚❌⚓",
+    "date": "2024-01-01T00:00:00"
+  },
+  "My sensations were strange.": {
+    "emoji": "🧠❓ My sensations were strange.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the profound calm which only apparently precedes and prophesies of the storm, is perhaps more awful than the storm itself": {
+    "emoji": "🌌😌☁️⚡ (quiet before storm) 👉🔮🌪️📜, 😨😟🔮➡️🌪️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "what wonder remained soon waned away; for in a whaler wonders soon wane": {
+    "emoji": "🤔❓➡️😮🌠➡️📉😔; 🐋⛵✨📉➡️😐",
+    "date": "2024-01-01T00:00:00"
+  },
+  "“Swim away from me, do ye?” murmured Ahab, gazing over into the water. There seemed but little in the words, but the tone conveyed more of deep helpless sadness than the insane old man had ever before evinced.": {
+    "emoji": "“🏊‍♂️➡️🆚me, do ye?” 🤔 Ahab, 👀🌊. There seemed but little in the words, but the tone conveyed more of deep 😞😢 than the 🤪👴 had ever before shown.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "French soldiers in the Russian campaign turned their dead horses into tents, and crawled into them": {
+    "emoji": "🇫🇷🪖➡️🇷🇺🥶🐴💀➡️⛺️👤🕳️🐴",
+    "date": "2024-01-01T00:00:00"
+  },
+  "till you get to be Captain, the higher you rise the harder you toil": {
+    "emoji": "🧗‍♂️ ➡️ ⚓️, ⬆️⬆️⬆️ = 💪🔨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "coffined, hearsed, and tombed in the secret inner chamber and sanctum sanctorum of the whale": {
+    "emoji": "⚰️🐳📦⬛️🔒🐋🌌",
+    "date": "2024-01-01T00:00:00"
+  },
+  "a strange fatality pervades the whole career of these events, as if verily mapped out before the world itself was charted": {
+    "emoji": "🌀✨🗺️ A strange destiny threads through these events, as if they were destined before the world was even mapped 🌍🗺️✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "sharks do most socially congregate, and most hilariously feast": {
+    "emoji": "🦈🤝😄🍽️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "The whale, like all things that are mighty, wears a false brow to the common world.": {
+    "emoji": "🐋 ➡️ like all 🌍 that are 💪, wears a 😶⬆️ to the 🌐.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "it should still remain a problem": {
+    "emoji": "🤔➡️📌😕",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the sound of gay voices all over the house": {
+    "emoji": "🔊🏳️‍🌈🗣️🏠🌈",
+    "date": "2024-01-01T00:00:00"
+  },
+  "in this world, head winds are far more prevalent than winds from astern": {
+    "emoji": "🌎💨⬆️🏃‍♂️🌬️➡️🛳️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "a righteous judgment descended upon him": {
+    "emoji": "⚖️✨⬇️👨‍⚖️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I felt a melting in me. No more my splintered heart and maddened hand were turned against the wolfish world.": {
+    "emoji": "😊💖🫠. 🚫💔✋🐺🌍.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Nature absolutely paints like the harlot, whose allurements cover nothing but the charnel-house within": {
+    "emoji": "🌿🎨💃✨➡️⚰️🏚️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Ahab’s harpoon had shed older blood than the Pharaoh’s.": {
+    "emoji": "⚓️🦑📏💉🩸📜🔴👑",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Hence, the spare boats, spare spars, and spare lines and harpoons, and spare everythings, almost, but a spare Captain and duplicate ship.": {
+    "emoji": "🛶🛶, 🎣, 🔗, 🏹, and almost everything else, but 👨‍✈️❌ and 🚢❌.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "immortality is but ubiquity in time": {
+    "emoji": "🧬⏳ is but 🌍⏰ in time",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I felt dreadfully.": {
+    "emoji": "😟💔",
+    "date": "2024-01-01T00:00:00"
+  },
+  "’Twas rehearsed by thee and me a billion years before this ocean rolled.": {
+    "emoji": "🌊🎭🔄🙌1️⃣0️⃣0️⃣0️⃣0️⃣0️⃣0️⃣0️⃣0️⃣0️⃣0️⃣🔙⌛️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "in this zoned quest, does Ahab touch no land?": {
+    "emoji": "🏞️❓🔍, 🏴‍☠️🧔🤔🚫🌍?",
+    "date": "2024-01-01T00:00:00"
+  },
+  "much wriggling, and loud and incessant expostulations": {
+    "emoji": "🐛🔊🔊🤚😡⚠️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "In the case of a small Sperm Whale the brains are accounted a fine dish.": {
+    "emoji": "🐋🧠🍽️✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "any highly cultured, poetical nation shall lure back to their birth-right, the merry May-day gods of old": {
+    "emoji": "🌟🏛️📜✨🌸🌿🌞✨🌟🎭⏳➡️🏡👣, 😂🌼📅👼⏳🔙",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the archangel cared little or nothing for the captain and mates; and since the epidemic had broken out, he carried a higher hand than ever": {
+    "emoji": "😇🚫❤️😑👨‍✈️🧑‍✈️🤝🚷😷🌍😤✋⬆️📈",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the deep cistern will yield no more": {
+    "emoji": "💧⛏️🕳️🔙🚫👐",
+    "date": "2024-01-01T00:00:00"
+  },
+  "its most dreaded creatures glide under water, unapparent for the most part, and treacherously hidden beneath the loveliest tints of azure": {
+    "emoji": "🐉🌊👻🦑🤫🔍🤔⛔️🚫🌊👀🎨💙",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I lay there broad awake, feeling a great deal worse than I have ever done since": {
+    "emoji": "🛌😳, 🤕🤒😩😖😔💭",
+    "date": "2024-01-01T00:00:00"
+  },
+  "account for those repeated whaling disasters": {
+    "emoji": "📊➡️🐋🌊☠️🔄📉",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Bear thee grimly, demigod!": {
+    "emoji": "🐻 ⚔️ 🏺🦸‍♂️!",
+    "date": "2024-01-01T00:00:00"
+  },
+  "bleeds with keenest anguish at the undraped spectacle of a valor-ruined man.": {
+    "emoji": "🩸😢👁️‍🗨️🩸😢👁️‍🗨️(cry with pain) at the sight of a ⚔️ ruined 🤦‍♂️.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "it seemed hardly to budge at all": {
+    "emoji": "🤔➡️🟢 moved⬅️😐",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I try all things; I achieve what I can.": {
+    "emoji": "🤔🔍✨; 🏆💪🎯",
+    "date": "2024-01-01T00:00:00"
+  },
+  "instantly, a swift tremor was felt running like lightning along the keel": {
+    "emoji": "⚡️💨⛵️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "it is but reasonable to presume, that the longer the stricken whale stays under water, the more he is exhausted": {
+    "emoji": "🐋💦⏳➡️😴",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Let me only say that it fared with him as with the storm-tossed ship, that miserably drives along the leeward land.": {
+    "emoji": "⛵️💨➡️😟⛴️🌊➡️⛅️🌊🏝️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "It is by reason of this cosy blanketing of his body, that the whale is enabled to keep himself comfortable in all weathers, in all seas, times,and tides": {
+    "emoji": "🐋🧺➡️🏠🔲🌡️🐋➡️😌🌊🌦️🕰️🌊🔄",
+    "date": "2024-01-01T00:00:00"
+  },
+  "And so, through all the thick mists of the dim doubts in my mind, divine intuitions now and then shoot": {
+    "emoji": "🌫️🤔💭✨💡➡️🧠💭😊🙏🌟✨👉🏼💥",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Is heaven a murderer when its lightning strikes a would-be murderer in his bed, tindering sheets and skin together?": {
+    "emoji": "☁️⚡️➡️👼🔪? 🛏️🔥👤🛌🛏️✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Or is it, that as in essence whiteness is not so much a colour as the visible absence of colour": {
+    "emoji": "🤔❓🔍🌟❕🤍➡️🚫🌈📏👉👀🚫🎨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Darkness came on": {
+    "emoji": "🌑🌌✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Talk not to me of blasphemy, man; I’d strike the sun if it insulted me.": {
+    "emoji": "🗣️🚫➡️😡🌞😤✋⚡",
+    "date": "2024-01-01T00:00:00"
+  },
+  "But in pursuit of those far mysteries we dream of, or in tormented chase of the demon phantom": {
+    "emoji": "🔍🌌💭✨😈👻🏃‍♂️💨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "pondering all this, the palsied universe lies before us a leper": {
+    "emoji": "🤔🌌🤝😟🦠",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the measureless crush and crash of the sperm whale's ponderous flukes": {
+    "emoji": "🐋💥🔊🔨📏❌🌊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "this interlude was over": {
+    "emoji": "⏸️💭⏳➡️🏁",
+    "date": "2024-01-01T00:00:00"
+  },
+  "It was Moby Dick’s open mouth and scrolled jaw; his vast, shadowed bulk still half blending with the blue of the sea.": {
+    "emoji": "🐋📖😮👄➕🔄🐳; 🐋⬛️🌊🔵",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Take heart, take heart, O Bulkington!": {
+    "emoji": "❤️‍🔥 ❤️‍🔥, O 🚢⚓️!",
+    "date": "2024-01-01T00:00:00"
+  },
+  "he knew that for all this the chief mate, in his soul, abhorred his captain’s quest, and could he, would joyfully disintegrate himself from it, or even frustrate it": {
+    "emoji": "🧔‍♂️💭➡️⚓️👨‍✈️🧑‍✈️💔🛳️🏴‍☠️🗺️❌🙏🔚🎯🚫💥😄🚪😡",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I own thy speechless, placeless power": {
+    "emoji": "Here's a translation of the text into emojis:\n\n\"I 👁️ own 🎤🤐, 🌍🏠❌ power 💪\"",
+    "date": "2024-01-01T00:00:00"
+  },
+  "like another Ixion I did revolve": {
+    "emoji": "👍🔄🌀🧔➡️🔄",
+    "date": "2024-01-01T00:00:00"
+  },
+  "that harpoon—so like a corkscrew now—was flung in Javan seas, and run away with by a whale, years afterwards slain off the Cape of Blanco": {
+    "emoji": "🐋🪝🔄🌊📍🐳➡️⬅️🏝️🔪📍⏳➡️🗺️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Don’t I always say that to be good, a whale-steak must be tough? There are those sharks now over the side, don’t you see they prefer it tough and rare?": {
+    "emoji": "🙅‍♂️➡️🗣️🔄👆🤔🐋🥩👊👌❓🦈➡️👀🤔👀➡️👍🌶️🍖🍴",
+    "date": "2024-01-01T00:00:00"
+  },
+  "His life, as they significantly call it, was untouched.": {
+    "emoji": "👉🙂 'His life, as they significantly call it, was untouched.' 🌱",
+    "date": "2024-01-01T00:00:00"
+  },
+  "after all this silence, his unearthly voice was heard announcing that silvery, moon-lit jet": {
+    "emoji": "🤫🌕🌌🔊👽🗣️🚀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Ah! how they still strove through that infinite blueness to seek out the thing that might destroy them!": {
+    "emoji": "😲💪🔍🌊🔵🔍🔍💥",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the fare was of the most substantial kind—not only meat and potatoes, but dumplings; good heavens! dumplings for supper!": {
+    "emoji": "🍽️🥩🥔🥟🌙😲🥟🍽️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Queequeg was George Washington cannibalistically developed.": {
+    "emoji": "Queequeg 🗿➡️🇺🇸🍴👨‍🌾",
+    "date": "2024-01-01T00:00:00"
+  },
+  "There, then, he sat, holding up that imbecile candle in the heart of that almighty forlornness.": {
+    "emoji": "🪑🔥🤦‍♂️🕯️💔🌌",
+    "date": "2024-01-01T00:00:00"
+  },
+  "this dignity is heightened by the pepper and salt colour of his head at the summit, giving token of advanced age and large experience": {
+    "emoji": "👴✨🧂🍳👨‍🦳⬆️🔝🕰️📚",
+    "date": "2024-01-01T00:00:00"
+  },
+  "these spiritual throes in him heaved his being up from its base, and a chasm seemed opening in him, from which forked flames and lightnings shot up, and accursed fiends beckoned him to leap down among them": {
+    "emoji": "🌀💫🔥😖📈🔝🌌😟🕳️🌋⚡👹👆👇",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Porpoises, indeed, are to this day considered fine eating. The meat is made into balls about the size of billiard balls, and being well seasoned and spiced might be taken for turtle-balls or veal balls.": {
+    "emoji": "🐬➡️🤤🍽️🔪🍖➡️⚪️➕🌶️👌➕🧄💫👉🐢🍖🔄🐄🍖",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I have ever found your plain things the knottiest of all.": {
+    "emoji": "🙋‍♂️❓🤔🔎👉💼➡️👔🧩🔗🌐❗️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "my means are sane, my motive and my object mad": {
+    "emoji": "🤔👉🤯, 🎯📈 🤪",
+    "date": "2024-01-01T00:00:00"
+  },
+  "a black night in an open boat, when almost despairing of reaching any hospitable shore": {
+    "emoji": "🌑⛵🌌😟🏝️😔",
+    "date": "2024-01-01T00:00:00"
+  },
+  "The drama’s done.": {
+    "emoji": "🎭✅",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Squall, whale, and harpoon had all blended together; and the whale, merely grazed by the iron, escaped.": {
+    "emoji": "🌧️🐋🔱➕✨➡️🐋, 🩹➖🔱, 🏃‍♂️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "One day the planks stream with freshets of blood and oil": {
+    "emoji": "☀️📅🌊🪵➡️🌊🩸🛢️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Gnawed within and scorched without, with the infixed, unrelenting fangs of some incurable idea": {
+    "emoji": "🧠🔥🐍💡❌",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I might proceed with several more examples, one way or another known to me, of the great power and malice at times of the sperm whale.": {
+    "emoji": "🐋 ➡️ 🤔 ➡️ 🔜 ➕ 🔢 📚, 🔀 ↔️ ❓ ➡️ 🤝 💭, 🔝 🌟 💪 & 😠 🎭 🕰️ 🐳",
+    "date": "2024-01-01T00:00:00"
+  },
+  "More and more she leans over to the whale": {
+    "emoji": "👩➡️🐋📈",
+    "date": "2024-01-01T00:00:00"
+  },
+  "With a terrific snap, every fastening went adrift; the ship righted, the carcase sank.": {
+    "emoji": "📸💥⛓️➡️🌊; 🚢⚓️🔄, 🐋⬇️🌊.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "however they may thump and punch me about, I have the satisfaction of knowing that it is all right": {
+    "emoji": "👊😤🔄🤕😊✌️🤔💬👍",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Supplied by a late consumptive usher to a grammar school": {
+    "emoji": "📦🔜🕰️😞📚🚶🏫📚",
+    "date": "2024-01-01T00:00:00"
+  },
+  "But what thinks Lazarus? Can he warm his blue hands by holding them up to the grand northern lights?": {
+    "emoji": "🤔🤔🌟❓🤔☀️❓🌌🙌🔵👐❓",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Fool! I am the Fates’ lieutenant; I act under orders.": {
+    "emoji": "🤡! I am the 🕰️🎭💼; I 👨‍✈️📜.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "whether these spoutings are, after all, really water, or nothing but vapor—this is surely a noteworthy thing": {
+    "emoji": "💧🤔💨❓🤷‍♂️✨📌",
+    "date": "2024-01-01T00:00:00"
+  },
+  "There are certain queer times in this strange mixed affair we call life when a man takes this whole universe for a vast practical joke": {
+    "emoji": "🌌🤔 There are certain 🤨 times in this 🤔 strange mixed 🎭 affair we call 🌍 life when a 🤷‍♂️ man takes this 🌌 whole universe for a 😂 vast practical 😂 joke",
+    "date": "2024-01-01T00:00:00"
+  },
+  "in the tail the confluent measureless force of the whole whale seems concentrated to a point": {
+    "emoji": "🐋➡️🔚: 🌊💥🔄🔁✨🐳🎯",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the rushing Pequod, freighted with savages, and laden with fire, and burning a corpse, and plunging into that blackness": {
+    "emoji": "🚢💨🛶🌍🔥🔥⚰️🔥⬛🌊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "We thought the tissued, infiltrated head of the Sperm Whale, was the lightest and most corky part about him; and yet thou makest it sink in an element of a far greater specific gravity than itself.": {
+    "emoji": "🧠➡️💧🐋⚖️📉💡📦🔍🤔 ➕ 🌊⚪️⬇️🌌📉⚖️🤷‍♂️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "But why say more?": {
+    "emoji": "🤷‍♂️🤐❓",
+    "date": "2024-01-01T00:00:00"
+  },
+  "The truest of all men was the Man of Sorrows, and the truest of all books is Solomon’s": {
+    "emoji": "😢👨‍🦱✝️📖💯📚🔝📘✍️👑✡️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Ahab to-and-fro paced the deck; in his forward turn beholding the monsters he chased, and in the after one the bloodthirsty pirates chasing him": {
+    "emoji": "🧔‍♂️➡️⬅️🚶‍♂️🛳️; ➡️🔍🐋 he 🔙👀🦜🏴‍☠️🔪 him",
+    "date": "2024-01-01T00:00:00"
+  },
+  "And, to wind up, with Pisces, or the Fishes, we sleep.": {
+    "emoji": "🐟💤",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Here now’s the very dreaded symbol of grim death, by a mere hap, made the expressive sign of the help and hope of most endangered life.": {
+    "emoji": "☠️➡️❤️✋💀➡️👍🙌🤞🌟💪",
+    "date": "2024-01-01T00:00:00"
+  },
+  "he takes to wife in the wilderness of waters, and the best of wives she is, though she keeps so many moody secrets": {
+    "emoji": "👨‍❤️‍👩💍🌊🏞️, 👰✨👍, 🤫🌊💬",
+    "date": "2024-01-01T00:00:00"
+  },
+  "It was a Saturday night, and such a Sabbath as followed!": {
+    "emoji": "🌙📅✨ It was a Saturday night, and such a Sabbath as followed! ✨🙏",
+    "date": "2024-01-01T00:00:00"
+  },
+  "What is best let alone, that accursed thing is not always what least allures.": {
+    "emoji": "🤔❓👉🚫🔝🕒, 👿💔🚫👀🔙🕒🌀🕒✨.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "a prodigious sensation in all directions": {
+    "emoji": "🌟😲🌟 in all 🔄",
+    "date": "2024-01-01T00:00:00"
+  },
+  "my men, the thunder turned old Ahab’s needles; but out of this bit of steel Ahab can make one of his own, that will point as true as any": {
+    "emoji": "👨‍🦳⚡️🔄👴🧭📌; 🛠️🪛🧔‍♂️👉⚙️🆕🧭, 👨‍✈️📌➡️⬆️📍📍🔝",
+    "date": "2024-01-01T00:00:00"
+  },
+  "up from yonder cottage goes a sleepy smoke": {
+    "emoji": "🌄🏠💤🌫️⬆️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Whelped somewhere by the sharkish sea": {
+    "emoji": "🐶🌊🦈🌊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "throw out some hints touching the phrenological characteristics of other beings than man": {
+    "emoji": "🔍💭👉😯🔍👤+🔍👥👽",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the constituents of a chaos, nothing less is here": {
+    "emoji": "🌌✨💥, 🚫⬇️🔽📍🤔",
+    "date": "2024-01-01T00:00:00"
+  },
+  "mortal man should feed upon the creature that feeds his lamp": {
+    "emoji": "🧍‍♂️➡️🍴🐄➡️💡",
+    "date": "2024-01-01T00:00:00"
+  },
+  "how it is that we still refuse to be comforted for those who we nevertheless maintain are dwelling in unspeakable bliss": {
+    "emoji": "🤔😢💭❌😌👥👼🌈",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I think his broad brow to be full of a prairie-like placidity, born of a speculative indifference as to death.": {
+    "emoji": "🤔👤🤕🌾😊🧠➡️😌🌾🌻, 🍼🔍❓😶🏴‍☠️💀.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "to comprehend it aright, you must know something of the curious internal structure of the thing operated upon": {
+    "emoji": "🤔➡️🧠👍, 👉📖🧐🔍🏗️🌀💡🤔🔧",
+    "date": "2024-01-01T00:00:00"
+  },
+  "admire and model thyself after the whale! Do thou, too, remain warm among ice. Do thou, too, live in this world without being of it.": {
+    "emoji": "🐋✨ Admire the whale! Be like the whale! Stay warm ❄️🔥 in the cold. Live in the world 🌍 without being of it. 🌊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "of what a very light substance the entire interior of the sperm whale’s enormous head consists": {
+    "emoji": "🐋🤔🌟💭📦🚫🐘🧠💡🎭",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Why tell the whole?": {
+    "emoji": "🤔❓🗣️😮‍💨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "In the midst of the personified impersonal, a personality stands here.": {
+    "emoji": "👤✨ in the 🌪️ of 🌐, a 👤 stands ⬇️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the body showed symptoms of sinking with all its treasures unrifled": {
+    "emoji": "🏴‍☠️⚓️ The body showed symptoms of sinking, with all its treasures unrifled 🏴‍☠️💎🔒",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Vacantly eyeing the heaving whale": {
+    "emoji": "👀😶🐋",
+    "date": "2024-01-01T00:00:00"
+  },
+  "What are the Rights of Man and the Liberties of the World but Loose-Fish?": {
+    "emoji": "🟠❓🤷‍♂️⚖️🧑‍⚖️🌎🔓🐟",
+    "date": "2024-01-01T00:00:00"
+  },
+  "The truth is, that living or dead, if but decently treated, whales as a species are by no means creatures of ill odor": {
+    "emoji": "🔍➡️🐳✨🤔💀, ☝️🙂😇, 🐋💙🦑 🚫🐉⚠️💨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "in everything imposingly beautiful, strength has much to do with the magic": {
+    "emoji": "💪✨ In everything imposingly beautiful, strength has much to do with the magic ✨💪",
+    "date": "2024-01-01T00:00:00"
+  },
+  "they swam out of the white curds of the whale’s direful wrath into the serene, exasperating sunlight": {
+    "emoji": "👥🏊‍♂️🏊‍♀️➡️🐳🌊🌩️➡️🌞😌😠",
+    "date": "2024-01-01T00:00:00"
+  },
+  "conscience is the wound, and there’s naught to staunch it": {
+    "emoji": "🧠🤕 = 😔, ❌🚫🩹",
+    "date": "2024-01-01T00:00:00"
+  },
+  "an ostrich of potent digestion gobbles down bullets and gun flints": {
+    "emoji": "🦩🍽️🔫💥🥄",
+    "date": "2024-01-01T00:00:00"
+  },
+  "They are the only whales regularly hunted by man.": {
+    "emoji": "🐋❗️🔍🔫🙋‍♂️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "we have elsewhere seen": {
+    "emoji": "🔍🌍👀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "does the all-contributed and all-receptive ocean alluringly spread forth his whole plain of unimaginable, taking terrors": {
+    "emoji": "🌊🤝🌍🌊✨👐🌌😱",
+    "date": "2024-01-01T00:00:00"
+  },
+  "As in general shape the noble Sperm Whale’s head may be compared to a Roman war-chariot": {
+    "emoji": "🐋⚔️🏛️🗡️ In general shape, the noble Sperm Whale's head may be compared to a Roman war-chariot.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "my free will had received a mortal wound; and that another’s mistake or misfortune might plunge innocent me into unmerited disaster": {
+    "emoji": "🙇‍♂️🩸➡️💔⚖️🪦; ➕💔's 💭💬⚠️⚡➡️😇😔😣⚡➡️🚫🏆😞",
+    "date": "2024-01-01T00:00:00"
+  },
+  "The whale fell directly over him, and probably killed him in a moment.": {
+    "emoji": "🐋⬇️😲☠️⚡️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "not one in fifty of the actual disasters and deaths by casualties in the fishery, ever finds a public record at home, however transient and immediately forgotten that record": {
+    "emoji": "🤔 Not 1️⃣ in 5️⃣0️⃣ of the actual ⚠️🌊 and ☠️ in the 🎣, ever finds a 📜🏠, however 🕒 and 🔜 forgotten that record",
+    "date": "2024-01-01T00:00:00"
+  },
+  "a dim consciousness of knowing something about me seemed slowly dawning over him": {
+    "emoji": "😶💭🕵️‍♂️💡🤔➡️🕰️👥",
+    "date": "2024-01-01T00:00:00"
+  },
+  "bury thyself in a life which, to your now equally abhorred and abhorring, landed world, is more oblivious than death": {
+    "emoji": "🪦🤔🌱➡️🌍📚,🔄💔🙅‍♂️➡️🌀🌌🌍,🚫🔍➡️💀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I trod the ship; I knew the crew; I have seen and talked with Steelkilt since the death of Radney.": {
+    "emoji": "👣🚢👥🤝🗣️💀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "in most creatures, nay in man himself, very often the brow is but a mere strip of alpine land lying along the snow line": {
+    "emoji": "🌍➡️😺, 🚫👨‍🔬🤷‍♂️, 🔁🕰️😯🚶‍♂️🔝, 👁️⚠️👁️ 🍞🌄⏩❄️📉",
+    "date": "2024-01-01T00:00:00"
+  },
+  "And here, shipmates, is true and faithful repentance; not clamorous for pardon, but grateful for punishment.": {
+    "emoji": "🗣️🧑‍✈️➡️🚢🤝💙😔: 🙏✨↔️🔄🙏; 🤐🔊❌🙏, 🤲💖✔️⚖️.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "a miraculous lamp that burnt without any oil": {
+    "emoji": "🔮🪔✨🔥❌🛢️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "In this world, shipmates, sin that pays its way can travel freely, and without a passport": {
+    "emoji": "🌍⛵️❗️😈💵🛣️✈️🆓, 🛂🚫",
+    "date": "2024-01-01T00:00:00"
+  },
+  "malignant iron scorchingly devoured the baptismal blood": {
+    "emoji": "🦠🔥 voraciously consumed 💧💀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "thoughts like these troubled very few of the reckless crew": {
+    "emoji": "🤔💭 like these 🤯 worried very few of the 🤪🛳️ crew",
+    "date": "2024-01-01T00:00:00"
+  },
+  "beneath all that silence and placidity, the utmost monster of the seas was writhing and wrenching in agony": {
+    "emoji": "🌊🤫🐋💤 -> 😖🔄👹💥😩",
+    "date": "2024-01-01T00:00:00"
+  },
+  "a long, low, shelf-like table covered with cracked glass cases, filled with dusty rarities gathered from this wide world’s remotest nooks": {
+    "emoji": "🪑📏🧊❌🌍📚🕸️🏺🗺️🔍",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the more whales the less fish": {
+    "emoji": "🐋➕🐋➡️🐟➖",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Methinks that what they call my shadow here on earth is my true substance.": {
+    "emoji": "🧐🌍💭➡️🕶️☁️=💯🌟",
+    "date": "2024-01-01T00:00:00"
+  },
+  "creatures, that warm themselves under the lee of an iceberg, as a traveller in winter would bask before an inn fire": {
+    "emoji": "🐾❄️🧊🌬️☀️🧳🌨️➡️🔥🏨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Hurrah! this is the way to sail now. Every keel a sunbeam!": {
+    "emoji": "🎉⛵️☀️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Though I cannot tell why it was exactly that those stage managers, the Fates, put me down for this shabby part of a whaling voyage": {
+    "emoji": "🤔⛴️🎭🤷‍♂️➡️🎭🎭,🤔🔮🔀👉🧑‍✈️🌊🐳🛳️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Almost forgetting for the moment all thoughts of Moby Dick, we now gazed at the most wondrous phenomenon which the secret seas have hitherto revealed to mankind.": {
+    "emoji": "🐋🤔❌💭➡️🐳, 👀🔍✨🌊🌌🔍🤫🌊🌏➡️👀👥.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the sea dashes even the mightiest whales against the rocks, and leaves them there side by side with the split wrecks of ships": {
+    "emoji": "🌊🐳💥🪨➡️🌊⛵️💔",
+    "date": "2024-01-01T00:00:00"
+  },
+  "In the long try watches of the night it is a common thing for the seamen to dip their ship-biscuit into the huge oil-pots and let them fry there awhile.": {
+    "emoji": "🌙⏳🤔🕒🌌🌊🚢👨‍✈️👉🍪➡️🛢️➡️🍳🕒",
+    "date": "2024-01-01T00:00:00"
+  },
+  "But look! here come more crowds, pacing straight for the water, and seemingly bound for a dive. Strange!": {
+    "emoji": "👀🏃‍♂️🏃‍♀️➡️🌊🤔💦🤿😮",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Go visit the Prairies in June, when for scores on scores of miles you wade knee-deep among Tiger-lilies": {
+    "emoji": "🟢🌾🌞➡️🚌➡️🌾➡️🗓️🌞6️⃣📅➡️📏➡️🌼🏃‍♂️🌼🌼🌼",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Every one knows the fine story of Perseus and Andromeda": {
+    "emoji": "👨‍🎤🔱📖✨🐍👩‍🦱",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I squeezed that sperm till a strange sort of insanity came over me": {
+    "emoji": "👋🌀🧑‍⚕️🤯",
+    "date": "2024-01-01T00:00:00"
+  },
+  "accursed fiends beckoned him to leap down among them": {
+    "emoji": "😈🧛‍♂️🧟‍♂️👉👇🤔",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the tun of the whale contains by far the most precious of all his oily vintages; namely, the highly-prized spermaceti, in its absolutely pure, limpid, and odoriferous state": {
+    "emoji": "🐋🍶✨🔝🌟💧💎➡️🥇📈🌊🏆💰✨🐳👇📈🥰",
+    "date": "2024-01-01T00:00:00"
+  },
+  "mortal disasters have immemorially and indiscriminately befallen tens and hundreds of thousands of those who have gone upon the waters": {
+    "emoji": "💀🌊⛵️☠️⏳👉⚓️💯➕👥🚶‍♂️🔹",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Moby Dick moved on, still withholding from sight the full terrors of his submerged trunk, entirely hiding the wrenched hideousness of his jaw.": {
+    "emoji": "🐋➡️🚶‍♂️, 🤫👀😱🌊🤫🔰, 🙈😨👄🔒.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Thou saw’st the murdered mate when tossed by pirates from the midnight deck; for hours he fell into the deeper midnight of the insatiate maw": {
+    "emoji": "⚓️👀💀🚢🏴‍☠️🌌➡️🕒⬇️🌊📉🖤🕳😈🦈",
+    "date": "2024-01-01T00:00:00"
+  },
+  "even then, Ahab, in his hidden self, raved on": {
+    "emoji": "🌜🤔, 🏴‍☠️🐳, 🤫🙍‍♂️, 🔥💭🎭",
+    "date": "2024-01-01T00:00:00"
+  },
+  "breathing is only a function indispensable to vitality": {
+    "emoji": "🌬️➡️🔧💨🧘‍♂️🚫➡️💯🏆🔌🌱",
+    "date": "2024-01-01T00:00:00"
+  },
+  "For worm-like, then, oh! who would craven crawl to land!": {
+    "emoji": "🐛❓😲🪱➡️🌍🌱",
+    "date": "2024-01-01T00:00:00"
+  },
+  "“I fear not thy epidemic, man,” said Ahab": {
+    "emoji": "🗣️ \"I fear not thy epidemic, man,\" 🗣️ said Ahab",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I’ll get a crucible, and into it, and dissolve myself down to one small, compendious vertebra.": {
+    "emoji": "🔮➡️🔥🔽🧪📉🔄➖📏🦴",
+    "date": "2024-01-01T00:00:00"
+  },
+  "there are instances where, after the lapse of many hours or several days, the sunken whale again rises, more buoyant than in life": {
+    "emoji": "🌊🕒➡️⌛️🗓️➡️☀️🐋⬆️, 🚢🐳🔝, 📈💨📈🌞",
+    "date": "2024-01-01T00:00:00"
+  },
+  "through infancy’s unconscious spell, boyhood’s thoughtless faith, adolescence’ doubt (the common doom), then scepticism, then disbelief, resting at last in manhood’s pondering repose of If": {
+    "emoji": "👶✨ ➡️ 🧒🙏 ➡️ 🧑‍🎓❓ ➡️ 🤔➡️ 🤨➡️ 🙌 ➡️ 👨🧠💭 'If'",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Silence reigned over the before tumultuous but now deserted deck.": {
+    "emoji": "🤫👑 🌊🛳️➡️🤯📉➡️🏝️🗃️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "it would not do to be sellin’ human heads about the streets when folks is goin’ to churches": {
+    "emoji": "🧠🚫➡️🏙️🛒🚶‍♂️➡️⛪",
+    "date": "2024-01-01T00:00:00"
+  },
+  "high above the flying scud and dark-rolling clouds, there floated a little isle of sunlight": {
+    "emoji": "☁️⬆️🌬️🌥️☁️✨🌤️🏝️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Moby Dick bodily burst into view!": {
+    "emoji": "🐋💥👀!",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Inferable from these statements, are many collateral subtile matters touching the chase of whales.": {
+    "emoji": "🔍🗯️📜✒️🐋➡️🤔📚🏹🐳",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Not so much thy skill, then, O hunter, as the great necessities that strike the victory to thee!": {
+    "emoji": "🏹❌🙅‍♂️🤔📚🐾🔍🤔, 🌟🛑🧑‍🦳🏹, 🔛🤔🌟📈🚨🔑🐾🌟💪🏆👉🎯!",
+    "date": "2024-01-01T00:00:00"
+  },
+  "There’s orthodoxy!": {
+    "emoji": "🩻👨‍⚕️📚!",
+    "date": "2024-01-01T00:00:00"
+  },
+  "For God’s sake, be economical with your lamps and candles! not a gallon you burn, but at least one drop of man’s blood was spilled for it.": {
+    "emoji": "🙏💡🕯️💰❗️🔥⛽️➡️💧🩸💀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I came here to hunt whales, not my commander’s vengeance.": {
+    "emoji": "🛬🦈🔍🐋❌🫵⚔️👗",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the proper skin of the tremendous whale is thinner and more tender than the skin of a new-born child": {
+    "emoji": "🐋➡️👶👶✨🆕👶👶👶💓",
+    "date": "2024-01-01T00:00:00"
+  },
+  "But once gone through, we trace the round again; and are infants, boys, and men, and Ifs eternally.": {
+    "emoji": "🔄👶👦👨⏳♾️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "length of foundation is nothing without corresponding breadth": {
+    "emoji": "📏➕🏗️➖💬📏💤⛔️📚⚖️📏👍🆚📏🌐",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Ginger!—what the devil is ginger? Sea-coal? firewood?—lucifer matches?—tinder?—gunpowder?—what the devil is ginger, I say": {
+    "emoji": "🫚❗—😈❓🫚❓🌊🪵❓🔥🪵❓—✨🧨❓—🔥🌿❓—💣❓—😈❓🫚❓",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Light though thou be, thou leapest out of darkness; but I am darkness leaping out of light, leaping out of thee!": {
+    "emoji": "💡➡️🌑; 🌑➡️💡, ➡️💡!",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Avast! heave to! I mean when you die, cook. It’s an awful question. Now what’s your answer?": {
+    "emoji": "🏴‍☠️🛑⚓️ I mean 🪦👨‍🍳❓ It's 😱🤔🤨 Now 🤷‍♂️?",
+    "date": "2024-01-01T00:00:00"
+  },
+  "be but an idle whim": {
+    "emoji": "🕒❌🤔💭",
+    "date": "2024-01-01T00:00:00"
+  },
+  "a sort of brief interlude and solo between more extensive performances": {
+    "emoji": "🎭⏸️🎶✨🎤⏸️🎶🎭📜🌟",
+    "date": "2024-01-01T00:00:00"
+  },
+  "this round gold is but the image of the rounder globe": {
+    "emoji": "🔄🏅➡️🖼️🌍🔵",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Didn’t ye hear a word about them matters and something more, eh?": {
+    "emoji": "👂❓🗣️🙉🤔📜ℹ️➕🔍🤨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "spiritually feasting upon some unearthly reminiscence": {
+    "emoji": "🧘‍♀️✨🍽️👻🕰️🔮",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Then there you lie like the one warm spark in the heart of an arctic crystal.": {
+    "emoji": "🛌✨❤️❄️💎",
+    "date": "2024-01-01T00:00:00"
+  },
+  "even the high lifted and chivalric Crusaders of old times were not content to traverse two thousand miles of land to fight for their holy sepulchre, without committing burglaries, picking pockets, and gaining other pious perquisites": {
+    "emoji": "👑💂‍♂️🛡️⚔️🗺️✝️🏰🏴‍☠️💰👜✋🙏",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Nothing but two dismal tallow candles, each in a winding sheet.": {
+    "emoji": "🚫🎇🕯️🕯️☠️🩸",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I always go to sea as a sailor, because of the wholesome exercise and pure air of the fore-castle deck.": {
+    "emoji": "👨‍✈️🌊🚢👨‍✈️💨🏋️‍♂️🌞🍃⚓️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "great bodies are at times encountered": {
+    "emoji": "💪😃🏋️‍♀️👀🤝",
+    "date": "2024-01-01T00:00:00"
+  },
+  "not the smallest atom stirs or lives on matter, but has its cunning duplicate in mind.": {
+    "emoji": "🔬❌⬇️🌌🔄🌱➕🧠🌀👯‍♂️💡",
+    "date": "2024-01-01T00:00:00"
+  },
+  "less celestial, I celebrate a tail": {
+    "emoji": "🌌⬇️, 🎉🐾",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the boat looks as if it were pulling off with a prodigious great wedding-cake to present to the whales.": {
+    "emoji": "🚤➡️🎂🐋🎁?",
+    "date": "2024-01-01T00:00:00"
+  },
+  "With the landless gull, that at sunset folds her wings and is rocked to sleep between billows": {
+    "emoji": "🕊️🌅🛌🌊💤",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Captain Ahab remained invisibly enshrined within his cabin.": {
+    "emoji": "🧔‍♂️🚢🛋️🤫",
+    "date": "2024-01-01T00:00:00"
+  },
+  "his brain seems that geometrical circle which it is impossible to square": {
+    "emoji": "🧠 ➡️ 🔄 📏❌ 🔲",
+    "date": "2024-01-01T00:00:00"
+  },
+  "The huge corpulence of that Hogarthian monster undulates on the surface, scarcely drawing one inch of water.": {
+    "emoji": "🐷🌊 The huge bulk of that artistic monster ripples on the surface, barely dipping into the water.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "no way of reaching that place would offer": {
+    "emoji": "🚫➡️🏞️🔜🤝🏞️❌",
+    "date": "2024-01-01T00:00:00"
+  },
+  "In old Norse times, the thrones of the sea-loving Danish kings were fabricated, saith tradition, of the tusks of the narwhale.": {
+    "emoji": "🐋👑🌊🦷🦄🔨🕰️📜🇩🇰dados",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the doom of boats, and ships, and men": {
+    "emoji": "⛴️⚓💥🧍‍♂️⚰️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "What a fine frosty night; how Orion glitters; what northern lights!": {
+    "emoji": "🌌✨ What a fine frosty night ❄️; how Orion glitters ✨; what northern lights! 🌌🎇",
+    "date": "2024-01-01T00:00:00"
+  },
+  "If this be so, fancy the irresistibleness of that might, to which the most impalpable and destructive of all elements contributes.": {
+    "emoji": "🔍🤔✨➡️💪⚡️🌪️🔥💧➡️👐🌬️✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "But the reason of this is obvious.": {
+    "emoji": "🤔➡️🔍🌟",
+    "date": "2024-01-01T00:00:00"
+  },
+  "For hardly have we mortals by long toilings extracted from this world’s vast bulk its small but valuable sperm": {
+    "emoji": "👉😓😅🌍🌍💪🕵️‍♂️➡️💧🤑🌟🧠⛏️👥",
+    "date": "2024-01-01T00:00:00"
+  },
+  "and here, going from Virtue, Leo, a roaring Lion, lies in the path—he gives a few fierce bites and surly dabs with his paw": {
+    "emoji": "🦁➡️🦁➡️🔊🦁➡️🛣️➡️🦁➡️😡🦁➡️🤚",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Touching that monstrous bulk of the whale or ork we have received nothing certain.": {
+    "emoji": "👉🐋🤔❓",
+    "date": "2024-01-01T00:00:00"
+  },
+  "many strange things were hinted in reference to this wild affair": {
+    "emoji": "🌀🤔📜💬➡️🌲🤯",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Genius in the Sperm Whale? Has the Sperm Whale ever written a book, spoken a speech?": {
+    "emoji": "🧠 in the 🐳? Has the 🐳 ever ✍️ a 📚, 🗣️ a 🗨️?",
+    "date": "2024-01-01T00:00:00"
+  },
+  "were the whale then to run the line out to the end almost in a single, smoking minute as he sometimes does, he would not stop there": {
+    "emoji": "🐋➡️🏃‍♂️🪢➡️🔚⏱️💨🔄🐋⭕🚫🛑",
+    "date": "2024-01-01T00:00:00"
+  },
+  "It was a terrific, most pitiable, and maddening sight.": {
+    "emoji": "🌟😢😡",
+    "date": "2024-01-01T00:00:00"
+  },
+  "There is nothing surprising in this.": {
+    "emoji": "🤷‍♂️🔍 Nothing surprising in this. ",
+    "date": "2024-01-01T00:00:00"
+  },
+  "hear the thunder": {
+    "emoji": "👂🌩️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Go to the meat-market of a Saturday night and see the crowds of live bipeds staring up at the long rows of dead quadrupeds.": {
+    "emoji": "👥➡️🥩🛒🌃📅👀👥🔍⬆️🆚📏👥☠️🦌",
+    "date": "2024-01-01T00:00:00"
+  },
+  "let us squeeze ourselves universally into the very milk and sperm of kindness": {
+    "emoji": "🫂🌎🍼🧬💕",
+    "date": "2024-01-01T00:00:00"
+  },
+  "from the ashes of the burned scraps of the whale, a potent lye is readily made": {
+    "emoji": "🔥🐋➡️🅿️💪🧼✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Nor have I been at all sparing of historical whale research, when it has seemed needed.": {
+    "emoji": "🐳📚✋😶👉📜📜🔍, 📅📅📅🤔📜📜⭕️📚😌",
+    "date": "2024-01-01T00:00:00"
+  },
+  "sail round his vast head in your jolly-boat": {
+    "emoji": "🛶⛵️🌀🗣️🌊👤💫",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Are you not the precious image of each and all of us men in this whaling world?": {
+    "emoji": "🤔👤❓🌟🖼️👨‍👩‍👦‍👦🐋🌎❓",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Up from the spray of thy ocean-perishing—straight up, leaps thy apotheosis!": {
+    "emoji": "🌊⬆️🔝🌊—⬆️➡️✨, 🔝, 🚀🌟!",
+    "date": "2024-01-01T00:00:00"
+  },
+  "But how?": {
+    "emoji": "🤔❓",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I saw the opening maw of hell, With endless pains and sorrows there; Which none but they that feel can tell— Oh, I was plunging to despair.": {
+    "emoji": "👁👄🔥😱, 💢💔😭🚪; 👤❌🤕🗣🌊— 😩, 👤⬇️🌀⚫",
+    "date": "2024-01-01T00:00:00"
+  },
+  "striving to get a still better seaward peep": {
+    "emoji": "🚶‍♂️➡️🌊👀🔍📈",
+    "date": "2024-01-01T00:00:00"
+  },
+  "this sort of thing is unpleasant enough": {
+    "emoji": "🤔😕😬",
+    "date": "2024-01-01T00:00:00"
+  },
+  "She was a thing of trophies. A cannibal of a craft, tricking herself forth in the chased bones of her enemies.": {
+    "emoji": "👩‍🎨🏆✨🍖🛠️🎭📚💀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Narcissus, who because he could not grasp the tormenting, mild image he saw in the fountain, plunged into it and was drowned.": {
+    "emoji": "💧🌿 Narcissus, who because he couldn't reach the tormenting, gentle image he saw in the fountain, 🚶‍♂️➡️💦 and was 🌊💀.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the joke is at nobody’s expense but his own": {
+    "emoji": "😂➡️🕵️‍♂️💸➡️👤❌💸➡️😄",
+    "date": "2024-01-01T00:00:00"
+  },
+  "not a single groan or cry of any sort, nay, not so much as a ripple or a bubble came up from its depths": {
+    "emoji": "😶🌊❌😩❌😢❌🔊, 🚫, ❌🌊🔄❌💧📈⬆️🔙🌊🔝",
+    "date": "2024-01-01T00:00:00"
+  },
+  "this one small brain think thoughts": {
+    "emoji": "🧠🤏💭🤔",
+    "date": "2024-01-01T00:00:00"
+  },
+  "abating in his flurry, the whale once more rolled out into view": {
+    "emoji": "🐋⬇️🌊, 🐋🔄👀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "The few sleepers below in their bunks were often startled by the sharp slapping of their tails against the hull, within a few inches of the sleepers’ hearts.": {
+    "emoji": "🛌😴👇🚢🐟💥😲🚢🔊♥️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "For ere they drown, drowning things will twice rise to the surface; then rise again, to sink for evermore.": {
+    "emoji": "🌊 Before they sink, 🌊 sinking things will ⬆️ rise twice to the 🔝 surface; then rise again, ⬇️ to sink forever. 🌊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "both he and the sharks were at times half hidden by the blood-muddled water": {
+    "emoji": "🤷‍♂️🦈🌊🔴❓🔍",
+    "date": "2024-01-01T00:00:00"
+  },
+  "There’s your law of precedents; there’s your utility of traditions; there’s the story of your obstinate survival of old beliefs": {
+    "emoji": "📜⚖️➡️ 📚⏳; 📚➡️🔗👴; 📖➡️🙅‍♂️⏳🔗💭",
+    "date": "2024-01-01T00:00:00"
+  },
+  "There is more character in the Sperm Whale’s head.": {
+    "emoji": "🐋💡➡️ SperM Whale's 🧠📈",
+    "date": "2024-01-01T00:00:00"
+  },
+  "He saw God’s foot upon the treadle of the loom": {
+    "emoji": "👨‍🦰👀👣⚙️🧶",
+    "date": "2024-01-01T00:00:00"
+  },
+  "an unfurnished parlor called the blubber-room": {
+    "emoji": "🛋️🚪📦 ➡️ 🐋➡️🚪",
+    "date": "2024-01-01T00:00:00"
+  },
+  "my dear Ishmael, be sure to inquire the price, and don’t be too particular": {
+    "emoji": "👤❤️🐋, 📋🔍💲, ❌🧐⚖️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I was now as much afraid of him as if it was the devil himself": {
+    "emoji": "😨👤➡️😈",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the triumphant tackle rises into sight": {
+    "emoji": "🏆🤾‍♂️⬆️👀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "How it is I know not; but there is no place like a bed for confidential disclosures between friends.": {
+    "emoji": "🛌🤔✨❓; 🛏️🏠💬🤝🌟👥",
+    "date": "2024-01-01T00:00:00"
+  },
+  "A steak, a steak, ere I sleep!": {
+    "emoji": "🥩🥩😴",
+    "date": "2024-01-01T00:00:00"
+  },
+  "they were nigh enough to risk a harpoon from the bowsprit": {
+    "emoji": "🧑‍✈️➡️🏹🌊📏⚓️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I never hurt when I hit, except when I hit a whale or something of that sort": {
+    "emoji": "🤜😌➡️💥❌🐋😖🦣💥",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Let the most absent-minded of men be plunged in his deepest reveries—stand that man on his legs, set his feet a-going, and he will infallibly lead you to water": {
+    "emoji": "🧠➡️💭👨‍🦯🔄🚶‍♂️➡️💦",
+    "date": "2024-01-01T00:00:00"
+  },
+  "of all tools used in the shadow of the moon, men are most apt to get out of order": {
+    "emoji": "🌑🔧👨‍🔧🚶‍♂️📉",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Of erections, how few are domed like St. Peter’s! of creatures, how few vast as the whale!": {
+    "emoji": "🏗️⛪️❗️🐋❗️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "“That’s he! that’s he!—the long-togged scaramouch the Town-Ho’s company told us of!”": {
+    "emoji": "🗣️ \"👀 That's him! That's him!—the 🎭 long-coated scaramouch the 🚢 Town-Ho's crew told us about!\"",
+    "date": "2024-01-01T00:00:00"
+  },
+  "But let us hold on here by this tooth, and look about us where we are.": {
+    "emoji": "🦷🔍👀🛑🤔📍🗺️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "we heard about Moby Dick—as some call him—and then I knew it was he.": {
+    "emoji": "👂🐋📖—👥📞👨‍👨‍👦👨‍🔧—👉👨👈🧠📖👍🔈🔍",
+    "date": "2024-01-01T00:00:00"
+  },
+  "The crotch alluded to on a previous page deserves independent mention.": {
+    "emoji": "🔍👖➡️📄🤔👍📝",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I deny their credentials as whales; and have presented them with their passports to quit the Kingdom of Cetology.": {
+    "emoji": "🙅‍♂️🐋❌🎓✉️🔍➡️🛂💼🏴‍☠️🐋🇬🇧",
+    "date": "2024-01-01T00:00:00"
+  },
+  "He looked like a man who had never cringed and never had had a creditor.": {
+    "emoji": "👨😎❌🤦‍♂️❌💸",
+    "date": "2024-01-01T00:00:00"
+  },
+  "For small erections may be finished by their first architects; grand ones, true ones, ever leave the copestone to posterity.": {
+    "emoji": "🏗️🔨🏠➡️🧑‍🔧👷‍♂️📏; 🏢🏛🆚🥇, ⏩⏳👣🧱➡️👶🌍.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "it rings most vast, but hollow": {
+    "emoji": "🔔🌌 most vast, but 🕳️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "All that most maddens and torments": {
+    "emoji": "😡😤🤯🔪",
+    "date": "2024-01-01T00:00:00"
+  },
+  "what he ate did not so much relieve his hunger, as keep it immortal in him": {
+    "emoji": "🤔🍽️❌😌🤤🍴🍽️🔁⏳",
+    "date": "2024-01-01T00:00:00"
+  },
+  "It’s an all-fired outrage to tell any human creature that he’s bound to hell. Flukes and flames!": {
+    "emoji": "😡🔥🚫👼➡️🔥🌋. 🐠🔥!",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the three boats lay there on that gently rolling sea, gazing down into its eternal blue noon": {
+    "emoji": "🚤🚣⛵️ ~ 🌊, 👀⬇️🌊🔵🌞✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Paddles were dropped, and oars came loudly into play.": {
+    "emoji": "🚣‍♂️🪂⬇️, 🌊🔊↔️🛶",
+    "date": "2024-01-01T00:00:00"
+  },
+  "my face shall not be seen": {
+    "emoji": "🙈🚫👀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "that tempestuous wind Euroclydon kept up a worse howling than ever it did about poor Paul's tossed craft": {
+    "emoji": "💨🌪️⛈️😣🔊⬆️🌊⛵️🚫😟🙏💔",
+    "date": "2024-01-01T00:00:00"
+  },
+  "almost all men in their degree, some time or other, cherish very nearly the same feelings towards the ocean": {
+    "emoji": "👨🌊❤️🌊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "God help thee, old man, thy thoughts have created a creature in thee": {
+    "emoji": "🙏🧓🧠➡️👹",
+    "date": "2024-01-01T00:00:00"
+  },
+  "In old times, there seem to have prevailed the most curious fancies": {
+    "emoji": "⏳🏰👴🕰️🤔🌀🔍✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "if any strange suspicious sights are seen, my lord whale keeps a wary eye on his interesting family": {
+    "emoji": "👀🧐🌊👑🐋👀👀👨‍👩‍👧‍👦",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the weeping and wailing and teeth-gnashing there": {
+    "emoji": "😢😭🗣️😫😬🦷",
+    "date": "2024-01-01T00:00:00"
+  },
+  "he ain’t sick; but no, he isn’t well either": {
+    "emoji": "👨❌😷 ➡️ 😐❌😌 ",
+    "date": "2024-01-01T00:00:00"
+  },
+  "they were going all abreast with great speed": {
+    "emoji": "👥➡️🏃💨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "remain an infidel as to one of the most appalling, but not the less true events, perhaps anywhere to be found in all recorded history": {
+    "emoji": "🕵️‍♂️🤔📜❌😱, 🤷‍♂️😳✅📜, ✈️📚🕰️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I grin at thee, thou grinning whale!": {
+    "emoji": "😊😄🐋",
+    "date": "2024-01-01T00:00:00"
+  },
+  "English and American whale draughtsmen seem entirely content with presenting the mechanical outline of things, such as the vacant profile of the whale": {
+    "emoji": "🇬🇧🖌️🐋👨‍🎨➡️😊👉📐🖍️🔄, 😶🖼️🐋",
+    "date": "2024-01-01T00:00:00"
+  },
+  "The red tide now poured from all sides of the monster like brooks down a hill.": {
+    "emoji": "🟥🌊🔜🐉📍↔️🌊🔽🏞️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "are these ashes from that destroyed city, Gomorrah?": {
+    "emoji": "🤔🌫️🏙️🔥🗺️❓",
+    "date": "2024-01-01T00:00:00"
+  },
+  "and by that humming, we, too, who look on the loom are deafened": {
+    "emoji": "🐝🔊, 👥👀👗🎶👂❌",
+    "date": "2024-01-01T00:00:00"
+  },
+  "But will any whaleman believe these stories?": {
+    "emoji": "🐋🤔❓",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Still New Bedford is a queer place.": {
+    "emoji": "🛑✨ New Bedford is a 🌀🕵️‍♀️ place.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "see how elastic our stiff prejudices grow when love once comes to bend them": {
+    "emoji": "👀➡️📈❤️↔️👉💪📏💭🌱🌿🔥",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the glorious, golden, glad sun, the only true lamp—all others but liars!": {
+    "emoji": "🌅✨, 🌟, 😊☀️, 🌞, ➡️ 🕯️—all 🔦🚫🤥!",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Nor white whale, nor man, nor fiend, can so much as graze old Ahab in his own proper and inaccessible being.": {
+    "emoji": "🐋🚫👨🚫👿🚫➡️✒️📛🧓🏴‍☠️🛡️💭🌌",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the skeleton of a sperm whale": {
+    "emoji": "🐋💀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "But Faith, like a jackal, feeds among the tombs, and even from these dead doubts she gathers her most vital hope.": {
+    "emoji": "🦊🪦🕊️, like a 🐶, 🍽️ among the ⚰️, and even from these ☠️❓ she gathers her most 🌟🕊️.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Think not, is my eleventh commandment; and sleep when you can, is my twelfth": {
+    "emoji": "🤔🚫, is my 1️⃣1️⃣th 📜; and 😴🛌 when you can, is my 1️⃣2️⃣th 📜",
+    "date": "2024-01-01T00:00:00"
+  },
+  "is it for these reasons that there is such a dumb blankness, full of meaning, in a wide landscape of snows": {
+    "emoji": "❓❄️🧐🤔🗻❄️👀🤯🌨️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I’ll eat this whale in one mouthful.": {
+    "emoji": "👅🐋➡️🥄",
+    "date": "2024-01-01T00:00:00"
+  },
+  "For we are all killers, on land and on sea; Bonapartes and Sharks included.": {
+    "emoji": "👥🔪🌍⛴️; 🏇🦈 ➕🦈✅.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Any man may kill a snake, but only a Perseus, a St. George, a Coffin, have the heart in them to march boldly up to a whale.": {
+    "emoji": "👨🐍❌, 🤔👨‍🎤💪🐉, 🧔❤️🐳🚶‍♂️🔥",
+    "date": "2024-01-01T00:00:00"
+  },
+  "leave us, if you please, and I will see to this strange affair myself": {
+    "emoji": "👋🚶‍♂️, 🙏, 🤔➡️👀👤👉🤨📜💪",
+    "date": "2024-01-01T00:00:00"
+  },
+  "it’s worth a fellow’s while to be born into the world, if only to fall right asleep": {
+    "emoji": "👶💫🌍➡️😴👍",
+    "date": "2024-01-01T00:00:00"
+  },
+  "this difficulty is ingeniously overcome": {
+    "emoji": "🧠🔧➡️😊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "in New Bedford, actual cannibals stand chatting at street corners; savages outright; many of whom yet carry on their bones unholy flesh": {
+    "emoji": "🌆🔪😳 In New Bedford, actual cannibals stand chatting at street corners; savages outright; many of whom yet carry on their bones unholy flesh 🍖❌",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Born of earth, yet suckled by the sea; though hill and valley mothered me, ye billows are my foster-brothers!": {
+    "emoji": "🌍➡️👶⚓️🌊; 🌄🌿🌾👩‍👦, 🌊🌊👨‍👦",
+    "date": "2024-01-01T00:00:00"
+  },
+  "marks in my whale-books": {
+    "emoji": "📑📖🐋",
+    "date": "2024-01-01T00:00:00"
+  },
+  "whatever other business he has to attend to, waking or sleeping, breathe he must, or die he will": {
+    "emoji": "🌐🧑‍💼➡️😴😴, 🌬️💨=🗝️, 💨💭🏴, ☠️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "this occasional inevitable sinking of the recently killed Sperm Whale is a very curious thing": {
+    "emoji": "🐋💀🌊➡️🤔❓",
+    "date": "2024-01-01T00:00:00"
+  },
+  "sin that pays its way can travel freely, and without a passport; whereas Virtue, if a pauper, is stopped at all frontiers": {
+    "emoji": "💸😈✈️🌍🆓🛂❌, 🤔🌟🚶‍♂️🚧💰❌↪️⛔️🌍🚷",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I would rather feel your spine than your skull, whoever you are.": {
+    "emoji": "🙂➕📚>💀🔍👤",
+    "date": "2024-01-01T00:00:00"
+  },
+  "we saw an arm thrust upright from the blue waves; a sight strange to see, as an arm thrust forth from the grass over a grave": {
+    "emoji": "🌊👀🖐️⬆️💙🌊; 👀🤔🚶🖐️⬆️🌿⚰️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I found Queequeg’s arm thrown over me in the most loving and affectionate manner. You had almost thought I had been his wife.": {
+    "emoji": "👫❤️🛌 I found Queequeg’s arm thrown over me in the most loving and affectionate manner. You'd almost think I was his wife! 💍",
+    "date": "2024-01-01T00:00:00"
+  },
+  "they went to the captain and told him if Gabriel was sent from the ship, not a man of them would remain": {
+    "emoji": "👥➡️🧑‍✈️🚢👉👨‍✈️📢🚫🗣️👨‍🦱🌊🚢,🚫🧑‍🤝‍🧑↔️⛴️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "there are a rabble of uncertain, fugitive, half-fabulous whales, which, as an American whaleman, I know by reputation, but not personally": {
+    "emoji": "🐋❓🤔🙌🤷‍♂️🎩🏴‍☠️🌍👥🇺🇸🧑‍✈️📚🤝❌👤",
+    "date": "2024-01-01T00:00:00"
+  },
+  "If you attentively regard almost any quadruped’s spine, you will be struck with the resemblance of its vertebræ to a strung necklace of dwarfed skulls": {
+    "emoji": "👀➡️🐾🔍🐕🐈🦴 ➡️ 🤯➡️📿💀💀💀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "their spirits penetrate through the thick haze of the future, and descry what shoals and what rocks must be shunned": {
+    "emoji": "🔮🕊️✨🌫️🔮🔍⛵⛔️💥",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the hoisted sperm whale’s head jogged about very violently, and Gabriel was seen eyeing it with rather more apprehensiveness than his archangel nature seemed to warrant": {
+    "emoji": "🐋🔝🐳's 👤🏃‍♂️💥, 👁️😨😟 ➡️😇 ➕👁️‼️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "there was no time for shuddering": {
+    "emoji": "⏰❌⏱️😨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the Lord Warden is busily employed at times in fobbing his perquisites; which are his chiefly by virtue of that same fobbing of them": {
+    "emoji": "👑🔍🕰️💼💰➡️⏰🤹‍♂️📜💼💰👈✨➡️🔄",
+    "date": "2024-01-01T00:00:00"
+  },
+  "his vindictiveness towards the White Whale might have possibly extended itself in some degree to all sperm whales": {
+    "emoji": "👨‍✈️💢➡️🐋⚪️🔄➕📈🔜🔄⚪️🐳",
+    "date": "2024-01-01T00:00:00"
+  },
+  "simply irresistible": {
+    "emoji": "😊🌀❤️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the spermaceti whale obtains his whole food in unknown zones below the surface": {
+    "emoji": "🐋🌊🍽️❓⬇️🌐",
+    "date": "2024-01-01T00:00:00"
+  },
+  "if this whale be a king, he is a very sulky looking fellow": {
+    "emoji": "🐋👑😠🤔👤",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Seldom have I known any profound being that had anything to say to this world": {
+    "emoji": "😶‍🌫️🤔 😶‍🌫️🌍",
+    "date": "2024-01-01T00:00:00"
+  },
+  "so that all deified Nature absolutely paints like the harlot, whose allurements cover nothing but the charnel-house within": {
+    "emoji": "🎨🌿 paints like 💋 but hides ☠️🏠 within.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "In this enchanted mood, thy spirit ebbs away to whence it came": {
+    "emoji": "✨🌙🧙‍♂️🌀, 💫✨💨🔙➡️🌌",
+    "date": "2024-01-01T00:00:00"
+  },
+  "It is well to parenthesize here": {
+    "emoji": "🔍😊 ( )",
+    "date": "2024-01-01T00:00:00"
+  },
+  "go down with him, and get what thou wantest thyself": {
+    "emoji": "👥⬇️⬇️🔄👦, 🛍️➡️🔍😌🫵",
+    "date": "2024-01-01T00:00:00"
+  },
+  "This terrible event clothed the archangel with added influence": {
+    "emoji": "😔⚠️👼🕊️ ➕✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "And if you be a philosopher, though seated in the whale-boat, you would not at heart feel one whit more of terror": {
+    "emoji": "🧠🤔🐋⛵️❤️😌😱❌",
+    "date": "2024-01-01T00:00:00"
+  },
+  "a cobbler’s job, that’s at an end in the middle, and at the beginning at the end": {
+    "emoji": "👞🔧, 🔚➖🔜, 🏁➡️ 🔚",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the last one must be grown in America": {
+    "emoji": "🌱➡️🗽🇺🇸",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the chambers of my soul are all in crookedness!": {
+    "emoji": "🌀💔 The chambers of my soul are all in crookedness! 😣🌀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "And in this same last or shoe, that old woman of the nursery tale, with the swarming brood, might very comfortably be lodged, she and all her progeny.": {
+    "emoji": "👵👟 In this large shoe, the old woman from the nursery tale, along with her many children, could be comfortably housed. 🏠👶👶👶",
+    "date": "2024-01-01T00:00:00"
+  },
+  "a lesson by no means to be forgotten": {
+    "emoji": "📚❌🧠💭🔄",
+    "date": "2024-01-01T00:00:00"
+  },
+  "But even so, amid the tornadoed Atlantic of my being, do I myself still for ever centrally disport in mute calm": {
+    "emoji": "🌀🌊🤯, 🌀🌪️😶🔕💭.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "as for the narwhale, one glimpse at it is enough to amaze one, that in this nineteenth century such a hippogriff could be palmed for genuine": {
+    "emoji": "🦄➡️🐋👀✨😲📅🔟➕🌐🦄➡️🤔💯",
+    "date": "2024-01-01T00:00:00"
+  },
+  "And so saying the lighted tomahawk began flourishing about me in the dark.": {
+    "emoji": "🌕🗣️🔥🪓💨🕺🌌",
+    "date": "2024-01-01T00:00:00"
+  },
+  "screw-drivers, cork-screws, tweezers, awls, pens, rulers, nail-filers, countersinkers": {
+    "emoji": "🔩🪛, 🍾🔑, ✂️👝, 🪡, 🖊️, 📏, 💅🗃️, 🔩⭕️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "furrowed heads, broken teeth, scolloped fins": {
+    "emoji": "🤔👤🦷💔🐟✂️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I stood in the middle of a dreary street shouldering my bag, and comparing the gloom towards the north with the darkness towards the south": {
+    "emoji": "👤🚶‍♂️🛣️🌧️👜🤔🌫️⬆️⬛🆚🌌⬇️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "you are experienced in these things, and I am not": {
+    "emoji": "🔍😏✨📚, 🤔❌",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Sing out for every spout, though he spout ten times a second!": {
+    "emoji": "🎤🤩🗣️🌟🔟x⏸️秒",
+    "date": "2024-01-01T00:00:00"
+  },
+  "That is to say, he would then live without breathing.": {
+    "emoji": "🤔➡️💬😶➡️🏠😶➡️🚫💨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the malignant iron scorchingly devoured the baptismal blood": {
+    "emoji": "🦠🔥🍴🩸",
+    "date": "2024-01-01T00:00:00"
+  },
+  "“Ego non baptizo te in nomine patris, sed in nomine diaboli!” deliriously howled Ahab": {
+    "emoji": "👤💬 \"I don't baptize you in the name of the Father, but in the name of the Devil!\" 🐋😱 Ahab",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I s'pose you are goin' a-whalin', so you'd better get used to that sort of thing.": {
+    "emoji": "🧔‍♂️🌊🐳➡️🛥️🤔🥶🫴🔄💁",
+    "date": "2024-01-01T00:00:00"
+  },
+  "we harpooneers of Nantucket should be enrolled in the most noble order of St. George": {
+    "emoji": "🧍‍♂️🗡️🦈🛶🏝️➡️🏅👑🗡️⚔️🏰",
+    "date": "2024-01-01T00:00:00"
+  },
+  "certainly knowest not thy beginning, hence callest thyself unbegun": {
+    "emoji": "🤔❓📅👉📍, 🚫📞🙋‍♂️🚫⏪",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Oh, Death, why canst thou not sometimes be timely?": {
+    "emoji": "😮💀, 🤔🕰️❓",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I never go as a passenger": {
+    "emoji": "🛳️🚫👤👨‍✈️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "they are full of fight, fun, and wickedness, tumbling round the world at such a reckless, rollicking rate, that no prudent underwriter would insure them": {
+    "emoji": "🤺🎉😈, 🌍🏃‍♀️💨💥, ⚠️📈, 🛡️❌",
+    "date": "2024-01-01T00:00:00"
+  },
+  "As strange misgrown masses gather in the knot-holes of the noblest oaks when prostrate, so from the points which the whale’s eyes had once occupied, now protruded blind bulbs, horribly pitiable to see.": {
+    "emoji": "🐋😧🌳🌿🌀➡️👀🔀👁️🔍🌑➡️🔴🔴😢",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Whaling is imperial! By old English statutory law, the whale is declared “a royal fish.”": {
+    "emoji": "🐋👑⚖️! 🇬🇧📜, 🐋=🤴🐟",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the hidden ways of the Sperm Whale when beneath the surface remain, in great part, unaccountable to his pursuers": {
+    "emoji": "🐋❓🌊🔍❌👀🔍👀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "And God had prepared a great fish to swallow up Jonah.": {
+    "emoji": "🐟🙏🛐 ➡️ 📖➡️📖 🐠 to 🔄😊➡️👤 🌊👀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "The next day was exceedingly still and sultry": {
+    "emoji": "🌞➡️📅➡️😌🌬️😓🔥",
+    "date": "2024-01-01T00:00:00"
+  },
+  "there no conceivable time or occasion when you will find them in such countless numbers, and in gayer or more jovial spirits, than around a dead sperm whale": {
+    "emoji": "🐋🚫🕰️🤔📅🔍👥🔢😂🤣🌈🎉✨🐋☠️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "do you mean what you say, and have been saying all along": {
+    "emoji": "🤔💬 \"do you mean what you say, and have been saying all along\"",
+    "date": "2024-01-01T00:00:00"
+  },
+  "a circle of profound darkness": {
+    "emoji": "⚫️🌑🔄",
+    "date": "2024-01-01T00:00:00"
+  },
+  "But if the great sun move not of himself; but is as an errand-boy in heaven": {
+    "emoji": "☀️❓➡️ 🚶‍♂️❌🔄 ⬆️; ➡️ 📧👦📍🌌",
+    "date": "2024-01-01T00:00:00"
+  },
+  "a creature in the transition stage—neither caterpillar nor butterfly": {
+    "emoji": "🦋➡️🐛📶🔄🐛🚫🦋",
+    "date": "2024-01-01T00:00:00"
+  },
+  "So rarely is it beheld, that though one and all of them declare it to be the largest animated thing in the ocean, yet very few of them have any but the most vague ideas concerning its true nature and form": {
+    "emoji": "🐋✨🧐🤔🌊🌟🤯📏, 🤷‍♂️🌍🗣️📣🔝📏📊🔍🌊, 🤔🙈👥🤏💡💭➡️🦑📐❓🏞️🔎",
+    "date": "2024-01-01T00:00:00"
+  },
+  "in what is called a long dart, the heavy implement has to be flung to the distance of twenty or thirty feet": {
+    "emoji": "🏹➡️🏋️‍♂️📏💪🌌20⃣-3⃣0⃣👣",
+    "date": "2024-01-01T00:00:00"
+  },
+  "what trances of torments does that man endure who is consumed with one unachieved revengeful desire": {
+    "emoji": "🤔😣🤯💭🔥💔😡🔁🔚",
+    "date": "2024-01-01T00:00:00"
+  },
+  "this is a thing which carries more of true terror than any other aspect of this dangerous affair": {
+    "emoji": "😨➡️⚠️📦🤔🆙😱📈☠️💼",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Should you ever be athirst in the great American desert, try this experiment": {
+    "emoji": "🤔🌵 If you're ever thirsty in the great American desert, try this 💡🌵",
+    "date": "2024-01-01T00:00:00"
+  },
+  "with a dexterous, off-handed daring, unknown in any other vocation, the sailors, goat-like, leaped down the rolling ship’s side into the tossed boats below": {
+    "emoji": "👐🐐⛵️🌊🚣‍♂️⬇️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "this fellow has broken loose from somewhere; he’s talking about something and somebody we don’t know": {
+    "emoji": "👤🔓🏃‍♂️🆓❓; 🗣️💬🤔📜❓❔",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the customary cheering cry was heard from aloft, and ere long a spectacle of singular magnificence saluted us": {
+    "emoji": "📣✨ As the traditional cheer echoed from above, a scene of extraordinary splendor greeted us. 👀🏰🌟",
+    "date": "2024-01-01T00:00:00"
+  },
+  "violently flailing with his flexible tail, and tossing the keen spade about him, wounding and murdering his own comrades": {
+    "emoji": "🐉💥😤 with his 🔄 tail, and 🔄⚒️🤺 around him, 🗡️💔🙍‍♂️ and ☠️ his own 👥",
+    "date": "2024-01-01T00:00:00"
+  },
+  "perhaps we may become jolly good bedfellows after all—there’s no telling": {
+    "emoji": "🤔➡️😊👍🛏️👫🔮",
+    "date": "2024-01-01T00:00:00"
+  },
+  "How can the prisoner reach outside except by thrusting through the wall?": {
+    "emoji": "🔒🤔➡️🚶‍♂️📤❓➡️🧱💪📤",
+    "date": "2024-01-01T00:00:00"
+  },
+  "a little withered old man, who, for their money, dearly sells the sailors deliriums and death": {
+    "emoji": "👴💰➡️⚓😵💀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "At first sight, you would not think it so strong as it really is.": {
+    "emoji": "👀➡️💭🧠:〰️🔍💪🔋⚔️🏋️‍♂️✊👊💥🌟",
+    "date": "2024-01-01T00:00:00"
+  },
+  "this mere painstaking burrower and grub-worm of a poor devil of a Sub-Sub appears to have gone through the long Vaticans and street-stalls of the earth": {
+    "emoji": "🪤🐛👤🔍✨📜🌍✨🛒",
+    "date": "2024-01-01T00:00:00"
+  },
+  "It is a little significant, that while one sperm whale only fights another sperm whale with his head and jaw, nevertheless, in his conflicts with man, he chiefly and contemptuously uses his tail.": {
+    "emoji": "🐋➡️🐋🆚🦷, 🤔💭💥, 👨‍👧‍👦❌, 👀📏👣.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Our souls are like those orphans whose unwedded mothers die in bearing them": {
+    "emoji": "Here’s a translation of your text into emojis: \n\n👥❤️➡️ 🧑‍🤝‍🧑👶😢🕊️➡️💔🛏️🌹 \n\nLet me know if you need any adjustments!",
+    "date": "2024-01-01T00:00:00"
+  },
+  "moody Ahab was now all quiescence, at least so far as could be known": {
+    "emoji": "😒🤔🌊🔇✨🔍💤",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the ancestry and posterity of Grief go further than the ancestry and posterity of Joy": {
+    "emoji": "👵🏽🔙👨‍👩‍👦‍👦😢➡️🔜👪😄🔜🔙",
+    "date": "2024-01-01T00:00:00"
+  },
+  "It was a negro church; and the preacher’s text was about the blackness of darkness": {
+    "emoji": "⛪️👤🖤🌑🌌✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "he will have no one near him but Nature herself; and her he takes to wife in the wilderness of waters, and the best of wives she is, though she keeps so many moody secrets": {
+    "emoji": "👤🚫👥🌳🌊👰💍🌿💖🤫🌌",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Look not too long in the face of the fire, O man! Never dream with thy hand on the helm!": {
+    "emoji": "👀⏳🔥👨‍✈️🚫💭🤚⚓️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "But there is another thing to rebut. They hint that all whales always smell bad. Now how did this odious stigma originate?": {
+    "emoji": "🤔🐋➡️🚫👃💨❗🧐❓💭💩❓",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the world-wandering whale-ship carries no cargo but herself and crew, their weapons and their wants": {
+    "emoji": "🌍🐋⚓️🚢❌📦👩‍✈️👨‍✈️💼⚔️💭",
+    "date": "2024-01-01T00:00:00"
+  },
+  "come along that way, and to my breezelessness bring his breeze": {
+    "emoji": "👉🚶‍♂️➡️🌬️❌➡️😌➡️✨🌬️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "If I had been downright honest with myself, I would have seen very plainly in my heart": {
+    "emoji": "🤔💭💔🔍✨❤️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "memory shot her crystals as the clear ice most forms of noiseless twilights": {
+    "emoji": "🧠💥💎❄️🔇🌆",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the tissued, infiltrated head of the Sperm Whale, was the lightest and most corky part about him; and yet thou makest it sink": {
+    "emoji": "🐋💦🧻🧠💡🌊⚖️🪂🤷‍♂️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "it is but the first salutation to the possibilities of the immense Remote, the Wild, the Watery, the Unshored": {
+    "emoji": "👋✨🌍🌊🌿🏞️🌀🏔️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Leap! leap up, and lick the sky!": {
+    "emoji": "🦘✨⬆️🌌💫",
+    "date": "2024-01-01T00:00:00"
+  },
+  "straining forwards and backwards on his seat, like a pacing tiger in his cage": {
+    "emoji": "😤➡️⬅️🪑🐅🔄🦁🏠",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the bottom of the whale-boat is like critical ice, which will bear up a considerable distributed weight, but not very much of a concentrated one": {
+    "emoji": "🐋🚤➡️❄️⚠️⚖️🔄💪🔳🔽🔄🚫🔝",
+    "date": "2024-01-01T00:00:00"
+  },
+  "goaded by it into more than sufferable anguish, the whale now spouting thick blood, with swift fury blindly darted at the craft": {
+    "emoji": "🐳💔😠💨🩸⚓️💨💥",
+    "date": "2024-01-01T00:00:00"
+  },
+  "If the gods think to speak outright to man, they will honorably speak outright; not shake their heads, and give an old wives’ darkling hint": {
+    "emoji": "👼⚡🗣️👨‍👩‍👦✨🗨️🙅‍♂️🔮👵🌑💡",
+    "date": "2024-01-01T00:00:00"
+  },
+  "he, shivering and half shipwrecked, instead of rainbows speaking hope and solace to his misery, views what seems a boundless churchyard grinning upon him with its lean ice monuments and splintered crosses": {
+    "emoji": "👨‍🦰❄️🛶🌈😞🕊️👀🌌⛪🪦😬➡️💀🏰❄️🪨✝️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Leviathan is of so mighty a magnitude, all his proportions are so stately, that the same deficiency which in the sculptured Jove were hideous, in him is no blemish at all.": {
+    "emoji": "🐉💪✨📏🕊️🤴🏽⚖️⚡️🛠️🔍❌😱➕😊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "an Ohio honey-hunter, who seeking honey in the crotch of a hollow tree, found such exceeding store of it, that leaning too far over, it sucked him in, so that he died embalmed": {
+    "emoji": "🏞️🍯🐝🌳🤏😯😱🧑‍🌾➡️💨😵‍💫⚰️🕊️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "For, d’ye see, rainbows do not visit the clear air; they only irradiate vapor.": {
+    "emoji": "🌈❌🌥️➡️🌤️; 🌈➕💫💨.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "And what are you, reader, but a Loose-Fish and a Fast-Fish, too?": {
+    "emoji": "🐟💨🤔📖✨🔄🐋💨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "ye shall soon be initiated into certain facts hitherto pretty generally unknown": {
+    "emoji": "👥🔜✨📜🤔❓❗️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the whale beyond also rose": {
+    "emoji": "🐋➡️🌊⬆️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "what is it that makes the front of a man—what, indeed, but his eyes?": {
+    "emoji": "🤔❓👤➡️👀❓",
+    "date": "2024-01-01T00:00:00"
+  },
+  "we are all somehow dreadfully cracked about the head, and sadly need mending.": {
+    "emoji": "👫💔😟🧠🛠️✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "that man was swallowed up in the deep": {
+    "emoji": "👨🌊🌀➡️🌊🌌",
+    "date": "2024-01-01T00:00:00"
+  },
+  "does the ocean furnish any fish that in disposition answers to the sagacious kindness of the dog? The accursed shark alone can in any generic respect be said to bear comparative analogy to him.": {
+    "emoji": "🌊🐟🤔💖🐕❓🐠😈🦈🆚🐕",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Great pains, small gains for those who ask the world to solve them; it cannot solve itself.": {
+    "emoji": "😩💔🔄🌍🤲❌🆘💡💔",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Bethink yourself also of another thing.": {
+    "emoji": "💭🤔➡️🧠🔄✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "and if he had a chance he will pull down and pulverize that subaltern’s tower, and make a little heap of dust of it": {
+    "emoji": "🔽💥🏰🪨➡️💨✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "you can hardly regard any creatures of the deep with the same feelings that you do those of the shore": {
+    "emoji": "🧜‍♂️😕🌊🦈🐠🔍💔🏖️🤔",
+    "date": "2024-01-01T00:00:00"
+  },
+  "all this indirectly proceeds from the helpless perplexity of volition": {
+    "emoji": "🌍➡️🤷‍♂️😵‍💫🌀💭",
+    "date": "2024-01-01T00:00:00"
+  },
+  "enlightened gourmand, who nailest geese to the ground and feastest on their bloated livers in thy pate de fois gras": {
+    "emoji": "🧘‍♂️🍽️🦢🔨🌍🍂🥩🍽️👅🍷💫",
+    "date": "2024-01-01T00:00:00"
+  },
+  "dusty rarities gathered from this wide world’s remotest nooks": {
+    "emoji": "🌍🕵️‍♂️✨💎🌪️🏞️🌌🔍",
+    "date": "2024-01-01T00:00:00"
+  },
+  "for ever and for ever, to the crack of doom, the sea will insult and murder him": {
+    "emoji": "🔄♾️🌊😠🔪💀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "We must watch for a breach in the living wall that hemmed us in; the wall that had only admitted us in order to shut us up.": {
+    "emoji": "👀🛡️🚪🧱🪨🚧🔒🔒",
+    "date": "2024-01-01T00:00:00"
+  },
+  "his smoke is horrible to inhale, and inhale it you must, and not only that, but you must live in it for the time": {
+    "emoji": "🚬😷💨😩➡️😤🏠⏳",
+    "date": "2024-01-01T00:00:00"
+  },
+  "in his ordinary attitude, the Sperm Whale's mouth is buried at least eight feet beneath the surface": {
+    "emoji": "🐋💭🌊⬇️🦶8️⃣🔽",
+    "date": "2024-01-01T00:00:00"
+  },
+  "A very white, and famous, and most deadly immortal monster, Don;—but that would be too long a story.": {
+    "emoji": "⚪🌟💀🧛‍♂️👹 Don;—📖❌🕰️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Warmest climes but nurse the cruellest fangs: the tiger of Bengal crouches in spiced groves of ceaseless verdure.": {
+    "emoji": "🌞🌴🐅🌶️🌿🍃🌳",
+    "date": "2024-01-01T00:00:00"
+  },
+  "as though they deemed our ship some drifting, uninhabited craft; a thing appointed to desolation": {
+    "emoji": "🚢🌊🤔➡️🚢❌🏠💨⚓️➡️💔🏝️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "he is always of the largest leviathanic proportions": {
+    "emoji": "👨‍🦰➡️🕛🔝⚓🐉📏",
+    "date": "2024-01-01T00:00:00"
+  },
+  "How wondrous familiar is a fool!": {
+    "emoji": "🤔✨🌍👀😅👨‍🏫",
+    "date": "2024-01-01T00:00:00"
+  },
+  "it was not so much the fear of striking hidden rocks, as the fear of that hideous whiteness that so stirred me": {
+    "emoji": "🤔💭🚫🪨😨💔👻⚪️😱✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "how it was exactly, there is no telling now": {
+    "emoji": "🤔🔍➡️🕰️❓📉",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Oh, busy weaver! unseen weaver!—pause!—one word!—whither flows the fabric? what palace may it deck?": {
+    "emoji": "🙀👩‍🎤🧵✨⏸️🗣️➡️🏰🧶🔜🏛️🌟👐",
+    "date": "2024-01-01T00:00:00"
+  },
+  "we eighteen men with our thirty-six arms, and one hundred and eighty thumbs and fingers, slowly toiled hour after hour upon that inert, sluggish corpse in the sea; and it seemed hardly to budge at all": {
+    "emoji": "👥18👨‍🔧💪36🖐️👀180👍✋💦🛏️💤📅⏳😩🌊💀⚓️😵‍💫🌀🧟‍♂️💨💦💧",
+    "date": "2024-01-01T00:00:00"
+  },
+  "they think that, at best, our vocation amounts to a butchering sort of business": {
+    "emoji": "🤔🤷‍♂️💭🔝🚫🔪🐖💼",
+    "date": "2024-01-01T00:00:00"
+  },
+  "these mystic gestures": {
+    "emoji": "✨🤲🔮",
+    "date": "2024-01-01T00:00:00"
+  },
+  "as if his chest had been a mortar, he burst his hot heart’s shell upon it": {
+    "emoji": "💔🔥💥💣💨💔❤️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "cook, you cook!—sail this way, cook!": {
+    "emoji": "👨‍🍳🍽️👉⛵️🚶‍♂️👨‍🍳",
+    "date": "2024-01-01T00:00:00"
+  },
+  "you were kicked by a great man, and with a beautiful ivory leg": {
+    "emoji": "👟➡️💪🌟👨‍🦱✨🦵🤍",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Gayer sallies, more merry mirth, better jokes, and brighter repartees, you never heard": {
+    "emoji": "🎉😄😂✨🔊💬🌈",
+    "date": "2024-01-01T00:00:00"
+  },
+  "tales of terror told in words of mirth": {
+    "emoji": "📖😱🗣️😂✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "With this once long lance, now wildly elbowed, fifty years ago did Nathan Swain kill fifteen whales between a sunrise and a sunset.": {
+    "emoji": "🏹⏳🛶🐋🐋🐋🐋🐋🐋🐋🐋🐋🐋🐋🐋🐋🐋🌅🌇✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "when, accordingly, Queequeg and a forecastle seaman came on deck, no small excitement was created among the sharks": {
+    "emoji": "🕒➡️⚓👫🧑‍✈️🆙🎉🐋🦈",
+    "date": "2024-01-01T00:00:00"
+  },
+  "All passed in a flash.": {
+    "emoji": "🌟⚡️⏳",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Look ye, sun, moon, and stars! I call ye assassins of as good a fellow as ever spouted up his ghost.": {
+    "emoji": "👀☀️🌙⭐️⚔️👤😇💨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "all the world": {
+    "emoji": "🌍🌎🌏",
+    "date": "2024-01-01T00:00:00"
+  },
+  "instantaneous, violent, convulsive": {
+    "emoji": "⚡️💥😱",
+    "date": "2024-01-01T00:00:00"
+  },
+  "All men tragically great are made so through a certain morbidness. Be sure of this, O young ambition, all mortal greatness is but disease.": {
+    "emoji": "👨‍💼⚰️🌟😔🔍💪💀🧠💔✨🕊️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "for what is man that he should live out the lifetime of his God?": {
+    "emoji": "🤔👨‍💼❓⚖️⏳🙏🏽✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "He sleeps with clenched hands; and wakes with his own bloody nails in his palms.": {
+    "emoji": "😴✋💪🔪🩸👐✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the thinnest shreds of isinglass": {
+    "emoji": "🧊✂️🪄✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "this mighty monster is actually a diademed king of the sea": {
+    "emoji": "🐉👑🌊🐟",
+    "date": "2024-01-01T00:00:00"
+  },
+  "A curious and most puzzling question might be started concerning this visual matter as touching the Leviathan.": {
+    "emoji": "🤔❓🔍🧩🖼️🐉",
+    "date": "2024-01-01T00:00:00"
+  },
+  "look-outs were repeatedly hailed, and admonished to keep wide awake": {
+    "emoji": "👀🚨🔊⚠️😴🛑💤👀🌙🌄",
+    "date": "2024-01-01T00:00:00"
+  },
+  "start her like grim death and grinning devils, and raise the buried dead perpendicular out of their graves, boys": {
+    "emoji": "🔪👩‍🎤💀😈👹⬆️⚰️🧑‍🦰",
+    "date": "2024-01-01T00:00:00"
+  },
+  "its grand fact and feature is the wonderful distance to which the long lance is accurately darted from a violently rocking, jerking boat, under extreme headway": {
+    "emoji": "🌊🚤⚡️🎯🗡️✨🌌🤯💨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "In what census of living creatures, the dead of mankind are included": {
+    "emoji": "📊👤🔍🌍⚰️‍🧑‍🤝‍🧑",
+    "date": "2024-01-01T00:00:00"
+  },
+  "not to speak of the peril of the thing, it is to be doubted whether this course is always the best": {
+    "emoji": "🚫🗣️⚠️🤔❓💭🤷‍♂️💭➡️👍❓",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Naught’s an obstacle, naught’s an angle to the iron way!": {
+    "emoji": "🚫🛑❌🔄➡️🛤️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "take mankind in mass, and for the most part, they seem a mob of unnecessary duplicates, both contemporary and hereditary": {
+    "emoji": "👥🌍➡️👥💥🔄🧬👬🧑‍🤝‍🧑🕰️🚫",
+    "date": "2024-01-01T00:00:00"
+  },
+  "this pine-tree shakes down its sighs like leaves upon this shepherd's head": {
+    "emoji": "🌲💨🍂💭😌👤🌳",
+    "date": "2024-01-01T00:00:00"
+  },
+  "once again leviathan returns to his native profundities, sliding along beneath the surface as before; but, alas! never more to rise": {
+    "emoji": "🐉🔙🌊⬇️🌌😔⚓️❌⬆️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the old man is hard bent after that White Whale, and the devil there is trying to come round him, and get him to swap away his silver watch, or his soul, or something of that sort, and then he’ll surrender Moby Dick": {
+    "emoji": "👴🏽💪🐋😈🔄🕰️💰😇💭➡️🤝🐳",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the grave-digger in the play sings, spade in hand. Dost thou never?": {
+    "emoji": "🪦👷‍♂️🎭🎶🪚🤔❓",
+    "date": "2024-01-01T00:00:00"
+  },
+  "What befell the weakling youth lifting the dread goddess’s veil at Lais?": {
+    "emoji": "🤔👦💪😟🕊️🏺👸🔮😯🌫️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "this brought about new revelations of the incredible ferocity of the foe": {
+    "emoji": "📈🔍✨🤯🦁💥👹",
+    "date": "2024-01-01T00:00:00"
+  },
+  "here sleeps his meadow, and there sleep his cattle": {
+    "emoji": "🏞️😴🐄💤🏞️🐄",
+    "date": "2024-01-01T00:00:00"
+  },
+  "an utterly fearless man is a far more dangerous comrade than a coward.": {
+    "emoji": "👨‍🦰💪😨🔫🤝💣💀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "It is customary to have two harpoons reposing in the crotch": {
+    "emoji": "🪝🪝🛌➡️👖",
+    "date": "2024-01-01T00:00:00"
+  },
+  "art thou not an arrant, all-grasping, intermeddling, monopolising, heathenish old scamp, to be one day making legs, and the next day coffins": {
+    "emoji": "🎨🤔🚫😈💰🤝👴🎩🖌️🚶‍♂️💀📦📅👉🛠️📦",
+    "date": "2024-01-01T00:00:00"
+  },
+  "At this hour of the night, of the last day of the week, that quarter of the town proved all but deserted.": {
+    "emoji": "🌙🕛🕰️🔚📅🏙️🚶‍♂️💨🚶‍♀️🕳️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "The lower subdivided part, called the junk, is one immense honeycomb of oil": {
+    "emoji": "🛠️📦➡️🗑️🍯🍯🍯➡️🛢️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "mark what robustness is there": {
+    "emoji": "📝🔍💪❓",
+    "date": "2024-01-01T00:00:00"
+  },
+  "they present the two extremes of all the known varieties of the whale": {
+    "emoji": "🐋➡️⚖️➡️🐳🔍🌊🌐",
+    "date": "2024-01-01T00:00:00"
+  },
+  "whatever random allusions to whales he could anyways find in any book whatsoever, sacred or profane": {
+    "emoji": "🌀📚🐋🔍✨🕊️📖💀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "they will not fail to elucidate several most important, however intricate passages, in scenes hereafter to be painted": {
+    "emoji": "👥❌❌🔜🔍📖✨📌🔆🎨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "a most delectable mess": {
+    "emoji": "🍽️😋🤪💥",
+    "date": "2024-01-01T00:00:00"
+  },
+  "this is a thing": {
+    "emoji": "👈👀✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I wonder, Flask, whether the world is anchored anywhere; if she is, she swings with an uncommon long cable, though.": {
+    "emoji": "🤔🧪🌍⚓️❓🌀🧗‍♂️🧵💫",
+    "date": "2024-01-01T00:00:00"
+  },
+  "For all his old age, and his one arm, and his blind eyes, he must die the death and be murdered": {
+    "emoji": "👴🏻🦾👀❌💀🔪",
+    "date": "2024-01-01T00:00:00"
+  },
+  "He bolts down all events, all creeds, and beliefs, and persuasions, all hard things visible and invisible": {
+    "emoji": "⚡️📅🌍🙏💭💪👀👻",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Moby Dick was ubiquitous; that he had actually been encountered in opposite latitudes at one and the same instant of time.": {
+    "emoji": "🐳🌊🌍🔄⏳✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "If they but knew it": {
+    "emoji": "🤔💭🤫💡✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "those same things that would have repelled most others, they were the very magnets that thus drew me": {
+    "emoji": "🔄💔➡️🚶‍♂️❌🌍, 🌟📌➡️💖🔗😌✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "this wild cannibal, tomahawk between his teeth, sprang into bed with me.": {
+    "emoji": "🌪️🪓🦷🛏️👤",
+    "date": "2024-01-01T00:00:00"
+  },
+  "A sweet and unctuous duty!": {
+    "emoji": "🍭🍯✨👐💖",
+    "date": "2024-01-01T00:00:00"
+  },
+  "The great God absolute! The centre and circumference of all democracy!": {
+    "emoji": "🙏👑✨🌍🔵🗳️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the doomed boat would infallibly be dragged down after him into the profundity of the sea; and in that case no town-crier would ever find her again": {
+    "emoji": "🚤💔⬇️🌊🌌❌🏙️🔔🔍🙅‍♂️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "all truth is profound": {
+    "emoji": "🔍✨📖💭",
+    "date": "2024-01-01T00:00:00"
+  },
+  "mere sounds, full of Leviathanism, but signifying nothing": {
+    "emoji": "🎶🔊🐋❌🗣️✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "The classification of the constituents of a chaos, nothing less is here essayed.": {
+    "emoji": "📊🤔🔍🌪️✨📝",
+    "date": "2024-01-01T00:00:00"
+  },
+  "He piled upon the whale’s white hump the sum of all the general rage and hate felt by his whole race from Adam down": {
+    "emoji": "👨‍🦳🐋⚪💢💢💢💢💢💭💢👣🌍💔",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the outermost enveloping layer of any animal, if reasonably dense, what can that be but the skin?": {
+    "emoji": "🐾🌍🧥🦓🙈💭💪✨🛡️👤✋👖？",
+    "date": "2024-01-01T00:00:00"
+  },
+  "few men’s courage is proof against protracted meditation unrelieved by action": {
+    "emoji": "👨‍🦰👨‍🦱💪😌🔍🕰️💭🚫⚔️💥",
+    "date": "2024-01-01T00:00:00"
+  },
+  "It was in Queen Anne’s time that the bone was in its glory, the farthingale being then all the fashion.": {
+    "emoji": "👑👸💃✨🦴🌟🕰️👗🎉💖",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Yes, the world’s a ship on its passage out, and not a voyage complete; and the pulpit is its prow.": {
+    "emoji": "👍🌍🚢🌊🌅🚀🛳️⚓️⛵️💫✨👨‍🏫📖🗣️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Yet habit—strange thing! what cannot habit accomplish?": {
+    "emoji": "🤔🌀🤷‍♂️💪✨❓🔝🔧",
+    "date": "2024-01-01T00:00:00"
+  },
+  "We cannibals must help these Christians.": {
+    "emoji": "🍽️👥🤝✝️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Shall we be dragged by him to the bottom of the sea? Shall we be towed by him to the infernal world?": {
+    "emoji": "😟🌊➡️🧑‍✈️🔽🧜‍♂️❓😱🌊➡️👹🌍❓",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Far inland, nameless wails came from him, as desolate sounds from out ravines": {
+    "emoji": "🌲➡️🌄😢🔊🌌🌊🌪️🌄🕳️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Oh, hard! that to fire others, the match itself must needs be wasting!": {
+    "emoji": "🔥😩💔🔥🧑‍🤝‍🧑💥🕯️💔🌪️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Nothing was said for some moments, while a succession of riotous waves rolled by, which by one of those occasional caprices of the seas were tumbling, not heaving it.": {
+    "emoji": "🤫⏳🌊🌊🎉🌊👉😮‍💨🌊⛅️🌊💥🌊👀📉",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Ego non baptizo te in nomine patris, sed in nomine diaboli!": {
+    "emoji": "👤❌💧➡️🙏👴,❌➡️🙏👿!",
+    "date": "2024-01-01T00:00:00"
+  },
+  "all the grave-yards, cemeteries, and family vaults of creation": {
+    "emoji": "🏴‍☠️⚰️🌌🏰🪦👪💀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the whale’s horrible wallow": {
+    "emoji": "🐋💔🛀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Nothing exists in itself.": {
+    "emoji": "🌀❌✨🔄",
+    "date": "2024-01-01T00:00:00"
+  },
+  "For like certain other omnivorous roving lovers that might be named, my Lord Whale has no taste for the nursery, however much for the bower": {
+    "emoji": "🐋❌👶🏻🌱💖🌳",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I am impatient of all misery in others that is not mad.": {
+    "emoji": "😤🤷‍♂️😔💔🤪",
+    "date": "2024-01-01T00:00:00"
+  },
+  "no suicides permitted here, and no smoking in the parlor": {
+    "emoji": "🚫💀🚫🚬🏠🛋️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "each silent sailor seemed resolved into his own invisible self": {
+    "emoji": "🌊🧑‍✈️🤫👥✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I’ve no idea of sleeping with a madman": {
+    "emoji": "😴🤷‍♀️💭🤪🧑‍🤝‍🧑",
+    "date": "2024-01-01T00:00:00"
+  },
+  "But here is an artist.": {
+    "emoji": "🎨👩‍🎨✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "we marry and think to be happy for aye, when pop comes Libra, or the Scales—happiness weighed and found wanting": {
+    "emoji": "💍❤️😊✨⚖️😕⚖️🔍🔄😞",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Serious fault might be found with the anatomical details of this whale, but let that pass; since, for the life of me, I could not draw so good a one.": {
+    "emoji": "⚠️🐋🧐❌✏️🤷‍♂️🎨✨👌",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I quaked to think of it.": {
+    "emoji": "😱💭🌪️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "we escape, and hail Virgo, the Virgin! that’s our first love": {
+    "emoji": "🏃‍♂️✨🌌🙌♍️👩‍🎤❤️🌟",
+    "date": "2024-01-01T00:00:00"
+  },
+  "He was intent on an audacious, immitigable, and supernatural revenge.": {
+    "emoji": "💪🔥😈🦸‍♂️💥⚡️💣",
+    "date": "2024-01-01T00:00:00"
+  },
+  "all this is both foolish and unnecessary": {
+    "emoji": "🤦‍♂️🤷‍♀️💭❌✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Ahab gave orders that not an oar should be used, and no man must speak but in whispers.": {
+    "emoji": "🧔📜➡️🚫🛶🚫🗣️👂💬",
+    "date": "2024-01-01T00:00:00"
+  },
+  "it is in vain to attempt a clear classification of the Leviathan, founded upon either his baleen, or hump, or fin, or teeth": {
+    "emoji": "🤷‍♂️🚫🔍📋🦈🐋💔🦷🦈✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I have swam through libraries and sailed through oceans": {
+    "emoji": "🏊‍♂️📚🌊⛵️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "His heart had burst!": {
+    "emoji": "💔💥",
+    "date": "2024-01-01T00:00:00"
+  },
+  "churning and churning": {
+    "emoji": "🌪️💨🔄🔁",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the robust and man-like sea heaved with long, strong, lingering swells, as Samson’s chest in his sleep": {
+    "emoji": "🌊💪💤💨🌊💪💨🌊🛌💪💤",
+    "date": "2024-01-01T00:00:00"
+  },
+  "at last he loses his identity": {
+    "emoji": "🏁😔👤❌",
+    "date": "2024-01-01T00:00:00"
+  },
+  "It signifies—“God: done this day by my hand.”": {
+    "emoji": "🙏✨📅✋🖊️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "all that we call lives and souls, lie dreaming, dreaming, still": {
+    "emoji": "🌍💫😴💭💭💤",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the pressure of the water is immense": {
+    "emoji": "🌊💧💦🔝",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Consider also the devilish brilliance and beauty of many of its most remorseless tribes": {
+    "emoji": "😈💡✨🌟💖⚔️🌍🇹🇷🔪",
+    "date": "2024-01-01T00:00:00"
+  },
+  "their three Nantucket irons entered the whale": {
+    "emoji": "🔄3🏺📍🐋",
+    "date": "2024-01-01T00:00:00"
+  },
+  "The continual sight of the fiend shapes before me, capering half in smoke and half in fire": {
+    "emoji": "👀🔥👹💨💃🏻💨🔥",
+    "date": "2024-01-01T00:00:00"
+  },
+  "what nameless, inscrutable, unearthly thing is it; what cozening, hidden lord and master, and cruel, remorseless emperor commands me": {
+    "emoji": "🤔❓👻🤷‍♂️✨🔍🕵️‍♂️👑🤫🧙‍♂️💔😠👨‍⚖️⚔️📜",
+    "date": "2024-01-01T00:00:00"
+  },
+  "no nose, eyes, ears, or mouth; no face; he has none": {
+    "emoji": "🤚👃❌👀❌👂❌👄❌😶‍🌫️❌👉👨‍⚖️🚫",
+    "date": "2024-01-01T00:00:00"
+  },
+  "a shocking sharkish business enough for all parties": {
+    "emoji": "🦈💼⚡️🤯💰👥🔄",
+    "date": "2024-01-01T00:00:00"
+  },
+  "an exasperated whale, purposing to spring clean over the craft, is in the enormous act of impaling himself upon the three mast-heads": {
+    "emoji": "🐋😤🧼🛶🔪🌊⚓⚓⚓",
+    "date": "2024-01-01T00:00:00"
+  },
+  "If you should write a fable for little fishes, you would make them speak like great whales.": {
+    "emoji": "📝🐟💬🐋",
+    "date": "2024-01-01T00:00:00"
+  },
+  "chance, though restrained in its play within the right lines of necessity, and sideways in its motions directed by free will, though thus prescribed to by both, chance by turns rules either, and has the last featuring blow at events": {
+    "emoji": "🎲🔒➡️⚖️✍️🆓🔄⚔️🌀🔚💥🎭",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Could annihilation occur to matter, this were the thing to do it.": {
+    "emoji": "💥❓🤔💨🔄⚛️👾🔜⚠️✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "his special lunacy stormed his general sanity, and carried it, and turned all its concentred cannon upon its own mad mark": {
+    "emoji": "😜⚡️🌪️🤪🧠💥➡️💣🔄🎯🌀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "people were reliably apprised of the existence of Moby Dick, and the havoc he had made": {
+    "emoji": "👥📢📖🐳⚡️💥",
+    "date": "2024-01-01T00:00:00"
+  },
+  "There seems some ground to imagine that the great Kraken of Bishop Pontoppodan may ultimately resolve itself into Squid.": {
+    "emoji": "🌊🦑📜🔍✨🐙🦑",
+    "date": "2024-01-01T00:00:00"
+  },
+  "And the man that has anything bountifully laughable about him, be sure there is more in that man than you perhaps think for.": {
+    "emoji": "🧔😄💰🤔✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "unusual yellowish incrustations": {
+    "emoji": "🌟🟡🪨✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I do not think I shall err": {
+    "emoji": "🤔❌🤷‍♂️🛑",
+    "date": "2024-01-01T00:00:00"
+  },
+  "A peddler of heads too—perhaps the heads of his own brothers. He might take a fancy to mine—heavens! look at that tomahawk!": {
+    "emoji": "🧑‍🎤🪖💀🤔👀🔪💥",
+    "date": "2024-01-01T00:00:00"
+  },
+  "That immaculate manliness we feel within ourselves, so far within us, that it remains intact though all the outer character seem gone": {
+    "emoji": "💪✨🧔🏼‍♂️💖🤍🌌👁️🛡️🌿🌟🌀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Methinks that in looking at things spiritual, we are too much like oysters observing the sun through the water": {
+    "emoji": "🤔👀🌊🌞🐚",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Moby Dick swam swiftly round and round the wrecked crew; sideways churning the water in his vengeful wake": {
+    "emoji": "🐳🌊🔄👥💔💨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "It became imperative to lance the flying whale, or be content to lose him": {
+    "emoji": "🏴‍☠️🎯🐋✈️⚔️❓😔❌🏆",
+    "date": "2024-01-01T00:00:00"
+  },
+  "we nowadays fly under the same jaws for protection": {
+    "emoji": "🕊️✈️🤝🦈🛡️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "moment followed moment, and no sign of either the sinker or the diver could be seen": {
+    "emoji": "⏳➡️⏳🚫🔍🪣🤿",
+    "date": "2024-01-01T00:00:00"
+  },
+  "all for love": {
+    "emoji": "❤️💖💘💞✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the only whales that thus sank were old, meagre, and broken-hearted creatures": {
+    "emoji": "🐋❌🛳️👵😔💔💔🦈",
+    "date": "2024-01-01T00:00:00"
+  },
+  "blind and deaf, the whale plunged forward, as if by sheer power of speed to rid himself of the iron leech that had fastened to him": {
+    "emoji": "🐋💨👀🚫👂🚫🔗⚓️💪✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I have another idea for you.": {
+    "emoji": "💡➡️🤔✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Listen, and thou wilt often hear my ivory foot upon the deck, and still know that I am there.": {
+    "emoji": "👂, 🐘👣📏🛳️, 🔊👂💬📍💭👤.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the head of this Leviathan, in the creature’s living intact state, is an entire delusion": {
+    "emoji": "🐉🧠✨🪄🔮🌊😵‍💫",
+    "date": "2024-01-01T00:00:00"
+  },
+  "His motions plainly denoted his extreme exhaustion.": {
+    "emoji": "👨‍🏫🕺➡️😩💤💔",
+    "date": "2024-01-01T00:00:00"
+  },
+  "this nameless phantom feeling": {
+    "emoji": "👻🤷‍♂️💭✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "you cannot get at it": {
+    "emoji": "👤❌➡️🛑",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Oh, my Captain! my Captain! noble soul! grand old heart, after all!": {
+    "emoji": "😢👨‍✈️💖✨💔🕰️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "smothered in the very whitest and daintiest of fragrant spermaceti": {
+    "emoji": "😮‍💨❄️🌟💖🌸🌊🐋✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "The intense concentration of self in the middle of such a heartless immensity, my God! who can tell it?": {
+    "emoji": "😤💭❤️🌌😱🙏❓",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Do the heavens yet hate thee, that thou can’st not go mad?": {
+    "emoji": "🌌💔😠🤔🔒😵‍💫",
+    "date": "2024-01-01T00:00:00"
+  },
+  "indeed out of bed-clothes too, seeing that there was no fire in the room.": {
+    "emoji": "🛏️➡️❌👗🔥🏠",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the hunted whale cannot now escape speedy extinction": {
+    "emoji": "🐋🏃‍♂️❌⚡🪦",
+    "date": "2024-01-01T00:00:00"
+  },
+  "nowadays, the whale-fishery furnishes an asylum for many romantic, melancholy, and absent-minded young men": {
+    "emoji": "🐋🎣🏠💖😔🧠👦👦👦",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I could see no compass before me to steer by": {
+    "emoji": "👀❌🧭👤➡️🚢",
+    "date": "2024-01-01T00:00:00"
+  },
+  "surrounded by circle upon circle of consternations and affrights": {
+    "emoji": "🔴🔴🔴😟😱🔴🔴🔴",
+    "date": "2024-01-01T00:00:00"
+  },
+  "in the port is safety, comfort, hearthstone, supper, warm blankets, friends, all that’s kind to our mortalities": {
+    "emoji": "⚓️🏝️🛡️🛋️🔥🍽️🛏️🧣👫❤️🌍😊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "one most perilous and long voyage ended, only begins a second; and a second ended, only begins a third, and so on, for ever and for aye": {
+    "emoji": "1️⃣🌊🚢⛵️⚓️🗺️🔚, 🔁🛳️🔜2️⃣; 2️⃣🔚, 🔁🔜3️⃣, 🔁🔜🔄, ♾️✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Let us scrape the ice from our frosted feet, and see what sort of a place this “Spouter” may be.": {
+    "emoji": "🧊👣❄️🧼👀🏞️🗣️❓",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Two days chased; twice stove to splinters; thy very leg once more snatched from under thee": {
+    "emoji": "2️⃣🌅🏃‍♂️💨; 2️⃣🔥🔥💥💣; 🦵🔪👋🎭🧙‍♂️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "The more so, I say, because truly to enjoy bodily warmth, some small part of you must be cold": {
+    "emoji": "💭💖🔥➡️❄️✨🫂🌡️🧊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I, for one, had no idea of so doing.": {
+    "emoji": "🙋‍♂️🤷‍♂️❓🤔➡️🙅‍♂️🔍🪄",
+    "date": "2024-01-01T00:00:00"
+  },
+  "a whale must be near": {
+    "emoji": "🐋➡️🌊🔍",
+    "date": "2024-01-01T00:00:00"
+  },
+  "through that gate lay the route to his vengeance": {
+    "emoji": "🚪➡️🛤️😈⚔️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "most letters never reach their mark; and many are only received after attaining an age of two or three years or more": {
+    "emoji": "✉️❌🎯; 📬🕒👶👶👧🕓✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "if you narrowly search, you will at last see a lashless eye": {
+    "emoji": "🔍👀🚫👁️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "But courage! there is good cheer in store for you": {
+    "emoji": "💪😊🎉✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "So have I seen a bird with clipped wing making affrighted broken circles in the air, vainly striving to escape the piratical hawks.": {
+    "emoji": "🐦✂️🕊️😨🔄🌌💨🙅‍♂️🦅⚓️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I tell you, the sperm whale will stand no nonsense.": {
+    "emoji": "👤➡️🗣️🐋❌🙈🌀🔊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "That sashless window, where the frost is on both sides, and of which the wight Death is the only glazier.": {
+    "emoji": "🪟❌🧣❄️⬅️➡️💀🔨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "This fundamental thing settled, the next point is, in what internal respect does the whale differ from other fish.": {
+    "emoji": "🔍🐋➡️❓🆚🐟",
+    "date": "2024-01-01T00:00:00"
+  },
+  "unfolding its noiseless measureless leaves upon the sea": {
+    "emoji": "📜➡️🤫📏🍃🌊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "from the unmarred dead body of the whale, you may scrape off with your hand an infinitely thin, transparent substance": {
+    "emoji": "🐋✨👋💧🔬",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I’ll try a pagan friend, thought I, since Christian kindness has proved but hollow courtesy.": {
+    "emoji": "🤔👥🪄✨🙏😇💔💁‍♂️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Some men die at ebb tide; some at low water; some at the full of the flood": {
+    "emoji": "🧑⚰️🌊⏳; 🧑⚰️🌊⬇️; 🧑⚰️🌊🌕✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "his mother tells him of me, of cannibal old me; how I am abroad upon the deep, but will yet come back to dance him again": {
+    "emoji": "👩‍👦🗣️👵🍴👤🌊✈️💃🔄",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I never saw such a sight in my life.": {
+    "emoji": "👀🤯🤩💫",
+    "date": "2024-01-01T00:00:00"
+  },
+  "an incorruptible sea": {
+    "emoji": "🌊✨🛡️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "did ever whale yaw so before? it must be, he’s lost his tiller": {
+    "emoji": "🐋😴❓😮‍💨🌊🪝👉🤔🔚🛶🎭",
+    "date": "2024-01-01T00:00:00"
+  },
+  "A curious sight; these bashful bears, these timid warrior whalemen!": {
+    "emoji": "🐻👀😳🐋⚔️🧔",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Hurrah! this is the way a fellow feels when he’s going to Davy Jones—all a rush down an endless inclined plane!": {
+    "emoji": "🎉😄➡️👨‍✈️💀🌊🏴‍☠️⏬🏔️💨💨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Wretched entertainment": {
+    "emoji": "😒🎭📺",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I said nothing, and tried to think nothing.": {
+    "emoji": "🤐🙅‍♂️💭🚫",
+    "date": "2024-01-01T00:00:00"
+  },
+  "gripe your oars, and clutch your souls, now!": {
+    "emoji": "🛶🙌⚓️👻💪✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "He’s the devil, I say. The reason why you don’t see his tail, is because he tucks it up out of sight; he carries it coiled away in his pocket, I guess.": {
+    "emoji": "👹🤔👉👿❓👀👎👈🐍🔒🤐🎒💭",
+    "date": "2024-01-01T00:00:00"
+  },
+  "He swam the seas before the continents broke water; he once swam over the site of the Tuileries, and Windsor Castle, and the Kremlin.": {
+    "emoji": "🏊‍♂️🌊🌍🏝️💧🏰🇫🇷🏰🇬🇧🏰🇷🇺",
+    "date": "2024-01-01T00:00:00"
+  },
+  "But sperm whales are not every day encountered; while you may, then, you must kill all you can.": {
+    "emoji": "🐋❌📅👀🔍💪🔫🐋💔",
+    "date": "2024-01-01T00:00:00"
+  },
+  "how had the mystic thing been caught? Whisper it not, and I will tell; with a treacherous hook and line": {
+    "emoji": "🤔✨🔮🐟❓🤫🗣️🔍🎣💔🐠",
+    "date": "2024-01-01T00:00:00"
+  },
+  "they saw a falling phantom in the air; and looking down, a little tossed heap of white bubbles in the blue of the sea": {
+    "emoji": "👀👻⬇️🌀💨⚪️🌊💙",
+    "date": "2024-01-01T00:00:00"
+  },
+  "doubting those traditions did not make those traditions one whit the less facts": {
+    "emoji": "🤔❓📜🔍🚫➡️👓🔍👥➡️📊✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "an accident which not seldom happens": {
+    "emoji": "🚗💥🤕🔄",
+    "date": "2024-01-01T00:00:00"
+  },
+  "neither knows where lie the nameless things of which the mystic sign gives forth such hints": {
+    "emoji": "🤷‍♂️❓🌌🔍✨💫🤔🔑🌀🔒📜🌓🌒🔮",
+    "date": "2024-01-01T00:00:00"
+  },
+  "in the midst of the manifold whizzings of a steam-engine in full play, when every flying beam, and shaft, and wheel, is grazing you": {
+    "emoji": "🌪️🚂💨⚙️🔩🔧✨💨🌀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "The head looks a sort of reproachfully at him, with an “Et tu Brute!” expression.": {
+    "emoji": "👤👉😒🗣️➡️👨‍⚖️💔✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "But the mingled, mingling threads of life are woven by warp and woof: calms crossed by storms, a storm for every calm.": {
+    "emoji": "🧶✨🌪️🌊🌈⚡️🌪️🌊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "utterly lost was he to all sense of reverence for the many marvels of their majestic bulk and mystic ways": {
+    "emoji": "🤷‍♂️💫😳✨🌌🦄🌠🏔️💖🔮",
+    "date": "2024-01-01T00:00:00"
+  },
+  "a purse is but a rag unless you have something in it": {
+    "emoji": "👜 ➡️ 🧻 ❌ 🤷‍♂️ 💰 🔒",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Better sleep with a sober cannibal than a drunken Christian.": {
+    "emoji": "😴💤👉🍽️👤🙅‍♂️🍷✝️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "mark of genius": {
+    "emoji": "🧠✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "whereto does all that circumnavigation conduct?": {
+    "emoji": "🔄➡️🌍❓",
+    "date": "2024-01-01T00:00:00"
+  },
+  "you would have thought the craft had two keels—one cleaving the water, the other the air—as the boat churned on through both opposing elements at once": {
+    "emoji": "🛥️🌊✈️⚓️💨🛶🌪️🍃✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "as the ship sailed down to them, they turned and fled with swift precipitancy": {
+    "emoji": "🚢⬇️👥🏃‍♂️💨💨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "And this, good friends, is ambergris, worth a gold guinea an ounce to any druggist.": {
+    "emoji": "🧑‍🤝‍🧑✨🐋💛🏅⚖️💊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "somehow, I never fancied broiling fowls": {
+    "emoji": "🤷‍♂️❓🍗🔥🐔",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I conclude that, like the dyspeptic old woman, he must have “broken his digester.”": {
+    "emoji": "🧑‍🦳💭➡️🤔🔚🧓💔🧠🍽️🔧",
+    "date": "2024-01-01T00:00:00"
+  },
+  "This is what I mean.": {
+    "emoji": "🤔👉📝✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "This whale is not dead; he is only dispirited; out of sorts, perhaps": {
+    "emoji": "🐋❌🪦😔💔🤷‍♂️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Queequeq, my fine friend, does this sort of thing often happen?": {
+    "emoji": "🤝🪸❓🤔🥳✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "carried down alive to wondrous depths, where strange shapes of the unwarped primal world glided to and fro before his passive eyes": {
+    "emoji": "🚶‍♂️⬇️🎉🌊🔍👀✨🔮🌍👻🌪️🌌👁️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "These are hieroglyphical; that is, if you call those mysterious cyphers on the walls of pyramids hieroglyphics": {
+    "emoji": "📝🔤🔍🤔✨🏺🏛️🌄🔒📜",
+    "date": "2024-01-01T00:00:00"
+  },
+  "magical": {
+    "emoji": "🪄✨🌟🔮🌈",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Invisible winged creatures that frolic all round us! Sweet childhood of air and sky! how oblivious were ye of old Ahab’s close-coiled woe!": {
+    "emoji": "🦋👻🦄🕊️🌈🌬️☁️🌟👶🎈✨⛅🌍💔🦅🔍",
+    "date": "2024-01-01T00:00:00"
+  },
+  "sharks also are the invariable outriders of all slave ships crossing the Atlantic, systematically trotting alongside, to be handy in case a parcel is to be carried anywhere, or a dead slave to be decently buried": {
+    "emoji": "🦈➡️🚢🌊🌍💼⚓️📦🪦🪦🪦",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Strike nothing, and stir nothing, but lash everything.": {
+    "emoji": "⚔️❌✨🚫🔄❌, ❌🔄❌☝️, 🔥⚡️🌀🔗👌everything.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "with blue lips and blood-shot eyes the exhausted savage at last climbs up the chains and stands all dripping and involuntarily trembling over the side": {
+    "emoji": "👄💙👁️‍🗨️🩸😩🗡️🔗🧗‍♂️💧💦😰🔗💪",
+    "date": "2024-01-01T00:00:00"
+  },
+  "he had been a great prophet; in their cracked, secret meetings having several times descended from heaven by the way of a trap-door, announcing the speedy opening of the seventh vial": {
+    "emoji": "👨‍🏫✨📜🤫🤝🚪☁️🔔⏳🍶7",
+    "date": "2024-01-01T00:00:00"
+  },
+  "place this reversed skull (scaled down to the human magnitude) among a plate of men’s skulls, and you would involuntarily confound it with them": {
+    "emoji": "🔄💀🔍👨‍🦰💀🍽️💀🤔",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Once more the sermon proceeded.": {
+    "emoji": "🕊️📖➡️🔊😊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "as the short northern day merged into night, we found ourselves almost broad upon the wintry ocean, whose freezing spray cased us in ice": {
+    "emoji": "🌅➡️🌃🌊👉❄️🌊🌨️🔜🧊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "On life and death this old man walked.": {
+    "emoji": "👴⚰️🚶‍♂️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "a young buck with an intelligent looking calf’s head before him, is somehow one of the saddest sights you can see": {
+    "emoji": "🦌👶🤔🐮😢",
+    "date": "2024-01-01T00:00:00"
+  },
+  "And, doubtless, my going on this whaling voyage, formed part of the grand programme of Providence that was drawn up a long time ago": {
+    "emoji": "👤➡️🛳️🐋🌊✨📜🗓️🕰️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Speak, thou vast and venerable head": {
+    "emoji": "🗣️👤🌌💫👴",
+    "date": "2024-01-01T00:00:00"
+  },
+  "something went hot and hissing along every one of their wrists": {
+    "emoji": "🔥💨🤚💨🤚💨🤚💨🤚💨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the signal was set to see what response would be made": {
+    "emoji": "📶🔧👀🤔💬",
+    "date": "2024-01-01T00:00:00"
+  },
+  "there is no one who will speak more respectfully, not to say reverentially, of a broiled fowl than I will": {
+    "emoji": "👤❌🙊🗣️➡️🗣️🙇‍♂️👐🍗💬👌🙋‍♂️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "relinquish this turbulence": {
+    "emoji": "✋🌪️🔚",
+    "date": "2024-01-01T00:00:00"
+  },
+  "until the whale is fairly captured and a corpse": {
+    "emoji": "🕰️🐋➡️🔒🏴‍☠️⚰️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Towards thee I roll, thou all-destroying but unconquering whale": {
+    "emoji": "➡️🦈💥🌊🌀🦈🛑💪🌊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I begged him as well as I could, to accelerate his toilet somewhat, and particularly to get into his pantaloons as soon as possible.In an instant’s compass, great hearts sometimes condense to one deep pang, the sum total of those shallow pains kindly diffused through feebler men’s whole lives.": {
+    "emoji": "🙏👨‍🔧⏩🚽🩳💨💔😢💔👥💪💭💡💖",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Whale-balls for breakfast—don’t forget.": {
+    "emoji": "🐋⚽️🍳—👉❌🔙",
+    "date": "2024-01-01T00:00:00"
+  },
+  "for in many old chronicles whales and dragons are strangely jumbled together, and often stand for each other": {
+    "emoji": "📖🕰️🐋🐉🔄🤔💭👥",
+    "date": "2024-01-01T00:00:00"
+  },
+  "he helplessly rolled away from the wreck he had made; lay panting on his side, impotently flapped with his stumped fin, then over and over slowly revolved like a waning world; turned up the white secrets of his belly": {
+    "emoji": "👨‍✈️😩➡️🚧🛠️💨😮‍💨🌍🔄🔄🔄🔆🤍🔍🦈",
+    "date": "2024-01-01T00:00:00"
+  },
+  "As if struck by some enchanter’s wand, the sleepy ship and every sleeper in it all at once started into wakefulness": {
+    "emoji": "✨🪄😴🚢💤😲🌊🌅",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I am horror-struck at this antemosaic, unsourced existence of the unspeakable terrors of the whale": {
+    "emoji": "😱🦈💀🖼️❌📖😨🌊🐋✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "A word concerning an incident in the last chapter.": {
+    "emoji": "🗣️💬⚠️📝📖✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "against all natural lovings and longings, I so keep pushing, and crowding": {
+    "emoji": "🚫🌿❤️💔➡️💪➡️👥",
+    "date": "2024-01-01T00:00:00"
+  },
+  "as the monomaniac incarnation of all those malicious agencies which some deep men feel eating in them": {
+    "emoji": "👤🔄🌀😈🔍💭🍽️🧠✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "So man’s seconds tick! Oh! how immaterial are all materials!": {
+    "emoji": "🕒👨‍🦰⏳! 😮🌌🔄💫📦💨!",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Drat the file, and drat the bone!": {
+    "emoji": "👎📂💔🦴",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I jerked him now and then from between the whale and ship": {
+    "emoji": "👐🐋🚢",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Ahab had purposely sailed upon the present voyage with the one only and all-engrossing object of hunting the White Whale.": {
+    "emoji": "🛥️🌊🎯🐋⚪️🔍",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Damn me, but all things are queer, come to think of ’em.": {
+    "emoji": "😳🤷‍♂️🤔🌈💭🌀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "What despair in those immovable inscriptions!": {
+    "emoji": "😟📜🛑✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "There were eight whales, an average pod.": {
+    "emoji": "🐋🐋🐋🐋🐋🐋🐋🐋 ➕ 📊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "sage ejaculation": {
+    "emoji": "🌿💧✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "It’s a mutual, joint-stock world, in all meridians.": {
+    "emoji": "🌍🤝💼🤑🗺️✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "It fell at Ahab’s feet.": {
+    "emoji": "🪨👣👑",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Old man of oceans! of all this fiery life of thine, what will at length remain but one little heap of ashes!": {
+    "emoji": "🌊👴🔥🌍❓🗑️🕯️💔🔥🕰️⚰️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "tossing like slumberers in their beds; the ever-rolling waves but made so by their restlessness": {
+    "emoji": "💤🌊😴🛏️🌊🔄💤⚪️🌊💨✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Pushing heavy cannon up mountain defiles, the elephant’s brow is majestic.": {
+    "emoji": "🐘💪🎆🗻➡️💥🔫🌄👑",
+    "date": "2024-01-01T00:00:00"
+  },
+  "he will infallibly lead you to water, if water there be": {
+    "emoji": "👨‍🦰➡️💧🌊, ❓🌊✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "an accident which not seldom happens, and with much less reason": {
+    "emoji": "🚗💥🙈🔄🤷‍♂️💭❌🔍",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the mere act of penning my thoughts of this Leviathan, they weary me, and make me faint with their outreaching comprehensiveness of sweep": {
+    "emoji": "🖊️💭🐋😩💤🌊✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "we at last came to something which there was no mistaking": {
+    "emoji": "👥🎉➡️🔍✨🧐🆗",
+    "date": "2024-01-01T00:00:00"
+  },
+  "No more my splintered heart and maddened hand were turned against the wolfish world.": {
+    "emoji": "💔✋🪓🙅‍♂️🐺🌍",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Look at that hanging lower lip! what a huge sulk and pout is there!": {
+    "emoji": "👀😮👄👇😒😤",
+    "date": "2024-01-01T00:00:00"
+  },
+  "higgledy-piggledy whale statements": {
+    "emoji": "🐋✨🌀🗣️💬",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Is it that by its indefiniteness it shadows forth the heartless voids and immensities of the universe": {
+    "emoji": "❓🌌❓🖤🔲🔆🌌🌌",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Yes, when a fellow’s soaked through, it’s hard to be sensible, that’s a fact.": {
+    "emoji": "👍💧👨‍💼🌧️😓🤔💯",
+    "date": "2024-01-01T00:00:00"
+  },
+  "and with half-stifled melancholy gurglings the spray-column lowers and lowers to the ground—so the last long dying spout of the whale": {
+    "emoji": "🌧️😢💧⬇️🐋💨➡️🌍",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the sperm whale, scientific or poetic, lives not complete in any literature. Far above all other hunted whales, his is an unwritten life.": {
+    "emoji": "🐋🔬📚❌✍️🌊🌌🔝🔍🏴‍☠️🌊✖️📖✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "they were afraid of him": {
+    "emoji": "😨👥👤💔",
+    "date": "2024-01-01T00:00:00"
+  },
+  "But that same image, we ourselves see in all rivers and oceans. It is the image of the ungraspable phantom of life": {
+    "emoji": "🖼️👀🌊🌊➡️🌊🌊🔍👻💫💖",
+    "date": "2024-01-01T00:00:00"
+  },
+  "down there, some ten feet below the level of the deck, the poor harpooneer flounders about, half on the whale and half in the water, as the vast mass revolves like a tread-mill beneath him.": {
+    "emoji": "⬇️🔟👣⬇️🛳️😞🎣🐋💦🔄🌀💪",
+    "date": "2024-01-01T00:00:00"
+  },
+  "What do ye do when ye see a whale, men?": {
+    "emoji": "🤔❓🐳👀👨‍✈️👨‍✈️👨‍✈️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Oh, immortal infancy, and innocency of the azure! Invisible winged creatures that frolic all round us! Sweet childhood of air and sky!": {
+    "emoji": "👶✨🌈💙🦋🕊️🎈🌼🌤️🌌",
+    "date": "2024-01-01T00:00:00"
+  },
+  "every eye counted every ripple": {
+    "emoji": "👁️👁️🔢💧🌊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "power to the tail": {
+    "emoji": "⚡🐍",
+    "date": "2024-01-01T00:00:00"
+  },
+  "we now gazed at the most wondrous phenomenon which the secret seas have hitherto revealed to mankind": {
+    "emoji": "👀✨🌊🌌🔍👤💫",
+    "date": "2024-01-01T00:00:00"
+  },
+  "There’s hogsheads of sperm ahead": {
+    "emoji": "🐖💧➡️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "all at once the exhausted harpooneer hears the exciting cry—“Stand up, and give it to him!”": {
+    "emoji": "🌊😩🎣🚀🗣️🏃‍♂️✊🐋",
+    "date": "2024-01-01T00:00:00"
+  },
+  "nothing but a whale, or a gale, or some violent, ungovernable, unintelligent destroyer": {
+    "emoji": "🐋💨🌊🤖💥🔪",
+    "date": "2024-01-01T00:00:00"
+  },
+  "A continual cascade played at the bows; a ceaseless whirling eddy in her wake": {
+    "emoji": "🎶💧🎻🌊💨🔄🌪️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "far more terrible is it to behold, when fathoms down in the sea, you see some sulky whale, floating there suspended, with his prodigious jaw, some fifteen feet long, hanging straight down at right-angles with his body": {
+    "emoji": "🌊🐋😠⬇️⚖️🦈📏🔽📏🔽",
+    "date": "2024-01-01T00:00:00"
+  },
+  "regarded discreetly and coolly, seems it not but a mad idea, this; that in the broad boundless ocean, one solitary whale, even if encountered, should be thought capable of individual recognition from his hunter": {
+    "emoji": "🤔🌊🐋💭😵‍💫🤷‍♂️🔍🎣",
+    "date": "2024-01-01T00:00:00"
+  },
+  "let me look into a human eye; it is better than to gaze into sea or sky; better than to gaze upon God": {
+    "emoji": "👀🔍👁️👤✨🌊☁️🌌✨🙏",
+    "date": "2024-01-01T00:00:00"
+  },
+  "it was plain that unless artificially upheld, the body would at once sink to the bottom": {
+    "emoji": "🪤➡️👤⬇️🕳️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "amid all the smoking horror and diabolism of a sea-fight, sharks will be seen longingly gazing up to the ship’s decks": {
+    "emoji": "🌊⚓️🔥😱🦈👀🛥️🛳️✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "dismasted man never entirely loses the feeling of his old spar, but it will be still pricking him at times": {
+    "emoji": "🧑‍✈️⚓️❌🪝💔🔄🕰️🔙✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "So long as a man’s eyes are open in the light, the act of seeing is involuntary": {
+    "emoji": "👀✨👨‍🦰🌞👁️➡️🔄",
+    "date": "2024-01-01T00:00:00"
+  },
+  "it’s against my principles to drink with the man I’ve diddled": {
+    "emoji": "🙅‍♀️🍹🚫👨‍❤️‍💋‍👨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "beast, boat, or stone, down it goes all incontinently that foul great swallow of his, and perisheth in the bottomless gulf of his paunch": {
+    "emoji": "🐉🛥️🪨⬇️💨😱💔🤢🕳️🍽️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I myself am a savage, owning no allegiance but to the King of the Cannibals": {
+    "emoji": "🤘🏽👤🏞️🤴🏽🍽️🌴🦁",
+    "date": "2024-01-01T00:00:00"
+  },
+  "we whalemen of America now outnumber all the rest of the banded whalemen in the world": {
+    "emoji": "🇺🇸🐋👨‍✈️👥🔝🌍🌊🐋👥✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "It’s ominous, thinks I.": {
+    "emoji": "😟🔮🤔",
+    "date": "2024-01-01T00:00:00"
+  },
+  "You must go home and be born over again; you don’t know how to cook a whale-steak yet.": {
+    "emoji": "🏠➡️👶🔄; 🤷‍♂️🍳🐋🥩❌",
+    "date": "2024-01-01T00:00:00"
+  },
+  "you had best not be too fastidious in your curiosity touching this Leviathan": {
+    "emoji": "👤❌⚡️😌🔍🦑🌊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "be sure, exalted to Jove’s high seat, the great Sperm Whale shall lord it": {
+    "emoji": "✅👑➡️☁️🔝, 🐋💪👑",
+    "date": "2024-01-01T00:00:00"
+  },
+  "sally out in canoes to give chase to the Leviathan": {
+    "emoji": "🛶👩‍🦰🏞️➡️🦑🌊👉🐍",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the plague, as he called it, was at his sole command": {
+    "emoji": "🦠, 🧔🏻‍♂️👉🗣️, 🟡👁️🕴️✨.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Such lovely leewardings! They must lead somewhere—to something else than common land, more palmy than the palms.": {
+    "emoji": "🌅💖🏞️🚶‍♂️➡️🗺️✨➡️🌴🌴🌴🌿🌞",
+    "date": "2024-01-01T00:00:00"
+  },
+  "This is my substitute for pistol and ball.": {
+    "emoji": "🔫➡️⚽️🎱",
+    "date": "2024-01-01T00:00:00"
+  },
+  "With a long, weary hoist the jaw is dragged on board, as if it were an anchor": {
+    "emoji": "🧗‍♂️💪😓⚓️🔗📦",
+    "date": "2024-01-01T00:00:00"
+  },
+  "This weapon is always kept as sharp as possible; and when being used is occasionally honed, just like a razor.": {
+    "emoji": "🗡️✨🪒🔪🔧⚔️💡🪄",
+    "date": "2024-01-01T00:00:00"
+  },
+  "The Titans, they say, hummed snatches when chipping out the craters for volcanoes": {
+    "emoji": "🪐👹🎶🪨🔨🌋✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the springs and motives which being cunningly presented to me under various disguises, induced me to set about performing the part I did": {
+    "emoji": "🌸✨🕵️‍♂️🎭👉🌀🎭❓💭💼🔄🎬💪✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Crack, crack, old ship! so long as thou crackest, thou holdest!": {
+    "emoji": "🦴🔊⛴️! 🕰️👋🏽🥚💥, 🕰️📜🌊🌊!",
+    "date": "2024-01-01T00:00:00"
+  },
+  "How can’st thou endure without being mad?": {
+    "emoji": "🤷‍♂️😩❓😵‍💫💭💔",
+    "date": "2024-01-01T00:00:00"
+  },
+  "At one time the greatest whaling people in the world, the Dutch and Germans are now among the least": {
+    "emoji": "🕰️🌊🐋🇳🇱👥🤝🇩🇪❌📉",
+    "date": "2024-01-01T00:00:00"
+  },
+  "knaves, fools, and murderers there may be": {
+    "emoji": "🥸🤡🔪",
+    "date": "2024-01-01T00:00:00"
+  },
+  "a dead sperm whale, moored by night to a whaleship at sea": {
+    "emoji": "🐋⚰️🌊🌙🚢🐳",
+    "date": "2024-01-01T00:00:00"
+  },
+  "mark the stranger’s evil eye": {
+    "emoji": "👁️👤😈✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "up comes the bucket again, all bubbling like a dairy-maid’s pail of new milk": {
+    "emoji": "🪣⬆️💧💨🥛👩‍🌾✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "a newly murdered thing of the sea": {
+    "emoji": "🆕🔪🐚🌊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Let faith oust fact; let fancy oust memory; I look deep down and do believe.": {
+    "emoji": "🙏✊📉💭🧘‍♂️🔍✨💖",
+    "date": "2024-01-01T00:00:00"
+  },
+  "something that regularly begins at the beginning, and is at the middle when midway, and comes to an end at the conclusion": {
+    "emoji": "🔄📅👉🏽🔄⏳🚶‍♂️➡️🔚📝",
+    "date": "2024-01-01T00:00:00"
+  },
+  "here was the very spot for cheap lodgings": {
+    "emoji": "🏡💰🛏️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "for the millionth time we say amen with Solomon—Verily there is nothing new under the sun": {
+    "emoji": "🤲💰🔁✝️💭🕶️☀️✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "At last, gush after gush of clotted red gore, as if it had been the purple lees of red wine, shot into the frighted air": {
+    "emoji": "🍷💧💦🔴😱🌬️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "having little or no money in my purse, and nothing particular to interest me on shore, I thought I would sail about a little": {
+    "emoji": "💸👛🪙📉🌊🛥️🌅🤔💭",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the mother’s pouring milk and blood rivallingly discolour the sea for rods": {
+    "emoji": "👩‍👧🥛🩸🌊🏴‍☠️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "so strange a dreaminess did there then reign all over the ship and all over the sea": {
+    "emoji": "🌊🛳️💭✨😮‍💨🌌🌊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "But it is not so.": {
+    "emoji": "🙅‍♂️❌✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "That same ocean rolls now; that same ocean destroyed the wrecked ships of last year.": {
+    "emoji": "🌊➡️🌊💔🚢🔚📅",
+    "date": "2024-01-01T00:00:00"
+  },
+  "that first adventurous little sloop put forth, partly laden with imported cobblestones—so goes the story—to throw at the whales": {
+    "emoji": "🚤✨🌊🪨🐋",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I think it high time to take that individual aside and argue the point with him.": {
+    "emoji": "🤔🕒➡️🚶‍♂️👤👉💬⚖️💭🗣️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the tallest boys stand in awe of you": {
+    "emoji": "👦👦🏽🗼😲🌟💖",
+    "date": "2024-01-01T00:00:00"
+  },
+  "that was freely given to the waves": {
+    "emoji": "🌊✨🤲💙",
+    "date": "2024-01-01T00:00:00"
+  },
+  "this critical act is not always unattended with the saddest and most fatal casualties": {
+    "emoji": "⚠️📜❌👀💔😢💀😞",
+    "date": "2024-01-01T00:00:00"
+  },
+  "random allusions to whales": {
+    "emoji": "🔄🌊🐋",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Yes, these eyes are windows, and this body of mine is the house. What a pity they didn’t stop up the chinks and the crannies though": {
+    "emoji": "👁️🏠💔🚪🪟🔍🌬️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Fain am I to stagger to this emprise under the weightiest words of the dictionary.": {
+    "emoji": "😅🙋‍♂️➡️😵🏋️‍♂️💼📚💬📖",
+    "date": "2024-01-01T00:00:00"
+  },
+  "It was the whiteness of the whale that above all things appalled me.": {
+    "emoji": "🐋⚪😱",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Every sailor swore he saw it once, but not a second time.": {
+    "emoji": "🌊🚢👨‍✈️🗣️👀1️⃣❌2️⃣",
+    "date": "2024-01-01T00:00:00"
+  },
+  "more tight than a harpstring": {
+    "emoji": "🎸➡️🔗❤️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I found myself unwittingly squeezing my co-laborers’ hands in it, mistaking their hands for the gentle globules.": {
+    "emoji": "🤲🤚🤝🤷‍♂️💼✨💦🤚💞👐",
+    "date": "2024-01-01T00:00:00"
+  },
+  "what matters it, after all?": {
+    "emoji": "🤔❓💭✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the picture lies thus tranced": {
+    "emoji": "🖼️🤥💤✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "There is, one knows not what sweet mystery about this sea": {
+    "emoji": "🌊🤔✨❓🍬🔍",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I am darkness leaping out of light, leaping out of thee!": {
+    "emoji": "🌑💨✨💥🕺💫🫂",
+    "date": "2024-01-01T00:00:00"
+  },
+  "A stark, bewildered feeling, as of death, came over me.": {
+    "emoji": "😳🌫️😵‍💫💀✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "That’s queer, too.": {
+    "emoji": "🤔🌈✌️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "In his fiery eyes of scorn and triumph, you then saw Ahab in all his fatal pride.": {
+    "emoji": "🔥👀😡🏆👀🧑‍✈️😎⚰️👑",
+    "date": "2024-01-01T00:00:00"
+  },
+  "To scan the lines of his face, or feel the bumps on the head of this Leviathan; this is a thing which no Physiognomist or Phrenologist has as yet undertaken.": {
+    "emoji": "👁️📏🖊️😮👤🔍😳👨‍🔬🧠🧑‍🔬⚖️💭❓",
+    "date": "2024-01-01T00:00:00"
+  },
+  "divide the spine": {
+    "emoji": "➗ 🦴",
+    "date": "2024-01-01T00:00:00"
+  },
+  "It was a Saturday night in December.": {
+    "emoji": "🌙🌌🛋️❄️📆✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Drink, ye harpooneers! drink and swear, ye men that man the deathful whaleboat’s bow—Death to Moby Dick!": {
+    "emoji": "🥤🍻👨‍✈️⚓️🛥️💀🦈☠️💔🐳🔥",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I abandon the glory and distinction of such offices to those who like them.": {
+    "emoji": "🙅‍♂️🏆🚪✨👔➡️🤷‍♂️❤️📜",
+    "date": "2024-01-01T00:00:00"
+  },
+  "He sleeps in his boots, don’t he?": {
+    "emoji": "😴👢❓",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the Yankees in one day, collectively, kill more whales than all the English, collectively, in ten years": {
+    "emoji": "⚾️🗽➡️📅🔪🐋💔🔝🇬🇧🤝🕙🔟🗓️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "incommunicable contemplations": {
+    "emoji": "🤐💭✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "this whole enormous boneless mass is as one wad": {
+    "emoji": "🤯👐🍖➡️1🌀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I am tormented with an everlasting itch for things remote. I love to sail forbidden seas, and land on barbarous coasts.": {
+    "emoji": "😣🌊🔍✨🗺️❤️⛵🚫🌊🏝️⚔️🌍",
+    "date": "2024-01-01T00:00:00"
+  },
+  "And after sermon she and I did stay behind them in the pew, and went out by ourselves a good while after them, which we judge a very fine project hereafter to avoyd contention.": {
+    "emoji": "⛪️👩‍🦰🤝🪑🚶‍♂️⏳🏃‍♀️💡📅🔀✌️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Having my old black suit new furbished, I was pretty neat in clothes today, and my boy, his old suit new trimmed, very handsome.": {
+    "emoji": "👔🖤✨🆕👔🔧👌🧥👦👔⚫✨🆕✂️😎",
+    "date": "2024-01-01T00:00:00"
+  },
+  "So to supper, which is also well served in. We had a lobster to supper, with a crabb Pegg Pen sent my wife this afternoon, the reason of which we cannot think; but something there is of plot or design in it, for we have a little while carried ourselves pretty strange to them.": {
+    "emoji": "🍽️🦞🍽️🦀📦🤔💭🕵️‍♀️🕵️‍♂️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "To the play, where coming late, and meeting with Sir W. Pen, who had got room for my wife and his daughter in the pit, he and I into one of the boxes, and there we sat and heard “The Little Thiefe,” a pretty play and well done.": {
+    "emoji": "🎭🏃‍♂️⏰🤝🤵🎭🙋‍♀️🪑👧🎭👨‍🦳🤝🪑🎟️🎭👂👀👉🎭🧒🌟👍",
+    "date": "2024-01-01T00:00:00"
+  },
+  "In the middle of the play my Lady Paulina, who had taken physique this morning, had need to go forth, and so I took the poor lady out and carried her to the Grange, and there sent the maid of the house into a room to her, and she did what she had a mind to, and so back.": {
+    "emoji": "🎭👩‍🎨🩺🌅🚶‍♀️🏡👧🚪↔️🙏🤓🔙",
+    "date": "2024-01-01T00:00:00"
+  },
+  "In their coach I took them to Islington, and then, after a walk in the fields, I took them to the great cheese-cake house and entertained them, and so home.": {
+    "emoji": "🚍➡️📍🧍‍♂️🚶‍♂️🌾➡️🧀🍰🏠🎉🏠",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Met Mr. Sanchy, Smithes, Gale, and Edlin at the play, but having no great mind to spend money, I left them there.": {
+    "emoji": "👨‍💼🎭👔👓🍃💰❌🏃‍♂️🚪",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I find myself involuntarily pausing before coffin warehouses, and bringing up the rear of every funeral I meet": {
+    "emoji": "🤔⏸️⚰️🏢➡️🚶‍♂️⚰️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "a sullen white surf beat against its steep sides; then all collapsed": {
+    "emoji": "🏝️🌊🤍☁️🌊🔊⛰️⬇️😞👉⬇️🔚",
+    "date": "2024-01-01T00:00:00"
+  },
+  "WHALING VOYAGE BY ONE ISHMAEL.": {
+    "emoji": "🐋🛳️🌊👤📜",
+    "date": "2024-01-01T00:00:00"
+  },
+  "At home and at the office all day.": {
+    "emoji": "🏠💻🏢🕒",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I made up my mind that if it so turned out that we should sleep together, he must undress and get into bed before I did.": {
+    "emoji": "🧠🤔➡️🛏️😴👉👕🩳➡️🛏️👨🏻🛌👉🔜👨🏼",
+    "date": "2024-01-01T00:00:00"
+  },
+  "if this vast local power in the tendinous tail were not enough, the whole bulk of the leviathan is knit over with a warp and woof of muscular fibres and filaments": {
+    "emoji": "🤔✨💪🐋🌀🔗🔋🌍📈🌊🔗💪🦴",
+    "date": "2024-01-01T00:00:00"
+  },
+  "By barge Sir George, Sir Williams both and I to Deptford, and there fell to pay off the Drake and Hampshire, then to dinner, Sir George to his lady at his house, and Sir Wm. Pen to Woolwich, and Sir W. Batten and I to the tavern, where much company came to us and our dinner.": {
+    "emoji": "🛶🤴🤴🧔➡️🌊➡️📍🎯🍽️🤴➡️👸🏠🤴➡️📍🍷🤵🤵➡️🍻➡️👥🍽️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I was much troubled to see a dead man lie floating upon the waters, and had done (they say) these four days, and nobody takes him up to bury him, which is very barbarous.": {
+    "emoji": "😟🧔⚰️🔍🌊🕒4️⃣📅👥❌👆⚰️⚰️😔🔪",
+    "date": "2024-01-01T00:00:00"
+  },
+  "in that dreamy mood losing all consciousness, at last my soul went out of my body": {
+    "emoji": "😴💭✨😌🧠➖😶👻➡🕊️💫",
+    "date": "2024-01-01T00:00:00"
+  },
+  "And so home to my office, and there did promise to drink no more wine but one glass a meal till Whitsuntide next upon any score.": {
+    "emoji": "🏠➡️🏢📜🍷🚫1⃣🥂🍽️⏳🔜⛪🔜🔢💰",
+    "date": "2024-01-01T00:00:00"
+  },
+  "The great talk is, that the Spaniards and the Hollanders do intend to set upon the Portuguese by sea, at Lisbon, as soon as our fleet is come away; and by that means our fleet is not likely to come yet these two months or three; which I hope is not true.": {
+    "emoji": "🗣️🇪🇸🤝🇳🇱⚓️⚔️🇵🇹🌊📍🇵🇹⛴️🛡️📅2️⃣🕛➕3️⃣🙏❌ℹ️🙅‍♂️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "So to dinner, and in comes uncle Fenner and the two Joyces. I sent for a barrel of oysters and a breast of veal roasted, and were very merry; but I cannot down with their dull company and impertinent.": {
+    "emoji": "🍽️👨‍👦‍👦🦪🍖😄🙄😒",
+    "date": "2024-01-01T00:00:00"
+  },
+  "By the way home and on Ludgate Hill there being a stop I bought two cakes, and they were our supper at home.": {
+    "emoji": "🏠🛣️⛰️🚏🛑🍰🍰🍽️🏡",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Sir George showed me an account in French of the great famine, which is to the greatest extremity in some part of France at this day, which is very strange.": {
+    "emoji": "🤴📜🇫🇷📰🗣️🍞➡️😞🇫🇷💀📅😲",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Thou knowest not how came ye, hence callest thyself unbegotten": {
+    "emoji": "🙈🤔❓🌌➡️🧙‍♂️🤷‍♂️♾️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Through its inexpressible, strange eyes, methought I peeped to secrets which took hold of God.": {
+    "emoji": "🌌👁️‍🗨️🧐🔍🤫✨🙏",
+    "date": "2024-01-01T00:00:00"
+  },
+  "a hideous and intolerable allegory": {
+    "emoji": "😖❌🧟‍♂️📖",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Yesterday came Col. Talbot with letters from Portugall, that the Queen is resolved to embarque for England this week.": {
+    "emoji": "🗓️➡️🤵📜🇵🇹, 👑🚢🇬🇧📅.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Nippers. Strictly this word is not indigenous to the whale’s vocabulary.": {
+    "emoji": "🔧❌🐋📖❌🈶",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Hurrah for the white-ash breeze!": {
+    "emoji": "🎉👏⚪🌿💨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "My Lord Windsor came to us to discourse of his affairs, and to take his leave of us; he being to go Governor of Jamaica with this fleet that is now going.": {
+    "emoji": "🙇‍♂️🏰🧔➡️🗣️📜✍️✈️🏝️🫡⚓️🛳️🌊⌛",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Ye see an old man cut down to the stump; leaning on a shivered lance; propped up on a lonely foot. ’Tis Ahab": {
+    "emoji": "👴🪓🌳🍂🔪🤺🪝🚶‍♂️🚶‍♂️🦶💔🏴‍☠️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Late at the office. Home with my mind full of business. So to bed.": {
+    "emoji": "🌆🏢👔💼🛋️🤯💭🛏️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "were you to turn the whole affair upside down, it would still be pretty much the same thing": {
+    "emoji": "🔄 🤔 🔄 🔄 🤷‍♂️🤷‍♀️ 🤷 💁‍♂️💁‍♀️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Up early to my lute and a song.": {
+    "emoji": "🔝🌅🎼🎸🎶",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I look, you look, he looks; we look, ye look, they look.": {
+    "emoji": "👁️👀👁️‍🗨️👀👁️‍🗨️; 👀👁️👁️‍🗨️👀👁️‍🗨️.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "With Sir W. Pen by water to Deptford; and among the ships now going to Portugall with men and horse, to see them dispatched.": {
+    "emoji": "🧔‍♂️🚣‍♂️➡️🚢⚓🇵🇹👥🐎👀✔️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Methinks my body is but the lees of my better being.": {
+    "emoji": "🤔👉💪🧍➡️☕🟰👍➡️🎭🧠",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Captn. Minnes and the other Captains that were with us tell me that negros drowned look white and lose their blackness, which I never heard before.": {
+    "emoji": "🧑‍✈️🔍🤿➡️⚫️🌊➡️⚪️😮",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Do you think the archangel Gabriel thinks anything the less of me": {
+    "emoji": "🤔😇🤔💭👉🤷‍♂️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "And so back to Greenwich by water, and there while something is dressing for our dinner, Sir William and I walked into the Park, where the King hath planted trees and made steps in the hill up to the Castle, which is very magnificent.": {
+    "emoji": "🔙🌊🛥️⚓🌳🤵🚶‍♂️🏞️🌳🤴🌲🪜🏰🌟",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I did get a bever, an old one, but a very good one, of Sir W. Batten, for which I must give him something; but I am very well pleased with it.": {
+    "emoji": "😄👍🦫👉👴✨👌👤🐻💵😊🎁",
+    "date": "2024-01-01T00:00:00"
+  },
+  "ambergris is supposed to be the cause, and by others the effect, of the dyspepsia in the whale": {
+    "emoji": "🏝️💼🐋➡️😖🐋📉",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Now this ambergris is a very curious substance": {
+    "emoji": "🕰️🔍🌊🐋💎🤔",
+    "date": "2024-01-01T00:00:00"
+  },
+  "My intention being to go this morning to White Hall to hear South, my Lord Chancellor’s chaplain, the famous preacher and oratour of Oxford, it did rain, and the wind against me, that I could by no means get a boat or coach to carry me.": {
+    "emoji": "🌧️🚫🛥️🚗💨➡️🏛️👂👨‍⚖️🗣️🎓👉💨💨🧭⛔",
+    "date": "2024-01-01T00:00:00"
+  },
+  "To White Hall to Sir G. Carteret, and so to the Chappell, where I challenged my pew as Clerk of the Privy Seal and had it.": {
+    "emoji": "🏛️➡️🤵‍♂️🛡️➡️⛪🪪👨‍💼🔒📜✔️🪑",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Walked home with Mr. Blagrave to his old house in the Fishyard, and there he had a pretty kinswoman that sings, and we did sing some holy things, and afterwards others came in and so I left them, and by water through the bridge (which did trouble me) home.": {
+    "emoji": "🚶‍♂️🏠👨‍🦳🏡🐟🧑‍🎤🎶🙏🎶➕👫🎤➡️🏠🚤🌉😟🏠",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I attempted to persuade my wife in bed to go to Brampton this week, but she would not, which troubles me, and seeing that I could keep it no longer from her, I told her that I was resolved to go to Portsmouth tomorrow.": {
+    "emoji": "🙋‍♂️💭💬👉👩‍❤️‍👨🛌➡️🚌➡️🗓️🏙️🚫😟🤐❌👉👩🗣️🛳️🏙️➡️🗓️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Sir Thos. Crew tells me how my Lady Duchess of Richmond and Castlemaine had a falling out the other day; and she calls the latter Jane Shore, and did hope to see her come to the same end that she did.": {
+    "emoji": "🤵‍♂️🎩🗣️🤔🤷‍♀️👸🏰😡👩‍🦳😡👩💬⛓️💭👀➡️🔚🛑",
+    "date": "2024-01-01T00:00:00"
+  },
+  "you may fancy, for yourself, how it would fare with you, did you sideways survey objects through your ears": {
+    "emoji": "👂👀🔄🤔📐🔭🦻🔍",
+    "date": "2024-01-01T00:00:00"
+  },
+  "My Lord Crew told me that news was come that the Queen is landed; at which I took leave, and by coach hurried to White Hall, the bells ringing in several places; but I found there no such matter, nor anything like it.": {
+    "emoji": "🙏👑🗣️📩🚢👑🛬; 👋🚗💨🏛️🔔🔔🔔📍❌❓📰🚫📍❌🤷‍♂️.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "see what we whalemen are, and have been": {
+    "emoji": "👀🌊🐋👨‍✈️🤔🕰️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the word ambergris is but the French compound for grey amber, yet the two substances are quite distinct": {
+    "emoji": "🔤🐋🇫🇷➕⚪🟠, ➡️2️⃣🧪🚫⬇️🔄",
+    "date": "2024-01-01T00:00:00"
+  },
+  "If your bitterest foe were walking straight towards you, with dagger uplifted in broad day, you would not be able to see him": {
+    "emoji": "👀❌🤝🗡️💔➡️👤🕛🌞, 👁️❌👤",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I cannot bawl very heartily and work very recklessly at one and the same time.": {
+    "emoji": "🙅‍♂️😢➕💪😮‍💨➕⏰✨⌛",
+    "date": "2024-01-01T00:00:00"
+  },
+  "After taking leave of my wife, which we could hardly do kindly, because of her mind to go along with me, Sir W. Pen and I took coach and so over the bridge to Lambeth, W. Bodham and Tom Hewet going as clerks to Sir W. Pen, and my Will for me.": {
+    "emoji": "👋❤️🚗🌉➡️🏠🧔🚗🧔📜➡️🧔🏢🔏🧑",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Such a portentous and mysterious monster roused all my curiosity.": {
+    "emoji": "🐉🤔👀❓",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Utter confusion exists among the historians": {
+    "emoji": "🤯🤷‍♂️📚❓",
+    "date": "2024-01-01T00:00:00"
+  },
+  "He, among good Storys, telling us a story of the monkey that got hold of the young lady’s cunt as she went to stool to shit, and run from under her coats and got upon the table, which was ready laid for supper after dancing was done.": {
+    "emoji": "🙊💁‍♀️🍑🚽💩🏃‍♀️🕴️👗🍽️🕺💃🌙",
+    "date": "2024-01-01T00:00:00"
+  },
+  "We came to Gilford and there passed our time in the garden, cutting of sparagus for supper, the best that ever I eat in my life but in the house last year.": {
+    "emoji": "🧑‍🤝‍🧑🏡🌷🕰️✂️🥦🍽️😋👍🏠🔙🕰️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "As you behold it, you involuntarily yield the immense superiority to him, in point of pervading dignity.": {
+    "emoji": "👀🤲🤯👑📈😌🧍‍♂️💼🌌✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "in the whale the sense of touch is concentrated in the tail": {
+    "emoji": "🐋👆👉🦵🎯🚫🖐️🐋👉🐟🚩",
+    "date": "2024-01-01T00:00:00"
+  },
+  "this labyrinth is indisputable": {
+    "emoji": "🌌🌀✅",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Up early, and to Petersfield, and there dined well; and thence got a countryman to guide us by Havant, to avoid going through the Forest; but he carried us much out of the way.": {
+    "emoji": "☀️⏰➡️🚗🍽️😊➡️👨‍🌾🗺️➡️🌳❌➡️😵‍🔄",
+    "date": "2024-01-01T00:00:00"
+  },
+  "to chase that white whale on both sides of land, and over all sides of earth, till he spouts black blood and rolls fin out": {
+    "emoji": "🏃‍♂️🐋⬜️🌍➡️🌍🔄🌊🔄🌪️🩸⚫🐋🌀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the audacity of these corsairs has of late been somewhat repressed": {
+    "emoji": "😲🏴‍☠️💪💥📉",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Upon our coming we sent away an express to Sir W. Batten to stop his coming, which I did project to make good my oath, that my wife should come if any of our wives came, which my Lady Batten did intend to do with her husband.": {
+    "emoji": "📅➡️📨✉️🚫👨‍✈️Sir W. Batten🛑➡️🚶‍♂️📅🤔🤞💍👩⚖️🚪👰🧍‍♀️🧑‍🤝‍🧑🚪,👰Lady Batten📅👫📅🙋‍♀️🧔⚓️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "we thus tore a white gash in the sea, on all sides menaced as we flew, by the crazed creatures to and fro rushing about us": {
+    "emoji": "🌊🩸⛵️⚓️🌊🤯🐟⚔️💨💥🚤😨🌀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "The Doctor and I lay together at Wiard’s, the chyrurgeon’s, in Portsmouth, his wife a very pretty woman.": {
+    "emoji": "🧑‍⚕️🛌🧑📍💑➡️🩺🏠,👩‍⚕️🏢,📍🚢🌊,👰😊👩",
+    "date": "2024-01-01T00:00:00"
+  },
+  "in the forehead’s wrinkles, you seem to track the antlered thoughts descending there to drink, as the Highland hunters track the snow prints of the deer": {
+    "emoji": "👴🤔🦌💭⬇️🚶‍♂️🌨️🦌👣🏴🦌🕵️‍♂️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "when they stood their long night watches, his officers and men must have some nearer things to think of than Moby Dick": {
+    "emoji": "🌙👀🕰️➡️😴🎣👨‍✈️👨‍🦱🤔➕➡️🐋",
+    "date": "2024-01-01T00:00:00"
+  },
+  "We lay very well and merrily; in the morning, concluding him to be of the eldest blood and house of the Clerkes, because that all the fleas came to him and not to me.": {
+    "emoji": "😴🎉🌞🤔🩸🏠🦟➡️🧍‍♂️🚫🧍‍♂️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the main body of the crew striking up a wild chorus, now commence heaving in one dense crowd at the windlass": {
+    "emoji": "🧑‍🚀👥🎶🌿🙌🚶‍♂️👥⚓️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "All of us to the Pay-house; but the books not being ready, we went to church to the lecture, where there was my Lord Ormond and Manchester, and much London company, though not so much as I expected.": {
+    "emoji": "👥➡️🏦; 📚❌⏳, ➡️⛪🎤, 👀🤴🕴️&🌆🧑‍🤝‍🧑, 🤔❌📈.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "It flashed like a bleached bone. What the devil’s the matter with me?": {
+    "emoji": "⚡️💀❓😈❓",
+    "date": "2024-01-01T00:00:00"
+  },
+  "W. Pen and I walked to the King’s Yard, and there lay at Mr. Tippets’s, where exceeding well treated.": {
+    "emoji": "👫🚶‍♂️➡️👑🛤️, 🏡📍Mr.🍽️, 😊🤝",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the wild thrilling sounds that were heard, were the voices of newly drowned men in the sea": {
+    "emoji": "🌊🔊😱👥🔊, 👤🔊👥🌊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I now demand of you to speak out": {
+    "emoji": "🫴🗣️❗",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I don’t fancy having a man smoking in bed with me. It’s dangerous. Besides, I ain’t insured.": {
+    "emoji": "🚫👨🚬🛏️😳🔥❌😬💼",
+    "date": "2024-01-01T00:00:00"
+  },
+  "But who could show a cheek like Queequeg?": {
+    "emoji": "🤔🤷‍♂️🎭🧔",
+    "date": "2024-01-01T00:00:00"
+  },
+  "All the morning at Portsmouth, at the Pay, and then to dinner, and again to the Pay.": {
+    "emoji": "🌅⏰➡️⚓💰➡️🍽️➡️💰",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Got the Doctor to go lie with me, and much pleased with his company; but I was much troubled in my eyes, by reason of the healths I have this day been forced to drink.": {
+    "emoji": "👨‍⚕️➡️🛌😊👀😩🍷🥂🔫🍻",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the harpoon, whose other naked, barbed end slopingly projects from the prow": {
+    "emoji": "🪝➡️🛥️📏",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Sir George and I, and his clerk Mr. Stephens, and Mr. Holt our guide, over to Gosport; and so rode to Southampton.": {
+    "emoji": "🤴👨‍💼🧑‍💼+🏇→🗺️🚴‍♂️→📍",
+    "date": "2024-01-01T00:00:00"
+  },
+  "In our way, besides my Lord Southampton’s parks and lands, which in one view we could see 6,000l. per annum, we observed a little church-yard, where the graves are accustomed to be all sowed with sage.": {
+    "emoji": "🏞️🛤️👑👀6️⃣0️⃣0️⃣0️⃣💷/📅⛪️🪦🌿",
+    "date": "2024-01-01T00:00:00"
+  },
+  "A sound like the moaning in squadrons over Asphaltites of unforgiven ghosts of Gomorrah, ran shuddering through the air.": {
+    "emoji": "🔊👻🌫️🛣️🪦🏴‍☠️🌀😨💨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "At Southampton we went to the Mayor’s and there dined, and had sturgeon of their own catching the last week, which do not happen in twenty years, and it was well ordered.": {
+    "emoji": "🏙️🍴👨‍⚖️🍽️🐟⏳🗓️2️⃣0️⃣🗓️👌",
+    "date": "2024-01-01T00:00:00"
+  },
+  "They brought us also some caveare, which I attempted to order, but all to no purpose, for they had neither given it salt enough, nor are the seedes of the roe broke, but are all in berryes.": {
+    "emoji": "👥🛍️🐟🧂❌⚠️🥄❌🌊🥚🟠🔍📉🍇",
+    "date": "2024-01-01T00:00:00"
+  },
+  "The towne is one most gallant street, and is walled round with stone, &c., and Bevis’s picture upon one of the gates; many old walls of religious houses, and the key, well worth seeing.": {
+    "emoji": "🏙️🏛️🔝🛤️🏗️🧱🔄⚔️🧱🖼️🚪🏰🏛️🕍👀👁️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "After dinner to horse again, being in nothing troubled but the badness of my hat, which I borrowed to save my beaver.": {
+    "emoji": "🍽️➡️🐎🔙😌🚫😟🧢😞📉🎩🔄💰🦫",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I always go to sea as a sailor, because they make a point of paying me for my trouble, whereas they never pay passengers a single penny": {
+    "emoji": "🧭🚢🧑‍✈️💰➡️😌💼❌🧳💸",
+    "date": "2024-01-01T00:00:00"
+  },
+  "prevent all communications": {
+    "emoji": "🚫📞📧💬",
+    "date": "2024-01-01T00:00:00"
+  },
+  "The more I consider this mighty tail, the more do I deplore my inability to express it.": {
+    "emoji": "🤔🐋👉😔📉🗣️❗",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Sir W. Pen got trimmed before me, and so took the coach to Portsmouth to wait on my Lord Steward to church, and sent the coach for me back again.": {
+    "emoji": "🤵✂️🚶‍♂️➡️🚌➡️🏙️➡️⛪👑⬅️🚌↩️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "her only friend her bitterest foe": {
+    "emoji": "👩‍❤️‍👩🔄😠",
+    "date": "2024-01-01T00:00:00"
+  },
+  "At chappell we had a most excellent and eloquent sermon. And here I spoke and saluted Mrs. Pierce, but being in haste could not learn of her where her lodgings are, which vexes me.": {
+    "emoji": "⛪👍🗣️📜😊🙋‍♂️🤝👩‍🦳🏃❓🏠😤",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the rest were buried before they died; you sail upon their tomb": {
+    "emoji": "💀⚰️⏳⛵⚰️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "After dinner Sir W. Batten and I, the Doctor, and Ned Pickering by coach to the Yard, and there on board the Swallow in the dock hear our navy chaplain preach a sad sermon, full of nonsense and false Latin; but prayed for the Right Honourable the principal officers.": {
+    "emoji": "🍽️🐟🚶‍♂️🔬🧑‍⚕️🚖🏠🚢🗣️😔📜🤦‍♂️👎🙏🤵🔥",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Back again by coach to Portsmouth, and then visited the Mayor, Mr. Timbrell, our anchor-smith, who showed us the present they have for the Queen; which is a salt-sellar of silver, the walls christall, with four eagles and four greyhounds standing up at the top to bear up a dish.": {
+    "emoji": "🔙🚌➡️🛳️🏙️,👨‍⚖️🤝👨‍🔧🛠️🎁👸; 🧂⛓️🥈🏰💎,🦅🦅🦅🦅🐕🐕🐕🐕⬆️🍽️.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "tormented to madness, he was now churning through the water, violently flailing with his flexible tail": {
+    "emoji": "😩🤯🌊🤸‍♂️🔄🐟",
+    "date": "2024-01-01T00:00:00"
+  },
+  "The Doctor and I begun philosophy discourse exceeding pleasant. He offers to bring me into the college of virtuosoes and my Lord Brouncker’s acquaintance, and to show me some anatomy, which makes me very glad; and I shall endeavour it when I come to London.": {
+    "emoji": "🧑‍⚕️🤝😊🎓🗣️📚🕴️🧑‍🏫🔬👀🏛️🫀😄👉🕰️🏙️🛤️👉🇬🇧📍",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Then comes the Doctor, and we carried them by coach to their lodging, which was very poor, but the best they could get, and such as made much mirth among us.": {
+    "emoji": "🕰️➡️👨‍⚕️🩺🚍🏡➡️😂",
+    "date": "2024-01-01T00:00:00"
+  },
+  "There’s a most doleful and most mocking funeral! The sea-vultures all in pious mourning, the air-sharks all punctiliously in black or speckled.": {
+    "emoji": "⚰️🌊🦅🖤🦈⬛🔲",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I went to the ladies, and there took them and walked to the Mayor’s to show them the present, and then to the Dock, where Mr. Tippets made much of them, and thence back again, the Doctor being come to us to their lodgings.": {
+    "emoji": "👩‍🦰➡️🚺🚶‍♀️➡️👨‍💼🏠🖼➡️🏗🛳🤝➡️🔙👨‍⚕️🏠",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Homewards, and called in at Antony Joyce’s, where we found his wife brought home sick from church, and was in a convulsion fit.": {
+    "emoji": "🏠➡️👨‍👩‍👦🏠🤒🚑🏥⛪️😷😵‍💫",
+    "date": "2024-01-01T00:00:00"
+  },
+  "My arme not being well, I staid within all the morning, and dined alone at home, my wife being gone out to buy some things for herself, and a gown for me to dress myself in.": {
+    "emoji": "🦾🚫🏠🌅🍽️🏠🙍‍♂️🚫👩‍🦰🏬👜👗👨‍🦰👗",
+    "date": "2024-01-01T00:00:00"
+  },
+  "How then is this? Are the green fields gone? What do they here?": {
+    "emoji": "🤔🌿🏞️👉⛔❓🤷‍♂️👀🗺️❓",
+    "date": "2024-01-01T00:00:00"
+  },
+  "This morning I got my seat set up on the leads, which pleases me well.": {
+    "emoji": "☀️⏰🚶‍♂️-->🪑🔧🚀🏆😊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I find it a hard matter to settle to business after so much leisure and pleasure.": {
+    "emoji": "🤔😓💼🤯🎉",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Went to Mrs. Turner’s: and thence found her out at the Theatre, where I saw the last act of the “Knight of the Burning Pestle,” which pleased me not at all.": {
+    "emoji": "🏠➡️👵❌🎭➡️👀🎭🎭🛡️🔥🔨❌🙂",
+    "date": "2024-01-01T00:00:00"
+  },
+  "And so after the play done, she and The. Turner and Mrs. Lucin and I, in her coach to the Park; and there found them out, and spoke to them; and observed many fine ladies, and staid till all were gone almost.": {
+    "emoji": "🎭➡️🚗👩‍❤️‍👨👫🏞️👀👋💃✨⏳🚶‍♀️👗🕒⏳",
+    "date": "2024-01-01T00:00:00"
+  },
+  "And when it comes to sleeping with an unknown stranger, in a strange inn, in a strange town, and that stranger a harpooneer, then your objections indefinitely multiply": {
+    "emoji": "😴🤔🌃🏨🛌🤷‍♂️🌆👤💥🔪😱➕➕➕",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Sperm, sperm’s the play! This at least is duty; duty and profit hand in hand.": {
+    "emoji": "🐟🎭! ✋🎭📈✋🖐️💼✋🤝💼.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Sir G Carteret told me that the Queen and the fleet were in Mount’s Bay on Monday last, and that the Queen endures her sickness pretty well.": {
+    "emoji": "🤵‍♂️🇬🇧👑🚢🌊⛰️📅👩‍⚕️🏥🤒🙂",
+    "date": "2024-01-01T00:00:00"
+  },
+  "He also told me how Sir John Lawson hath done some execution upon the Turks in the Straight, of which I am glad, and told the news the first on the Exchange, and was much followed by merchants to tell it.": {
+    "emoji": "👨‍💼🗣️🗡️⚔️🕌⛴️🌊😊📰✨🏢🔥🕴️💼👥🔀📈",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Sir G. Carteret comes, and he and I walked in the garden, and, among other discourse, tells me that it is Mr. Coventry that is to come to us as a Commissioner of the Navy; at which he is much vexed, and cries out upon Sir W. Pen, and threatens him highly.": {
+    "emoji": "👨‍✈️🏛️🚶‍♂️🌳🗣️🤝📜👨‍💻🚢😠😡🤬🔊👴⚓🔪",
+    "date": "2024-01-01T00:00:00"
+  },
+  "And looking upon his lodgings, which are now enlarging, he in passion cried, “Guarda mi spada; for, by God, I may chance to keep him in Ireland, when he is there:” for Sir W. Pen is going thither with my Lord Lieutenant. But it is my design to keep much in with Sir George.": {
+    "emoji": "👀🏠➡️📏😭💬👀🗡️🙏🇮🇪🔒👨‍✈️🛫✈️➡️🇮🇪🔄👨‍✈️🤝👨‍✈️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Foolish toy! babies’ plaything of haughty Admirals, and Commodores, and Captains; the world brags of thee, of thy cunning and might": {
+    "emoji": "🤡🧸👶⚓️🧔‍♂️🎩🌍🎩🤹‍♂️💪",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Moby Dick seeks thee not. It is thou, thou, that madly seekest him!": {
+    "emoji": "🐋🔍❌👤✖️🔁👤🔍🤪🔍🐳",
+    "date": "2024-01-01T00:00:00"
+  },
+  "To White Hall; and there walked an hour or two in the Park, where I saw the King now out of mourning, in a suit laced with gold and silver, which it was said was out of fashion.": {
+    "emoji": "👑➡️🏛️🚶‍♂️⏲️2️⃣⏰🌳🏞️👀🤴😔➡️😄👗👗✨💰🪙👀🗣️❌🕰️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "To the Wardrobe; and there consulted with the ladies about our going to Hampton Court tomorrow, and thence home, and after settled business there my wife and I to the Wardrobe.": {
+    "emoji": "🚪👚👗🤔👩👩‍🦱➡️🏰📅➡️🏠🤝📈👩‍❤️‍👨➡️🚪",
+    "date": "2024-01-01T00:00:00"
+  },
+  "some invisible, gracious agency preserved me": {
+    "emoji": "🫥✨🙏🛡️😊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "And so to barge again, and there we had good victuals and wine, and were very merry; and got home very well.": {
+    "emoji": "🏛️➡️⛴️🍽️🍷😊🏠✔️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "In vain, oh, ye strangers, ye fly our sad burial; ye but turn us your taffrail to show us your coffin!": {
+    "emoji": "🪦😔👥🌊💨🪦⚱️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "To walk to Pauls churchyard, and there evened all reckonings to this day.": {
+    "emoji": "🚶‍♂️➡️⛪️⚖️📅👍",
+    "date": "2024-01-01T00:00:00"
+  },
+  "they, in the heathenish sharked waters, and by the beaches of unrecorded, javelin islands, battled with virgin wonders and terrors": {
+    "emoji": "🧑‍🤝‍🧑🌊🦈🏝️🏖️⚔️🪶😲😨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I knew no one in the place.": {
+    "emoji": "👤❌1️⃣👥🌍✖️🏠",
+    "date": "2024-01-01T00:00:00"
+  },
+  "To my brother’s, and finding him in a lie about the lining of my new morning gown, saying that it was the same with the outside, I was very angry with him and parted so.": {
+    "emoji": "👨‍👦➡️🏠🤥🧥😡👐",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Home, and there came Mr. Morelock of Chatham, and brought me a stately cake, and I perceive he has done the same to the rest, of which I was glad.": {
+    "emoji": "🏠, ➕ 🧑‍💼➡️🧔‍♂️🏠📍🏘️, ➕ 🎁 🎂, ➕ 👀😃 ➡️ ⬇️, 😄",
+    "date": "2024-01-01T00:00:00"
+  },
+  "spasmodically dilating and contracting his spout-hole, with sharp, cracking, agonized respirations": {
+    "emoji": "🐋🔁⬆️⬇️😮‍💨💥😖😤",
+    "date": "2024-01-01T00:00:00"
+  },
+  "those grand fresh-water seas of ours,—Erie, and Ontario, and Huron, and Superior, and Michigan,—possess an ocean-like expansiveness, with many of the ocean’s noblest traits": {
+    "emoji": "🌊🌊🇺🇸🔝🌊🌊👀🌊🌊🏝️🌊🌊🌊🌊⛴️🌊🌊🌊🌤️🌊🌊🌊🌊🌊🌊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "We two watchmen never rest.": {
+    "emoji": "👫👀⏲️🚫🛌🔚",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I pondered some time without fully comprehending the reason for this.": {
+    "emoji": "🤔⏳❓🤷‍♂️💭",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I found a number of young seamen": {
+    "emoji": "🔍➡️#️⃣👦🧑‍✈️🌊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "All the bells of the town rung, and bonfires made for the joy of the Queen’s arrival, who came and landed at Portsmouth last night.": {
+    "emoji": "🔔🔔🏙️🎉🔥👑😊🚢📍🌃",
+    "date": "2024-01-01T00:00:00"
+  },
+  "But I do not see much thorough joy, but only an indifferent one, in the hearts of people, who are much discontented at the pride and luxury of the Court, and running in debt.": {
+    "emoji": "🤔😕😐💔😞👑🤑💸🏃‍♂️💳",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Where unrecorded names and navies rust, and untold hopes and anchors rot": {
+    "emoji": "🌊❓🚢⚓🌌⛓️🛠️💭💔",
+    "date": "2024-01-01T00:00:00"
+  },
+  "life dies sunwards full of faith; but see! no sooner dead, than death whirls round the corpse, and it heads some other way": {
+    "emoji": "🌱🌞🙏; 👀! 💀, ⚰️💫🔄, 🚶‍♂️🧭➡️↩️.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "with my shoulders leaning against the slackened royal shrouds, to and fro I idly swayed in what seemed an enchanted air": {
+    "emoji": "🧍‍♂️🪢👑🌬️🔄✨🌬️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Up early, Mr. Hater and I to the office, and there I made an end of my book of contracts which I have been making an abstract of.": {
+    "emoji": "⏰☀️👨‍💼➡️🏢✍️📚📄🔚",
+    "date": "2024-01-01T00:00:00"
+  },
+  "To Moorefields, and walked and eat some cheesecake and gammon of bacon, but when I was come home I was sick, forced to vomit it up again.": {
+    "emoji": "👉🚶‍♂️🍰🥓🤢🤮🏠",
+    "date": "2024-01-01T00:00:00"
+  },
+  "even this wears off in time": {
+    "emoji": "🕰️➡️🛡️😞⏳",
+    "date": "2024-01-01T00:00:00"
+  },
+  "My wife and I by coach to the Opera, and there saw the 2nd part of “The Siege of Rhodes,” but it is not so well done as when Roxalana was there, who, it is said, is now owned by my Lord of Oxford.": {
+    "emoji": "👩‍❤️‍👨🚌🎭👀2️⃣🎭🎵🏰🇬🇷😕🏛️👸✨👂📜🎭👑📍🏰📚💍",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Thence to Tower-wharf, and there took boat, and we all walked to Halfeway House, and there eat and drank, and were pleasant.": {
+    "emoji": "➡️🏰⚓🚤➡️🚶‍♂️🍴🥤😊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "And so finally home again in the evening, and so good night, this being a very pleasant life that we now lead, and have long done; the Lord be blessed, and make us thankful.": {
+    "emoji": "🏠🌇🙌🌙💤😊🙏🌟🌈🙏",
+    "date": "2024-01-01T00:00:00"
+  },
+  "But, though I am much against too much spending, yet I do think it best to enjoy some degree of pleasure now that we have health, money, and opportunity, rather than to leave pleasures to old age or poverty, when we cannot have them so properly.": {
+    "emoji": "🤔💰👎🤑🤔👍😊🕒🏥💸🚪🎉😌🎈😃😌🏃‍♂️🍀🤝⏳👉👵💵😞🚷👴🚫😕",
+    "date": "2024-01-01T00:00:00"
+  },
+  "where strange shapes of the unwarped primal world glided to and fro before his passive eyes": {
+    "emoji": "🌌🌀🌍👻👀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "To the Theatre to “The French Dancing Master,” and there with much pleasure gazed upon her (Lady Castlemaine); but it troubles us to see her look dejectedly and slighted by people already. The play pleased us very well; but Lacy’s part, the Dancing Master, the best in the world.": {
+    "emoji": "🎭➡️🕺🇫🇷👨‍🏫😊👀👩‍🦰👸😔👥👎🎭👏👍💃🕺💯🌍",
+    "date": "2024-01-01T00:00:00"
+  },
+  "My wife and I went and saw Mrs. Turner, whom we found not well, and her two boys Charles and Will come out of the country, grown very plain boys after three years being under their father’s care in Yorkshire.": {
+    "emoji": "👩‍❤️‍👨➡️👀👵😔👦👦🌳🏡🔙⏳3️⃣📈🙍‍♂️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "There! there again! there she breaches! right ahead! The White Whale, the White Whale!": {
+    "emoji": "🐳🚢🐳⬆️🐳🐋🐋",
+    "date": "2024-01-01T00:00:00"
+  },
+  "here goes for a cool, collected dive at death and destruction, and the devil fetch the hindmost": {
+    "emoji": "🏊‍♂️😎💦💀🔥😈👐",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I find nothing in them that is pleasing; and I see they have learnt to kiss and look freely up and down already, and I do believe will soon forget the recluse practice of their own country. They complain much for lack of good water to drink.": {
+    "emoji": "🙅‍♂️😊🙈👄👀😊↕️🔜😕🏞🚱",
+    "date": "2024-01-01T00:00:00"
+  },
+  "We felt very nice and snug, the more so since it was so chilly out of doors": {
+    "emoji": "😊🛋️🔥❄️🚪",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Thence homewards by coach, through Moorefields, where we stood awhile, and saw the wrestling.": {
+    "emoji": "🏠➡️🚌➡️🌳🚶‍♂️⏸️👀🤼‍♂️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "To my brother’s, where I found my father, poor man, come, which I was glad to see. He tells me his alterations of the house and garden at Brampton, which please me well.": {
+    "emoji": "👨‍👧‍👦🏠➡️👀👴😊🏡🌳📈👍",
+    "date": "2024-01-01T00:00:00"
+  },
+  "There you stand, lost in the infinite series of the sea, with nothing ruffled but the waves.": {
+    "emoji": "🌊🤔🌊🌊🌊🌊🔄💭🌊😌🌊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "My sensations were strange. Let me try to explain them.": {
+    "emoji": "🤔😳🔍🤯💬",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Comes my father by appointment to dine with me, which we did very merrily, I desiring to make him as merry as I can, while the poor man is in town.": {
+    "emoji": "👨‍👦📅🍽️😊➡️🎉🕺😄⬅️🏙️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I have several such dried bits, which I use for marks in my whale-books.": {
+    "emoji": "👁️📚📖🐳📚🪶📙💾🐋📓📕",
+    "date": "2024-01-01T00:00:00"
+  },
+  "his torn body and gashed soul bled into one another; and so interfusing, made him mad": {
+    "emoji": "🤕💔➡️🩸↔️🤯",
+    "date": "2024-01-01T00:00:00"
+  },
+  "There, then, he sat, the sign and symbol of a man without faith, hopelessly holding up hope in the midst of despair.": {
+    "emoji": "🏞️🪑🕴️🔄❓🙍‍♂️❌🙋‍♂️🙏💔🤲😞",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Pantheistic vitality seemed to lurk in their very joints and bones, after what might be called the individual life had departed.": {
+    "emoji": "🌿✨🦴🌌💀➡️🧍‍♂️🏃‍♂️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "In what rapt ether sails the world, of which the weariest will never weary?": {
+    "emoji": "🌌🌍⛵️⁉️😩🔄✨❤️‍🔥",
+    "date": "2024-01-01T00:00:00"
+  },
+  "In Lumbard Street was called out of a window by Alderman Backwell, where I went, and saluted his lady, a very pretty woman.": {
+    "emoji": "🏢🪟📞🌆🧔➡️🤝👮‍♂️🏢🚶‍♂️💼🤝👩😊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Here was Mr. Creed, and it seems they have been under some disorder in fear of a fire at the next door, and had been removing their goods, but the fire was over before I came.": {
+    "emoji": "👨‍💼🔥🏠😨📦🔥🔚🏃‍♂️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Thence home, and with my wife and the two maids, and the boy, took boat and to Foxhall, where I had not been a great while.": {
+    "emoji": "🏠👫👩‍🍳👩‍🍳👦🚤➡️🦊🏡📍📆⏳",
+    "date": "2024-01-01T00:00:00"
+  },
+  "To the Old Spring Garden, and there walked long, and the wenches gathered pinks. Here we staid, and seeing that we could not have anything to eat, but very dear, and with long stay, we went forth without any notice taken of us, and so we might have done if we had had anything.": {
+    "emoji": "👣🏡🌸🐦👭🌺⏳🍽️❌💰⌛🚶‍♂️🚶‍♀️👀🚪🚫💭🕒",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Thence to the New one, where I never was before, which much exceeds the other; and here we also walked, and the boy crept through the hedge and gathered abundance of roses.": {
+    "emoji": "🏞️➡️✨➡️🆕🏠🙋‍♂️🚫👀🌟➡️🆚🌿➡️🚶‍♂️🌿👦🌳🐍💐🌹🌹🌹",
+    "date": "2024-01-01T00:00:00"
+  },
+  "After a long walk, passed out of doors as we did in the other place, and here we had cakes and powdered beef and ale, and so home again by water with much pleasure.": {
+    "emoji": "🚶‍♂️➡️🚪➡️🏡🍰🥩🍺➡️🏠⛵😊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "This day, being the King’s birth-day, was very solemnly observed; and the more, for that the Queen this day comes to Hampton Court.": {
+    "emoji": "👑🎂🔔👑📅🔍😊📅👑👑📍🏰",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I made up my accounts, and find myself ‘de claro’ worth about 530l., and no more, so little have I increased it since my last reckoning; but I confess I have laid out much money in clothes.": {
+    "emoji": "🧮💼📊➡️📈💷530🧐➕🔚📉💸👕🛍️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Upon a suddaine motion I took my wife, and Sarah and Will by water, with some victuals with us, as low as Gravesend, intending to have gone into the Hope to the Royal James, to have seen the ship and Mr. Shepley.": {
+    "emoji": "🌊🚤⛵👩‍❤️‍👨👧👦🥪⛴️📍⚓🚢👀🧔",
+    "date": "2024-01-01T00:00:00"
+  },
+  "But meeting Mr. Shepley in a hoy, bringing up my Lord’s things, she and I went on board, and sailed up with them as far as half-way tree, very glad to see Mr. Shepley.": {
+    "emoji": "🛥️👨‍💼🤝📦🧳💃↔️🌳😊👀👨‍💼",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Here we saw a little Turk and a negroe, which are intended for pages to the two young ladies.": {
+    "emoji": "👀👦🏽🇹🇷➕👦🏿📜➡️👩‍🦰👩‍🦱",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Sink all coffins and all hearses to one common pool!": {
+    "emoji": "🛳️⚰️🛳️🚫⚰️🛻⚰️➕1⃣🌊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Many birds and other pretty noveltys there was, but I was afeard of being louzy, and so took boat again, and got to London before them, all the way, coming and going, reading in the “Wallflower” with great pleasure.": {
+    "emoji": "🐦🌺🆕😨🪳🛶➡️📚🌸😊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Mr. Shepley came to sup with me. So we had a dish of mackerell and pease, and so he bid us good night, going to lie on board the hoy, and I to bed.": {
+    "emoji": "👨‍🦳🍽️🐟🍽️🍽️🛌🌙🚢🛌",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Came Anthony Joyce, who duns me for money for the tallow which he served in lately by my desire, which vexes me, but I must get it him the next by my promise.": {
+    "emoji": "🏠🤵💼🤑👉💰➡️💡🕯️⏰🤔😠💭🤝🙏📅💭",
+    "date": "2024-01-01T00:00:00"
+  },
+  "This particular feat of the shark seems all but miraculous. How at such an apparently unassailable surface, they contrive to gouge out such symmetrical mouthfuls, remains a part of the universal problem of all things.": {
+    "emoji": "🦈✨🤔❓🌊😮✨🌀🦈🔍💭🤯🌍🔍🔄",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Had Sarah to comb my head clean, which I found so foul with powdering and other troubles, that I am resolved to try how I can keep my head dry without powder.": {
+    "emoji": "👩‍🦰👉🔟🔄🧖‍♀️🧼👩‍🦱🤢🧹💨🔙🔜❌💧📅❌🔲",
+    "date": "2024-01-01T00:00:00"
+  },
+  "And I did also in a suddaine fit cut off all my beard, which I had been a great while bringing up, only that I may with my pumice-stone do my whole face, as I now do my chin, and to save time, which I find a very easy way and gentile.": {
+    "emoji": "🪒😲✂️🧔➡️😌🧽😃⌚️🪞😊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "This month ends with very fair weather for a great while together. My health pretty well, but only wind do now and then torment me about the fundament extremely.": {
+    "emoji": "📅🌞🌈🔥👌💪😅💨😖🍑🌪️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "The Queen is brought a few days since to Hampton Court; and all people say of her to be a very fine and handsome lady, and very discreet; and that the King is pleased enough with her which, I fear, will put Madam Castlemaine’s nose out of joynt.": {
+    "emoji": "👑👩‍🦰➡️🏰🗓️🔙👩🎀👍👫😊👌🤔😟👸😠🔧👃🛠️😬",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the valiant butchers over the deck-table are thus cannibally carving each other’s live meat with carving-knives all gilded and tasselled": {
+    "emoji": "🦸‍♂️🔪👨‍🍳⚔️🍖👨‍🍳🔪✨🎀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "To church, where a Presbyter made a sad and long sermon, which vexed me.": {
+    "emoji": "👉⛪️, 📍👨‍⚖️🗣️😔📖😞⏳🗨️, 😠🙁.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "This day my wife put on her slasht wastecoate, which is very pretty.": {
+    "emoji": "📅👩‍❤️‍👨👗✨😊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Yesterday (Sir R. Ford told me) the Aldermen of the City did attend her in their habits, and did present her with a gold Cupp and 1000l. in gold therein.": {
+    "emoji": "🕰️👨‍💼🏙️👔🤵‍♂️🎁👩‍🦳🥇🏆💰🔢🪙",
+    "date": "2024-01-01T00:00:00"
+  },
+  "But mark the other head’s expression.": {
+    "emoji": "🤔👉😯",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Home and to bed, my mind troubled about Sir W. Pen, his playing the rogue with me today, as also about the charge of money that is in my house, which I had forgot.": {
+    "emoji": "🏠🛏️🤔🤯🤔🧔🎭🔄🤔💸🏡🤔❌🧠",
+    "date": "2024-01-01T00:00:00"
+  },
+  "those who glared like devils in the forking flames, the morn will show in far other, at least gentler, relief": {
+    "emoji": "😈🔥🌅😇💫",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I to my Lord’s, who I find resolved to buy Brampton Manor of Sir Peter Ball, at which I am glad.": {
+    "emoji": "👤➡️🙏's, 👤😊🗝️🏡🌳🐏👨‍⚖️, 😃",
+    "date": "2024-01-01T00:00:00"
+  },
+  "It was his death stroke.": {
+    "emoji": "👤💀⚔️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I went to my bookseller’s, and paid off all for books to this day, and do not intend to buy any more of any kind a good while, though I had a great mind to have bought the King’s works, as they are new printed in folio, and present it to my Lord.": {
+    "emoji": "👤➡️📚🏪💸📚📅🚫🛒📚⏳🤔📖👑📚🆕🖨️📖🎁🤴",
+    "date": "2024-01-01T00:00:00"
+  },
+  "fix your eye upon this strange, crested, comb-like incrustation on the top of the mass—this green, barnacled thing": {
+    "emoji": "🔧👁️🔝🦄🦁🤔🟢🌊🐚",
+    "date": "2024-01-01T00:00:00"
+  },
+  "three centuries ago the tongue of the Right Whale was esteemed a great delicacy in France, and commanded large prices there": {
+    "emoji": "3️⃣ 🕰️ 🐋 👅 🌟 🍴 🇫🇷 💰⬆️💲",
+    "date": "2024-01-01T00:00:00"
+  },
+  "So that I am vexed with all my heart at Pall for writing to him so much concerning my mother’s illness (which I believe was not so great), so that he should be forced to hasten down on the sudden back into the country without taking leave, or having any pleasure here.": {
+    "emoji": "😠💔📜✍️🤒🤔➡️😨🏃‍♂️💨🏡🚫👋😔🏙️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "This evening Savill the Paynter came and did varnish over my wife’s picture and mine, and I paid him for my little picture 3l., and so am clear with him.": {
+    "emoji": "🌆🎨👨‍🎨🖌️🖼️👩‍🎨🖼️🧍‍♀️💰3️⃣💷💬✔️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I trust you will have renounced all ignorant incredulity, and be ready to abide by this": {
+    "emoji": "🙏🤞🤝😇📜❌😕🤔🔄🤗📋",
+    "date": "2024-01-01T00:00:00"
+  },
+  "a supply of that hard white whalebone with which the fishermen fashion all sorts of curious articles, including canes, umbrella-stocks, and handles to riding-whips": {
+    "emoji": "🦴🦈🎣🛠️🌂🦯🏇",
+    "date": "2024-01-01T00:00:00"
+  },
+  "man’s insanity is heaven’s sense": {
+    "emoji": "👨🤪🌌🤔",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I tried on my riding cloth suit with close knees, the first that ever I had; and I think they will be very convenient, if not too hot to wear any other open knees after them.": {
+    "emoji": "🧥🤔👖🚴‍♂️👀👍❄️🔥👎👖",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Among many other businesses, I did get a vote signed by all, concerning my issuing of warrants, which they did not smell the use I intend to make of it; but it is to plead for my clerks to have their right of giving out all warrants, at which I am not a little pleased.": {
+    "emoji": "🗂️🤝💼✍️📜👥🔍🤔❓▶️📜📝🖋️🛡️👍👩‍💼📜⚖️💪😊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I was preparing to hear some good stories about whaling": {
+    "emoji": "👂📖🐋📚🗣️✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "To dinner, by Mr. Gauden’s invitation, to the Dolphin, where a good dinner; but what is to myself a great wonder; that with ease I past the whole dinner without drinking a drop of wine.": {
+    "emoji": "🍽️👉👤🍷📜✉️🍴🐬👉😊🍴🍽️❓😮👍🍽️🚫🍷",
+    "date": "2024-01-01T00:00:00"
+  },
+  "It being the longest day in the year, I made all my people go to bed by daylight.": {
+    "emoji": "📅🌞➡️🕛, 👁️👥🚶🛌☀️.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "But after I was a-bed and asleep, a note came from my brother Tom to tell me that my cozen Anne Pepys, of Worcestershire, her husband is dead, and she married again, and her second husband in town, and intends to come and see me tomorrow.": {
+    "emoji": "🛌💤📜👨‍👩‍👦‍👦➡️👰💔😇🔁💍🧔🏙️➡️👁️‍🗨️📅",
+    "date": "2024-01-01T00:00:00"
+  },
+  "cajoling me into the delusion that it was a choice resulting from my own unbiased freewill and discriminating judgment": {
+    "emoji": "🫄🤗➡️🤔🌀👉🤯💭🤏🤹‍♂️🆓🤝🧠⚖️🔍",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Up by 4 o’clock in the morning, and read Cicero’s Second Oration against Catiline, which pleased me exceedingly; and more I discern therein than ever I thought was to be found in him; but I perceive it was my ignorance, and that he is as good a writer as ever I read in my life.": {
+    "emoji": "⏫🕓🌄📚🧔🏻📜🤔👍🏼📖😃🧐📈🤔📚🤔📈🤷‍♂️✍️📚📖😮",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Oh, grassy glades! oh, ever vernal endless landscapes in the soul": {
+    "emoji": "🌿😮🌼🌿! 🌳😮, ♾️🍃💚🌄♾️🌄🧘‍♂️💖",
+    "date": "2024-01-01T00:00:00"
+  },
+  "My wife and I, and Sarah and the boy, a most pleasant walk to Halfway house, and so home and to bed.": {
+    "emoji": "👩‍❤️‍👨👩‍❤️‍👦👦🚶‍♂️🚶‍♀️🚶‍♂️🚶‍♀️😊🏠🛌",
+    "date": "2024-01-01T00:00:00"
+  },
+  "all their eyes gleaming in that pale phosphorescence, like a far away constellation of stars": {
+    "emoji": "👀✨🌌✨🔭✨🌟✨💫✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I name no names. Shame upon them! Put one foot upon the table. Shame upon all cowards.": {
+    "emoji": "🫣❌🔠😔⬇️👆🦶🪑😔⬇️🚫😨🦸‍♂️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Having a room got ready for us, we all went out to the Tower-hill; and there, over against the scaffold, made on purpose this day, saw Sir Henry Vane brought. A very great press of people.": {
+    "emoji": "🏠✅🧑‍🤝‍🧑🚶‍♂️➡️🗼🔝⛰️👀👥🔨🪜📅👀🧔🏃‍♂️👥📢👥",
+    "date": "2024-01-01T00:00:00"
+  },
+  "He made a long speech, many times interrupted by the Sheriff and others there; and they would have taken his paper out of his hand, but he would not let it go. The trumpets were brought under the scaffold that he might not be heard.": {
+    "emoji": "👨‍🗣️🗯️⏳📜💬✋👮‍♂️😠🤚👥🚫📄🤚🔔🔊🔇🏗️🔕➡️🔇",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Then he prayed, and so fitted himself, and received the blow; but the scaffold was so crowded that we could not see it done.": {
+    "emoji": "🙏➡️💪🔪👀😞📦🚫🔍",
+    "date": "2024-01-01T00:00:00"
+  },
+  "One asked him why he did not pray for the King. He answered, “Nay,” says he, “you shall see I can pray for the King: I pray God bless him!”": {
+    "emoji": "☝️🤔❓🙇‍♂️🤴❓🙅‍♂️💬🤷‍♂️😊👀🙏🤴🙏🙏🙏😇",
+    "date": "2024-01-01T00:00:00"
+  },
+  "may I ask whether this is the sort of bitters by which he blows back the life into a half-drowned man?": {
+    "emoji": "🧐❓🤔➡️🍷🤔💨🌀😅➡️🤕🥵🛟",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I hear my Lord Peterborough is come unexpected from Tangier, to give the King an account of the place, which, we fear, is in none of the best condition.": {
+    "emoji": "👂🤴🏰🛬😮🌍➡️👑📜📍😨❌👍📶",
+    "date": "2024-01-01T00:00:00"
+  },
+  "We had certain news that the Spaniard is before Lisbon with thirteen sail; six Dutch, and the rest his own ships; which will, I fear, be ill for Portugall.": {
+    "emoji": "📰😟👨‍✈️🇪🇸⛵️➡️🇵🇹⚓️💬1️⃣3️⃣⛴️⚓️6️⃣🇳🇱⛴️➕🔢🇪🇸⛴️😰😬🇵🇹",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Did you ever see any parson a wearing mourning for the devil?": {
+    "emoji": "🤔👀👨‍⚕️😔🖤😈❓",
+    "date": "2024-01-01T00:00:00"
+  },
+  "even Captain Ahab was by no means unobservant of the paramount forms and usages of the sea": {
+    "emoji": "⚓🧔‍♂️❌👀🌊⛵🛡️📜",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Yonder, to windward, all is blackness of doom; but to leeward, homeward—I see it lightens up there": {
+    "emoji": "🌫️⬆️💨⚫💀;⬇️🏠🌅✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Thou canst not tell where one drop of water or one grain of sand will be to-morrow noon": {
+    "emoji": "🤔💧❓🕒🌊🔍🌾❓🕒🌞",
+    "date": "2024-01-01T00:00:00"
+  },
+  "To church again; but my wife not being dressed as I would have her, I was angry, and she, when she was out of doors in her way to church, returned home again vexed.": {
+    "emoji": "👉⛪️🔄; 👩‍❤️‍👨🚫👗😠, 😡↩️🏠😡.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "he had just recalled a little duty ashore, which he was leaving undone; and therefore had changed his mind about dying": {
+    "emoji": "👨‍💭⚓️📝🏝️❌➡️🤔💀✋",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Home, and found my wife and Sarah gone to a neighbour church, at which I was not much displeased. By and by she comes again, and, after a word or two, good friends.": {
+    "emoji": "🏠➡️👩‍❤️‍👨❌➡️⛪🤷😊➡️👩🙂❤️🤝",
+    "date": "2024-01-01T00:00:00"
+  },
+  "you are struck by the general contrast between these heads": {
+    "emoji": "👉🤯😲🆚🧠🗣️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "She told me that her brother was married and had a wife worth 500l. to him, and did inquire how he might dispose the money to the best advantage, but I forbore to advise her till she could certainly tell me how things are with him, being loth to meddle too soon with him.": {
+    "emoji": "👩‍🗣️➡️👨‍🦱💒👰💰💵🤔💭❓🗣️💰👍🤔❓🤔🤐🧑‍💼⏳🔍👨‍🦱🙅‍♂️⏰",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the whole round sea was one huge cheese, and those sharks the maggots in it": {
+    "emoji": "🌊🧀🦈🪱",
+    "date": "2024-01-01T00:00:00"
+  },
+  "With my wife to the Wardrobe, and dined there; and in the afternoon with all the children by water to Greenwich, where I showed them the King’s yacht, the house, and the park, all very pleasant; and so to the tavern, and had the musique of the house, and so merrily home again.": {
+    "emoji": "👫🚪🍽️🕛🧒🛥️➡️🇬🇧📍👑🛥️🏠🌳🎶🍻😊🏠",
+    "date": "2024-01-01T00:00:00"
+  },
+  "To the office, and at Sir W. Batten’s, where we all met by chance and talked, and they drank wine; but I forebore all their healths. Sir John Minnes, I perceive, is most excellent company.": {
+    "emoji": "🏢➡️👥🍷🚫🏥👨‍🚀🤝😄",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Home and to bed betimes by daylight.": {
+    "emoji": "🏡🛏️⏰🌅",
+    "date": "2024-01-01T00:00:00"
+  },
+  "in many natural objects, whiteness refiningly enhances beauty, as if imparting some special virtue of its own": {
+    "emoji": "🌿⚪️✨🌷➕🌸🌟🌈",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Thence to Wright’s, the painter’s: but, Lord! the difference that is between their two works.": {
+    "emoji": "👨‍🎨➡️👨‍🎨🎨😲🤯➗2🖼️🎨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "So home, and after some merry discourse in the kitchen with my wife and maids as I now-a-days often do, I being well pleased with both my maids, to bed.": {
+    "emoji": "🏠😄🗣👩‍🍳👩‍❤️‍👨👩‍🍳😊🛏💤",
+    "date": "2024-01-01T00:00:00"
+  },
+  "oh, ever vernal endless landscapes in the soul; in ye,—though long parched by the dead drought of the earthy life,—in ye, men yet may roll": {
+    "emoji": "😮🌿🌄🔄✨🏞️🧘‍♂️;📍🌳,—🔄🌵🥵🌾☠️🌵🌎💀,—📍🌳,👨‍🦰💪👨‍🦳🌀↔️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Immense as whales, the motion of whose vast bodies can in a peaceful calm trouble the ocean till it boil.": {
+    "emoji": "🐋🌊🔄📏😌🌊🔉🔥",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Up by five o’clock, and while my man Will was getting himself ready to come up to me I took and played upon my lute a little.": {
+    "emoji": "☀️🔝5️⃣⏰👨‍🦰➡️🔜👍🎶🎸🎵🕺",
+    "date": "2024-01-01T00:00:00"
+  },
+  "suddenly in the distance, they saw a great heap of tumultuous white water": {
+    "emoji": "🌊👀😲😮‍💨🌌",
+    "date": "2024-01-01T00:00:00"
+  },
+  "We sat long to-day, and had a great private business before us about contracting with Sir W. Rider, Mr. Cutler, and Captain Cocke, for 500 ton of hemp, which we went through, and I am to draw up the conditions.": {
+    "emoji": "🪑⏳👔🗣️📜🤝🧔🔍👉📝",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Mr. Holliard had been with my wife to-day, and cured her of her pain in her ear by taking out a most prodigious quantity of hard wax that had hardened itself in the bottom of the ear, of which I am very glad.": {
+    "emoji": "👨‍⚕️🧑‍🤝‍🧑👂➡️😊🦻❌🍯🗑️🎉",
+    "date": "2024-01-01T00:00:00"
+  },
+  "what that is none know but those who have tried it": {
+    "emoji": "🤔🤷‍♂️🕵️‍♂️👥🥇🔍💭",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Though, God knows! the King is not able to set out five ships at this present without great difficulty, we neither having money, credit, nor stores.": {
+    "emoji": "🤔🙏👑🚫🛳️5⏳🚫🤑🤝🔋",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the true form of the whale was unknown": {
+    "emoji": "🐋❓💭",
+    "date": "2024-01-01T00:00:00"
+  },
+  "This day genteel woman came to me, claiming kindred of me, as she had once done before, and borrowed 10s. of me, promising to repay it at night, but I hear nothing of her. I shall trust her no more.": {
+    "emoji": "👩‍🦰➡️🤝👨‍🦰💼👩‍🦰💰🔟🕒🔄🌜❌🔔🤷‍♂️🚫🔒💔",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Squeeze! squeeze! squeeze! all the morning long; I squeezed that sperm till I myself almost melted into it": {
+    "emoji": "👐👐👐☀️⏰⏳👉👐🐋🩵➡️😅🔥😌🌊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I find it to be the very effect of my late oaths against wine and plays, which, if God please, I will keep constant in, for now my business is a delight to me, and brings me great credit, and my purse encreases too.": {
+    "emoji": "🤔✋🍷🎭🙏😇📈💼😊👍💰📈",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Yea, woe to him who, as the great Pilot Paul has it, while preaching to others is himself a castaway!": {
+    "emoji": "👍😔🧔📖🛳️📢➡️👥🤦‍♂️🚫➡️🌊💔",
+    "date": "2024-01-01T00:00:00"
+  },
+  "these two laws touching Fast-Fish and Loose-Fish, I say, will, on reflection, be found the fundamentals of all human jurisprudence": {
+    "emoji": "🐟⚖️🤔➡️🔍🧠➡️📚⚖️👥🌍",
+    "date": "2024-01-01T00:00:00"
+  },
+  "What’s the matter with you? What’s the matter with you, shipmate?": {
+    "emoji": "🤔❓🤷‍♂️🤔❓🤷‍♂️🛳️👫",
+    "date": "2024-01-01T00:00:00"
+  },
+  "To the settling of my own accounts, and I do find upon my monthly ballance, which I have undertaken to keep from month to month, that I am worth 650l., the greatest sum that ever I was yet master of. I pray God give me a thankfull, spirit, and care to improve and encrease it.": {
+    "emoji": "📊💼🔢📅💰💷💪🔝🙏🕊️🙌📈📈",
+    "date": "2024-01-01T00:00:00"
+  },
+  "To church with my wife, who this day put on her green petticoat of flowred satin, with fine white and gimp lace of her own putting on, which is very pretty.": {
+    "emoji": "⛪️👫💚👗🌸✨🤍🧵👗😍",
+    "date": "2024-01-01T00:00:00"
+  },
+  "But even Solomon, he says, “the man that wandereth out of the way of understanding shall remain” (i.e., even while living) “in the congregation of the dead.”": {
+    "emoji": "🤔➡️👑🤴🔄🚶‍♂️🛤️❌🧠➡️🕸️👥💀",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Thou saw’st the locked lovers when leaping from their flaming ship; heart to heart they sank beneath the exulting wave": {
+    "emoji": "👀🔒💑🔥🚢❤️➡️❤️🌊⬇️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Sir W. Penn do much fawn upon me, and I perceive would not fall out with me, and his daughter mighty officious to my wife, but I shall never be deceived again by him, but do hate him and his traitorous tricks with all my heart.": {
+    "emoji": "🧔‍♂️🧎‍♂️🐶👈🤝🤨➡️👩🧚‍♀️❤️💑🚫😡👉🤥💔🚫❤️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Went first on board the King’s pleasure boat. Then to Greenwich Park; and with much ado she was able to walk up to the top of the hill, and so down again, and took boat, and so through bridge to Blackfryers, she being much pleased with the ramble in every particular of it.": {
+    "emoji": "🚶‍♂️➡️🛥️👑➡️🛥️➡️🛥️➡️🚶‍♀️➡️🌳➡️🚶‍♀️⬆️⛰️➡️⬇️⛰️➡️🛥️➡️🌉➡️⚓➡️😊🌳⛰️🛥️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "This I take to be as bad a juncture as ever I observed.": {
+    "emoji": "☹️🔍🤔➡️😞📉😟👁️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "To Redriffe by land, Mr. Cowly, the Clerk of the Cheque, with me, discoursing concerning the abuses of the yard, in which he did give me much light.": {
+    "emoji": "➡️🛤️➡️🚶‍♂️👨‍💼🗒️💬💡",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Up by four o’clock, and before I went to the office I practised my arithmetique, and then, when my wife was up, did call her and Sarah, and did make up a difference between them, for she is so good a servant as I am loth to part with her.": {
+    "emoji": "⏫ 🕓, 🕛 🏢 ➕📚, 👰 📞👩‍🦳🤝, 💁‍♀️👌🔢😌❤️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "So to the office all the morning, where very much business, but it vexes me to see so much disorder at our table, that, every man minding a several business, we dispatch nothing.": {
+    "emoji": "🏢🌅🕒💼📈😖🔍🗂️❌👀🔄🍽️🔍👨‍💼🤷‍♂️🔢🗣️🚫",
+    "date": "2024-01-01T00:00:00"
+  },
+  "One often hears of writers that rise and swell with their subject, though it may seem but an ordinary one.": {
+    "emoji": "👂👤✍️⬆️🌊🗒️➡️📜🤔📈🔍📘➡️🔄✏️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I told Mr. Turner my whole mind, and how it was in my power to do him a discourtesy about his place of petty purveyance, and at last did make him see (I think) that it was his concernment to be friendly to me and what belongs to me.": {
+    "emoji": "🗣️➡️🧑‍💼💭🗣️👐💪😠🏠🛍️😒🤔🧐🏫➕🤝😊🫂",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I did discourse with Mr. Turner about the faults of our management of the business of our office, of which he is sensible, but I believe is a very knave.": {
+    "emoji": "🗣️🤝👨‍💼💬🤔🧑‍💼⚙️🏢🔍😔🤔🦹",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Think, think of thy whale-boat, stoven and sunk! Beware of the horrible tail!": {
+    "emoji": "🤔🤔🐋🚤💥🌊⚠️😱🐋👋",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Nantucket! Take out your map and look at it. See what a real corner of the world it occupies": {
+    "emoji": "🗺️🔍🌍➡️📍",
+    "date": "2024-01-01T00:00:00"
+  },
+  "And all the while the thick-lipped leviathan is rushing through the deep, leaving tons of tumultuous white curds in his wake": {
+    "emoji": "🌊🐋💨🌪️⚪🐳",
+    "date": "2024-01-01T00:00:00"
+  },
+  "he found himself hard by the very latitude and longitude where his tormenting wound had been inflicted": {
+    "emoji": "👨🔍🧭📍😖💔📍📌",
+    "date": "2024-01-01T00:00:00"
+  },
+  "It was a very dubious-looking, nay, a very dark and dismal night, bitingly cold and cheerless.": {
+    "emoji": "🌌🤔🤨🌑🌧️🥶🔪🌫️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "he swam away to the leeward, but with such a steady tranquillity, and making so few ripples as he swam": {
+    "emoji": "🏊‍♂️➡️🌊😌🔇🌊✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "I am buoyed by breaths of once living things, exhaled as air, but water now.": {
+    "emoji": "😌💨🌿➡️🌬️🫧➡️🌊",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the beheading of the Sperm Whale is a scientific anatomical feat, upon which experienced whale surgeons very much pride themselves": {
+    "emoji": "⚔️🐋🔬👩‍⚕️🐳🏆",
+    "date": "2024-01-01T00:00:00"
+  },
+  "what monstrous cannibal and savage could ever have gone a death-harvesting with such a hacking, horrifying implement": {
+    "emoji": "🤔👹🍽️😱👤☠️🪓😨🔪",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Here I am, proud as Greek god, and yet standing debtor to this blockhead for a bone to stand on!": {
+    "emoji": "🧍‍♂️🇬🇷💪🤔💸👨‍🦲🦴🦶",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the ivory-tusked Pequod sharply bowed to the blast, and gored the dark waves in her madness, till, like showers of silver chips, the foam-flakes flew over her bulwarks": {
+    "emoji": "🐘🚢🌊💨🎯🌊🤪🌊🌊🌊🌊💥✨🚢🛡️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Are you a believer in ghosts, my friend?": {
+    "emoji": "👻❓🤔🧑‍🤝‍🧑",
+    "date": "2024-01-01T00:00:00"
+  },
+  "the two—ship and whale, seemed yoked together like colossal bullocks, whereof one reclines while the other remains standing": {
+    "emoji": "🚢🐋🔗🐂🐂🛌🐂",
+    "date": "2024-01-01T00:00:00"
+  },
+  "going plump on a flying whale with your sail set in a foggy squall is the height of a whaleman’s discretion": {
+    "emoji": "🐋✈️🌫️🌬️⛵🔝🧭💭",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Strangest problems of life seem clearing; but clouds sweep between—Is my journey’s end coming?": {
+    "emoji": "🤔🌫️➡️☀️🌥️❓🚶‍♂️🏁🔜",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Yes, the long calm was departing. A low advancing hum was soon heard": {
+    "emoji": "👍, 🌅⬅️😌📉. 📉🔜👂🔈📈.",
+    "date": "2024-01-01T00:00:00"
+  },
+  "what disordered slippery decks of a whale-ship are comparable to the unspeakable carrion of those battle-fields": {
+    "emoji": "🤔🐋⚓️🛳️❓🔄🌊🤯⚔️💀🪖⚰️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "Would that I could keep squeezing that sperm for ever!": {
+    "emoji": "🤔🤲💦♾️✨",
+    "date": "2024-01-01T00:00:00"
+  },
+  "his distended eyes turned full upon old Ahab": {
+    "emoji": "👀🔄👴🧔‍♂️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "So have I seen Passion and Vanity stamping the living magnanimous earth, but the earth did not alter her tides and her seasons for that.": {
+    "emoji": "👀😡✨👣🌍✋💪🌊🌱↔️",
+    "date": "2024-01-01T00:00:00"
+  },
+  "What a noble thing is that canticle in the fish’s belly! How billow-like and boisterously grand!": {
+    "emoji": "🐟🎶🌊🎩💥",
+    "date": "2024-01-01T00:00:00"
+  }
+}

--- a/tests/test_emoji_translator.py
+++ b/tests/test_emoji_translator.py
@@ -54,5 +54,22 @@ class TestEmojiTranslator(unittest.TestCase):
         result = self.translator.last_n_words("Call me Ishmael said he.", n=4)
         self.assertEqual(result, "me Ishmael said he")
 
+    def test_should_post_new_toot(self):
+        result = self.translator.should_post({}, "hello", interval_days=120)
+        self.assertTrue(result)
+
+    def test_should_post_skip_recent(self):
+        from datetime import datetime
+        storage = {"hello": {"emoji": "🙂", "date": datetime.now().isoformat()}}
+        result = self.translator.should_post(storage, "hello", interval_days=120)
+        self.assertFalse(result)
+
+    def test_should_post_after_interval(self):
+        from datetime import datetime, timedelta
+        old_date = (datetime.now() - timedelta(days=121)).isoformat()
+        storage = {"hello": {"emoji": "🙂", "date": old_date}}
+        result = self.translator.should_post(storage, "hello", interval_days=120)
+        self.assertTrue(result)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- extend toot storage format to store emoji and date for each toot
- convert existing toot cache to new structure
- add function to determine whether a toot should be posted after a delay
- update posting logic to skip recently posted toots
- test posting interval logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cb18b6a548321b12d0092abf4acb4