### PR TITLE
Fix toot attribution handling

### DIFF
--- a/src/emoji_translator.py
+++ b/src/emoji_translator.py
@@ -66,12 +66,16 @@ class EmojiTranslator:
         return result
 
     def split_attribution(self, text):
-        """Split trailing attribution line starting with '--' from the text."""
+        """Split trailing attribution line starting with '--' from the text.
+
+        Hashtags within the attribution line are removed before returning.
+        """
         lines = text.splitlines()
         if len(lines) > 1:
             last = lines[-1].strip()
             if re.match(r"^--\s*", last):
-                return "\n".join(lines[:-1]), last
+                cleaned = re.sub(r"\s*#[^\s]+", "", last).rstrip()
+                return "\n".join(lines[:-1]), cleaned
         return text, ""
 
     def load_toot_storage(self, file_path):

--- a/tests/test_attribution.py
+++ b/tests/test_attribution.py
@@ -30,15 +30,6 @@ mock_dotenv.load_dotenv = fake_load_dotenv
 mock_dotenv.find_dotenv = fake_find_dotenv
 sys.modules.setdefault("dotenv", mock_dotenv)
 
-# Provide a minimal mock for moby_dick_parser
-mock_parser = types.ModuleType("moby_dick_parser")
-class DummyMobyDickParser:
-    def __init__(self, file_path):
-        pass
-    def find_fragment(self, fragment):
-        return (None, None, None, None)
-mock_parser.MobyDickParser = DummyMobyDickParser
-sys.modules.setdefault("moby_dick_parser", mock_parser)
 
 # Provide a minimal mock for requests module used by emoji_translator
 mock_requests = types.ModuleType("requests")
@@ -70,14 +61,16 @@ class TestEmojiTranslatorAttribution(unittest.TestCase):
 
     def test_translate_to_emoji_sets_attribution_with_author(self):
         text = "Hello world\n-- Jane"
-        emoji = self.translator.translate_to_emoji("http://fake", "token123", text)
+        emoji, attrib = self.translator.translate_to_emoji("http://fake", "token123", text)
         self.assertEqual(emoji, "😊")
+        self.assertEqual(attrib, "-- Jane")
         self.assertEqual(self.translator.attribution, "-- Jane")
 
     def test_translate_to_emoji_sets_attribution_without_author(self):
         text = "Hello world"
-        emoji = self.translator.translate_to_emoji("http://fake", "token123", text)
+        emoji, attrib = self.translator.translate_to_emoji("http://fake", "token123", text)
         self.assertEqual(emoji, "😊")
+        self.assertEqual(attrib, "")
         self.assertEqual(self.translator.attribution, "")
 
 if __name__ == "__main__":

--- a/tests/test_attribution.py
+++ b/tests/test_attribution.py
@@ -59,8 +59,21 @@ class TestEmojiTranslatorAttribution(unittest.TestCase):
         self.assertEqual(main, "Meaningful sentence")
         self.assertEqual(attrib, "-- John Doe")
 
+    def test_split_attribution_strips_hashtags(self):
+        text = "Meaningful sentence\n-- John Doe #quote #test"
+        main, attrib = self.translator.split_attribution(text)
+        self.assertEqual(main, "Meaningful sentence")
+        self.assertEqual(attrib, "-- John Doe")
+
     def test_translate_to_emoji_sets_attribution_with_author(self):
         text = "Hello world\n-- Jane"
+        emoji, attrib = self.translator.translate_to_emoji("http://fake", "token123", text)
+        self.assertEqual(emoji, "😊")
+        self.assertEqual(attrib, "-- Jane")
+        self.assertEqual(self.translator.attribution, "-- Jane")
+
+    def test_translate_to_emoji_cleans_hashtagged_attribution(self):
+        text = "Hello world\n-- Jane #tag1 #tag2"
         emoji, attrib = self.translator.translate_to_emoji("http://fake", "token123", text)
         self.assertEqual(emoji, "😊")
         self.assertEqual(attrib, "-- Jane")


### PR DESCRIPTION
## Summary
- Preserve attribution when translating to emoji
- Update attribution tests to avoid global mocks and check returned attribution

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a0b526efc083218eae7f700cede2ab