### PR TITLE
Fix attribution formatting and hashtag cleanup

### DIFF
--- a/tests/test_attribution.py
+++ b/tests/test_attribution.py
@@ -65,6 +65,12 @@ class TestEmojiTranslatorAttribution(unittest.TestCase):
         self.assertEqual(main, "Meaningful sentence")
         self.assertEqual(attrib, "-- John Doe")
 
+    def test_split_attribution_ignores_trailing_hashtags(self):
+        text = "Meaningful sentence\n-- John Doe\n#quote #test"
+        main, attrib = self.translator.split_attribution(text)
+        self.assertEqual(main, "Meaningful sentence")
+        self.assertEqual(attrib, "-- John Doe")
+
     def test_translate_to_emoji_sets_attribution_with_author(self):
         text = "Hello world\n-- Jane"
         emoji, attrib = self.translator.translate_to_emoji("http://fake", "token123", text)
@@ -74,6 +80,13 @@ class TestEmojiTranslatorAttribution(unittest.TestCase):
 
     def test_translate_to_emoji_cleans_hashtagged_attribution(self):
         text = "Hello world\n-- Jane #tag1 #tag2"
+        emoji, attrib = self.translator.translate_to_emoji("http://fake", "token123", text)
+        self.assertEqual(emoji, "😊")
+        self.assertEqual(attrib, "-- Jane")
+        self.assertEqual(self.translator.attribution, "-- Jane")
+
+    def test_translate_to_emoji_ignores_trailing_hashtags(self):
+        text = "Hello world\n-- Jane\n#tag1 #tag2"
         emoji, attrib = self.translator.translate_to_emoji("http://fake", "token123", text)
         self.assertEqual(emoji, "😊")
         self.assertEqual(attrib, "-- Jane")


### PR DESCRIPTION
## Summary
- Strip trailing hashtag lines before detecting attributions
- Include original attribution with h/t notice and remove colon formatting
- Add tests covering trailing hashtag lines and attribution handling

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a196e61c4c8321aa49c44c9d0efcf6