### PR TITLE
Refactor CLI to use --data-file

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ### Repository Overview
 
-_find-emoji-dik_ is a Python project that fetches short text fragments from literature-themed Mastodon accounts or from static text files, converts those fragments into emojis using an LLM API, and posts the emoji responses back to Mastodon.
+_find-emoji-dik_ is a Python project that fetches short text fragments from literature-themed Mastodon accounts or from text files in the `data/` directory, converts those fragments into emojis using an LLM API, and posts the emoji responses back to Mastodon.
 
 _Why? This funny little Python project served to refresh my Python skills. I'm learning  AI-supported coding and  interacting with LLM APIs. Learning by doing._
 
@@ -26,9 +26,9 @@ Then the script uses a Large Language Model (LLM) to translate sentence fragment
 
 (Read toots from Mastodon, parse most recent toot; post fragment to LLM API, let LLM translate to Emojis, process LLM response, post fragment+Emojis to own account)
 
-You can fetch a random snippet from a static text file with:
+You can fetch a random snippet from a text file stored in `data/` with:
 
-    ./src/emojis-mobydick.py --static-file path/to/mark-twain-from-gutenberg.txt --signature "Mark Twain"
+    ./src/emojis-mobydick.py --data-file path/to/mark-twain-from-gutenberg.txt --signature "Mark Twain"
 
 (Read random snippet from text file, let LLM translate to Emojis, process LLM response, post fragment+Emojis to own account)
 

--- a/src/data_fileparser.py
+++ b/src/data_fileparser.py
@@ -1,7 +1,7 @@
 import random
 
-class StaticFileParser:
-    """Parse a static text file and return random snippets."""
+class DataFileParser:
+    """Parse a text file in the data directory and return random snippets."""
     def __init__(self, file_path):
         self.file_path = file_path
         with open(file_path, 'r', encoding='utf-8') as f:

--- a/tests/test_data_fileparser.py
+++ b/tests/test_data_fileparser.py
@@ -4,9 +4,9 @@ import sys
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
 
-from static_fileparser import StaticFileParser
+from data_fileparser import DataFileParser
 
-class TestStaticFileParser(unittest.TestCase):
+class TestDataFileParser(unittest.TestCase):
     def setUp(self):
         self.test_file = 'data/test_static.txt'
         with open(self.test_file, 'w') as f:
@@ -16,11 +16,11 @@ class TestStaticFileParser(unittest.TestCase):
         os.remove(self.test_file)
 
     def test_snippet_count(self):
-        parser = StaticFileParser(self.test_file)
+        parser = DataFileParser(self.test_file)
         self.assertEqual(len(parser.snippets), 3)
 
     def test_random_snippet_returns_value(self):
-        parser = StaticFileParser(self.test_file)
+        parser = DataFileParser(self.test_file)
         snippet = parser.get_random_snippet()
         self.assertIn(snippet, parser.snippets)
 

--- a/tests/test_format_data_snippet.py
+++ b/tests/test_format_data_snippet.py
@@ -11,13 +11,13 @@ spec = importlib.util.spec_from_file_location(module_name, file_path)
 module = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(module)
 
-class TestFormatStaticSnippet(unittest.TestCase):
+class TestFormatDataSnippet(unittest.TestCase):
     def test_with_signature(self):
-        result = module.format_static_snippet('hello', '🙂', 'Author')
+        result = module.format_data_snippet('hello', '🙂', 'Author')
         self.assertEqual(result, 'hello:\n🙂\n        -- Author')
 
     def test_without_signature(self):
-        result = module.format_static_snippet('hello', '🙂')
+        result = module.format_data_snippet('hello', '🙂')
         self.assertEqual(result, 'hello:\n🙂')
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- rename `static_fileparser.py` to `data_fileparser.py`
- rename CLI option `--static-file` to `--data-file`
- rename helper function to `format_data_snippet`
- update README instructions
- rename related tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ccd11d1748321a66e4ce5f760bbc7